### PR TITLE
Farewells system rework

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -318,7 +318,7 @@ python early:
             RETURNS: True if the this key is here, false otherwise
             """
             return (
-                self.rules is not None 
+                self.rules is not None
                 and "monika wants this first" in self.rules
             )
 
@@ -711,12 +711,12 @@ python early:
             RETURNS:
                 True if this event passes its repeat rule, False otherwise
             """
-            # check if the event contains a MASSelectiveRepeatRule and 
+            # check if the event contains a MASSelectiveRepeatRule and
             # evaluate it
             if MASSelectiveRepeatRule.evaluate_rule(check_time, ev):
                 return True
 
-            # check if the event contains a MASNumericalRepeatRule and 
+            # check if the event contains a MASNumericalRepeatRule and
             # evaluate it
             if MASNumericalRepeatRule.evaluate_rule(check_time, ev):
                 return True
@@ -787,7 +787,7 @@ python early:
 
             IN:
                 events - dict of events of the following format:
-                    eventlabel: event objec
+                    eventlabel: event object
 
             RETURNS:
                 A filtered dict containing the events that passed their own rules
@@ -805,6 +805,57 @@ python early:
 
                 # check if the event contains a MASGreetingRule and evaluate it
                 if Event._checkGreetingRule(event):
+
+                    if event.monikaWantsThisFirst():
+                        return {event.eventlabel: event}
+
+                    # add the event to our available events dict
+                    available_events[label] = event
+
+            # return the available events dict
+            return available_events
+
+        @staticmethod
+        def _checkFarewellRule(ev):
+            """
+            Checks the given event against its own farewell specific rule.
+
+            IN:
+                ev - event to check
+
+            RETURNS:
+                True if this event passes its repeat rule, False otherwise
+            """
+            return MASFarewellRule.evaluate_rule(ev)
+
+
+        @staticmethod
+        def checkFarewellRules(events):
+            """
+            Checks the event dict (farewells) against their own farewell specific
+            rules, filters out those Events whose rule check return true. As for
+            now the only rule specific is their specific special random chance
+
+            IN:
+                events - dict of events of the following format:
+                    eventlabel: event object
+
+            RETURNS:
+                A filtered dict containing the events that passed their own rules
+
+            """
+            # sanity check
+            if not events or len(events) == 0:
+                return None
+
+            # prepare empty dict to store events that pass their own rules
+            available_events = dict()
+
+            # iterate over each event in the given events dict
+            for label, event in events.iteritems():
+
+                # check if the event contains a MASFarewellRule and evaluate it
+                if Event._checkFarewellRule(event):
 
                     if event.monikaWantsThisFirst():
                         return {event.eventlabel: event}

--- a/Monika After Story/game/dev/dev_farewells.rpy
+++ b/Monika After Story/game/dev/dev_farewells.rpy
@@ -33,3 +33,21 @@ label bye_dev:
     m 1e "Or maybe you're just running some tests?"
     m 1k "Don't give up until everything works as expected!"
     return 'quit'
+
+# This one exists so devs get an autoupdate once they pull these changes
+init 5 python:
+    ev = Event(persistent.farewell_database,eventlabel="bye_dev_temp",unlocked=True)
+    addEvent(ev,eventdb=evhand.farewell_database)
+    del ev
+
+label bye_dev_temp:
+    m 1c "Leaving now, eh [player]?"
+    m 1e "We had some changes in the farewell system, I need to update something first ..."
+    python:
+        for k in evhand.farewell_database:
+            # no need to do any special checks since all farewells were already available
+            renpy.store.evhand.farewell_database[k].unlocked = True
+    $ evhand.farewell_database["bye_dev_temp"].unlocked = False
+    m 1k "All done, thanks for waiting [player]!"
+    #Don't show this farewell again
+    return 'quit'

