### PR TITLE
self-pleasure - wrong word used

### DIFF
--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -3005,7 +3005,7 @@ label monika_pleasure:
     m "And sometimes, even if you don't feel the urge, you'll always find yourself wanting to do so."
     m 1o "Not to mention..."
     m 1r "Being addicted to the feeling causes you to view the world from a perverted point of view."
-    m "From what I hear, people addicted to self-pleasure often see other people of the opposite gender objectively."
+    m "From what I hear, people addicted to self-pleasure often see other people of the opposite gender in a dehumanising way, as objects that exist for your pleasure, not as persons."
     m 1q "That alone can cause problems in more ways than one."
     m 1h "That's why I have to keep an eye on you, [player]."
     m 1i "I'll be monitoring your browser history from now on, whether you like it or not."


### PR DESCRIPTION
"Objectively" sounds weird, since normally it means "without bias" or "relying on objective measures rather than direct perception". 

Doubtless whoever wrote this meant "in an objectifying way", and that would have worked as a rewrite. But "objectification" is such a buzzword nowadays that I felt actually unpacking that concept made for better dialog for Monika.