--- a/Monika After Story/game/dev/dev_farewells.rpy
+++ b/Monika After Story/game/dev/dev_farewells.rpy
@@ -1,0 +1,35 @@
+# dev related farewells
+
+init 5 python:
+    rules = dict()
+    rules.update(MASNumericalRepeatRule.create_rule(repeat=EV_NUM_RULE_YEAR))
+    addEvent(
+        Event(
+            persistent.farewell_database,
+            eventlabel="bye_st_patrick",
+            start_date=datetime.datetime(2017, 3, 17, 5),
+            end_date=datetime.datetime(2017, 3, 18, 5),
+            unlocked=True,
+            rules=rules
+        ),
+        eventdb=evhand.farewell_database
+    )
+    del rules
+
+label bye_st_patrick:
+    m 1c "Aww, leaving already?"
+    m 1e "It's really sad whenever you have to go..."
+    m 1b "Good luck with the hangover!"
+    return 'quit'
+
+init 5 python:
+    ev = Event(persistent.farewell_database,eventlabel="bye_dev",unlocked=True)
+    MASFarewellRule.create_rule(random_chance=5,ev=ev)
+    addEvent(ev,eventdb=evhand.farewell_database)
+    del ev
+
+label bye_dev:
+    m 1c "How's the new feature going, eh [player]?"
+    m 1e "Or maybe you're just running some tests?"
+    m 1k "Don't give up until everything works as expected!"
+    return 'quit'

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -29,7 +29,7 @@ init -500 python:
     mas_init_lockdb_template = (
         True, # event label
         False, # prompt
-        False, # label 
+        False, # label
         False, # category
         True, # unlocked
         True, # random
@@ -62,7 +62,7 @@ init -500 python:
     # set db defaults
     if persistent._mas_event_init_lockdb is None:
         persistent._mas_event_init_lockdb = dict()
-    
+
     # initalizes LOCKDB for the Event class
     Event.INIT_LOCKDB = persistent._mas_event_init_lockdb
 
@@ -175,7 +175,7 @@ init python:
 #                raise EventException("Syntax error in conditional statement for event '" + event.eventlabel + "'.")
 
         # now this event has passsed checks, we can add it to the db
-        eventdb.setdefault(event.eventlabel, event) 
+        eventdb.setdefault(event.eventlabel, event)
 
 
     def hideEventLabel(
@@ -442,7 +442,7 @@ label prompt_menu:
             jump prompt_menu
 
     elif madechoice == "goodbye":
-        call random_farewell from _call_random_farewell
+        call select_farewell from _call_select_farewell
 
     else: #nevermind
         $_return = None
@@ -619,10 +619,9 @@ label prompts_categories(pool=True):
 
     return
 
-label random_farewell:
+label select_farewell:
     python:
-        random_farewells = Event.filterEvents(evhand.farewell_database,random=True).keys()
-        pushEvent(renpy.random.choice(random_farewells))
+        farewell = store.mas_farewells.selectFarewell()
+        pushEvent(farewell.eventlabel)
 
     return
-

--- a/Monika After Story/game/event-rules.rpy
+++ b/Monika After Story/game/event-rules.rpy
@@ -10,6 +10,7 @@ init -1 python:
     EV_RULE_RP_SELECTIVE = "rp_selective"
     EV_RULE_RP_NUMERICAL = "rp_numerical"
     EV_RULE_GREET_RANDOM = "greet_random"
+    EV_RULE_FAREWELL_RANDOM = "farewell_random"
 
 
     # special constants for numerical repeat rules
@@ -93,7 +94,7 @@ init -1 python:
                     (Default: None)
 
             RETURNS:
-                A tuple containing the new start_date and end_date. If bad 
+                A tuple containing the new start_date and end_date. If bad
                 values were given, (-1, -1) is returned
             """
             # sanity check
@@ -198,7 +199,7 @@ init -1 python:
 
             # sanity check for a rule to use
             if rule is None:
-                    
+
                 if EV_RULE_RP_NUMERICAL not in ev.rules:
                     return False
 
@@ -226,12 +227,12 @@ init -1 python:
 
         @staticmethod
         def create_rule(
-                seconds=None, 
-                minutes=None, 
-                hours=None, 
-                days=None, 
-                weekdays=None, 
-                months=None, 
+                seconds=None,
+                minutes=None,
+                hours=None,
+                days=None,
+                weekdays=None,
+                months=None,
                 years=None,
                 ev=None
             ):
@@ -380,7 +381,7 @@ init -1 python:
             if random_chance < 0:
                 raise Exception("random_chance can't be negative")
 
-            # return the tuple
+            # return the tuple inside a dict
             rule = {EV_RULE_GREET_RANDOM : (skip_visual, random_chance)}
 
             if ev:
@@ -437,6 +438,72 @@ init -1 python:
             # returns the skip_visual boolean of the rule
             if rule:
                 return rule[0]
-                
+
             # False since there was no rule to check
             return False
+
+    class MASFarewellRule(object):
+        """
+        Static Class used to create farewell specific rules in tuple form.
+        That tuple is then stored in a dict containing this rule name constant.
+        Each rule is defined by a special random chance.
+        random_chance is used to define the 1 in random_chance chance that this
+        farewell can be called
+        """
+
+        @staticmethod
+        def create_rule(random_chance, ev=None):
+            """
+            IN:
+                random_chance - An int used to determine 1 in random_chance
+                    special chance for this farewell to appear
+                ev - Event to create rule for, if passed in
+                    (Default: None)
+
+            RETURNS:
+                a dict containing the specified rules
+            """
+
+            # random_chance can't be negative
+            if random_chance < 0:
+                raise Exception("random_chance can't be negative")
+
+            # return the rule inside a dict
+            rule = {EV_RULE_FAREWELL_RANDOM : random_chance}
+
+            if ev:
+                ev.rules.update(rule)
+
+            return rule
+
+
+        @staticmethod
+        def evaluate_rule(event=None, rule=None):
+            """
+            IN:
+                event - the event to evaluate
+                rule - the MASFarewellRule to check it's random_chance
+
+            RETURNS:
+                True if the random returned 1
+            """
+            # check if we have an event that contains the rule we need
+            # event rule takes priority so it's checked here
+            if event and EV_RULE_FAREWELL_RANDOM in event.rules:
+                rule = event.rules[EV_RULE_FAREWELL_RANDOM]
+
+            # sanity check if we don't have a rule return False
+            if rule is None:
+                return False
+
+            # store the rule for easy access
+            # keeping this so when we add another rule we'll keep
+            # the same code structure, also it's more readable changing the name
+            random_chance = rule
+
+            # check if random_chance is 0 return False
+            if random_chance == 0:
+                return False
+
+            # Evaluate randint with a chance of 1 in random_chance
+            return renpy.random.randint(1,random_chance) == 1

--- a/Monika After Story/game/event-rules.rpy
+++ b/Monika After Story/game/event-rules.rpy
@@ -412,8 +412,8 @@ init -1 python:
             # unpack the tuple for easy access
             skip_visual, random_chance = rule
 
-            # check if random_chance is 0 return False
-            if random_chance == 0:
+            # check if random_chance is less or equal to 0 return False
+            if random_chance <= 0:
                 return False
 
             # Evaluate randint with a chance of 1 in random_chance
@@ -501,8 +501,8 @@ init -1 python:
             # the same code structure, also it's more readable changing the name
             random_chance = rule
 
-            # check if random_chance is 0 return False
-            if random_chance == 0:
+            # check if random_chance is less or equal to 0 return False
+            if random_chance <= 0:
                 return False
 
             # Evaluate randint with a chance of 1 in random_chance

--- a/Monika After Story/game/script-farewells.rpy
+++ b/Monika After Story/game/script-farewells.rpy
@@ -1,11 +1,66 @@
 ##This file contains all of the variations of goodbye that monika can give.
-##Default behavior is to select a random farewell from the list, if the farewell
-##is non-specific, it can stay available, but if it's too specific it should
-##unset its own random flag.
-##Label must start with "bye" to prevent being pushed back onto the stack if closed
+## This also contains a store with a utility function to select an appropriate
+## farewell 
+
+init -1 python in mas_farewells:
+    # custom farewell functions
+    def selectFarewell():
+        """
+        Selects a farewell to be used. This evaluates rules and stuff
+        appropriately.
+
+        RETURNS:
+            a single farewell (as an Event) that we want to use
+        """
+
+        # filter events by their unlocked property first
+        unlocked_farewells = renpy.store.Event.filterEvents(
+            renpy.store.evhand.farewell_database,
+            unlocked=True
+        )
+
+        # filter farewells using the special rules dict
+        random_farewells_dict = renpy.store.Event.checkRepeatRules(
+            unlocked_farewells
+        )
+
+        # check if we have a farewell that actually should be shown now
+        if len(random_farewells_dict) > 0:
+
+            # select one label randomly
+            return random_farewells_dict[
+                renpy.random.choice(random_farewells_dict.keys())
+            ]
+
+        # since we don't have special farewells for this time we now check for special random chance
+        # pick a farewell filtering by special random chance rule
+        random_farewells_dict = renpy.store.Event.checkFarewellRules(
+            unlocked_farewells
+        )
+
+        # check if we have a farewell that actually should be shown now
+        if len(random_farewells_dict) > 0:
+
+            # select on label randomly
+            return random_farewells_dict[
+                renpy.random.choice(random_farewells_dict.keys())
+            ]
+
+        # We couldn't find a suitable farewell we have to default to normal random selection
+        # filter random events normally
+        random_farewells_dict = renpy.store.Event.filterEvents(
+            unlocked_farewells,
+            random=True
+        )
+
+        # select one randomly
+        return random_farewells_dict[
+            renpy.random.choice(random_farewells_dict.keys())
+        ]
+
 
 init 5 python:
-    addEvent(Event(persistent.farewell_database,eventlabel="bye_leaving_already",random=True),eventdb=evhand.farewell_database)
+    addEvent(Event(persistent.farewell_database,eventlabel="bye_leaving_already",unlocked=True,random=True),eventdb=evhand.farewell_database)
 
 label bye_leaving_already:
     m 1c "Aww, leaving already?"
@@ -17,38 +72,57 @@ label bye_leaving_already:
     return 'quit'
 
 init 5 python:
-    addEvent(Event(persistent.farewell_database,eventlabel="bye_goodbye",random=True),eventdb=evhand.farewell_database)
+    addEvent(Event(persistent.farewell_database,eventlabel="bye_goodbye",unlocked=True,random=True),eventdb=evhand.farewell_database)
 
 label bye_goodbye:
     m 1c "Goodbye, [player]!"
     return 'quit'
 
 init 5 python:
-    addEvent(Event(persistent.farewell_database,eventlabel="bye_sayanora",random=True),eventdb=evhand.farewell_database)
-    
+    addEvent(Event(persistent.farewell_database,eventlabel="bye_sayanora",unlocked=True,random=True),eventdb=evhand.farewell_database)
+
 label bye_sayanora:
     m 1j "Sayonara, [player]~"
     return 'quit'
 
 init 5 python:
-    addEvent(Event(persistent.farewell_database,eventlabel="bye_farewellfornow",random=True),eventdb=evhand.farewell_database)
-    
+    addEvent(Event(persistent.farewell_database,eventlabel="bye_farewellfornow",unlocked=True,random=True),eventdb=evhand.farewell_database)
+
 label bye_farewellfornow:
     m 1e "Farewell for now, my love~"
     return 'quit'
 
 init 5 python:
-    addEvent(Event(persistent.farewell_database,eventlabel="bye_untilwemeetagain",random=True),eventdb=evhand.farewell_database)
+    addEvent(Event(persistent.farewell_database,eventlabel="bye_untilwemeetagain",unlocked=True,random=True),eventdb=evhand.farewell_database)
 
 label bye_untilwemeetagain:
     m 2e "'{i}Goodbyes are not forever, Goodbyes are not the end. They simply mean I’ll miss you, Until we meet again.{/i}'"
     m "Ehehe, 'till then, [player]!"
     return 'quit'
-    
+
 init 5 python:
-    addEvent(Event(persistent.farewell_database,eventlabel="bye_take_care",random=True),eventdb=evhand.farewell_database)
-    
+    addEvent(Event(persistent.farewell_database,eventlabel="bye_take_care",unlocked=True,random=True),eventdb=evhand.farewell_database)
+
 label bye_take_care:
-    m 1a "Don't forget that I always love you, [player]~" 
+    m 1a "Don't forget that I always love you, [player]~"
     m 1k "Take care!"
+    return 'quit'
+
+init 5 python:
+    rules = dict()
+    rules.update(MASSelectiveRepeatRule.create_rule(hours=range(21,24)))
+    addEvent(
+        Event(
+            persistent.farewell_database,
+            eventlabel="bye_going_to_sleep",
+            unlocked=True,
+            rules=rules
+        ),
+        eventdb=evhand.farewell_database
+    )
+    del rules
+
+label bye_going_to_sleep:
+    m "Are you going to sleep, [player]?"
+    m 1e "I'll be seeing you in your dreams"
     return 'quit'

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -201,7 +201,7 @@ label v0_7_4(version="v0_7_4"):
         # auto updates would handle it
         import os
         try: os.remove(config.basedir + "/game/valentines.rpyc")
-        except: pass   
+        except: pass
 
         # remove white day stuff
         try: os.remove(config.basedir + "/game/white-day.rpyc")
@@ -218,7 +218,7 @@ label v0_7_4(version="v0_7_4"):
         year = datetime.timedelta(days=365)
         def _month_adjuster(key, months, span):
             new_anni_date = add_months(
-                start_of_day(persistent.sessions["first_session"]), 
+                start_of_day(persistent.sessions["first_session"]),
                 months
             )
             evhand.event_database[key].start_date = new_anni_date
@@ -236,10 +236,15 @@ label v0_7_4(version="v0_7_4"):
         _month_adjuster("anni_10", 120, month)
         _month_adjuster("anni_20", 240, year)
         evhand.event_database["anni_100"].start_date = add_months(
-            start_of_day(persistent.sessions["first_session"]), 
+            start_of_day(persistent.sessions["first_session"]),
             1200
         )
-            
+
+       # now properly set all farewells as unlocked, since the new system checks
+       # for the unlocked status
+        for k in evhand.farewell_database:
+            # no need to do any special checks since all farewells were already available
+            evhand.farewell_database[k].unlocked = True
 
 
     return
@@ -345,7 +350,7 @@ label v0_3_0(version="v0_3_0"):
 ###############################################################################
 ### Even earlier UPDATE SCRIPTS
 # these scripts are for doing python things REALLY earlly in the pipeline.
-# this consists of a giant init python block. 
+# this consists of a giant init python block.
 # make sure to del your vars after creating them
 # also start these in progressive order and explain reasoning behind
 # changes
@@ -372,5 +377,3 @@ label v0_3_0(version="v0_3_0"):
 #
 #        del _mas_events_unlocked_v073
 #        del ev_key
-        
-


### PR DESCRIPTION
This pull request modifies the old farewells system so it now checks for rules first to filter the farewells based on different conditions. 

This also adds a new rule specific for farewells: `MASFarewellRule`, right now this rule only defines a special random chance for the farewell to be selected.

Basically you can define a special ruled farewell using something like this:
```
init 5 python:
    rules = dict()
    rules.update(MASSelectiveRepeatRule.create_rule(hours=range(21,24)))
    addEvent(
        Event(
            persistent.farewell_database,
            eventlabel="bye_going_to_sleep",
            unlocked=True,
            rules=rules
        ),
        eventdb=evhand.farewell_database
    )
    del rules

label bye_going_to_sleep:
    m "Are you going to sleep, [player]?"
    m 1e "I'll be seeing you in your dreams"
    return 'quit'
```

This pull request addresses the changes discussed here: https://github.com/Monika-After-Story/MonikaModDev/issues/878 
