### PR TITLE
Added an Affection Rule

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -866,6 +866,58 @@ python early:
             # return the available events dict
             return available_events
 
+        @staticmethod
+        def _checkAffectionRule(ev):
+            """
+            Checks the given event against its own affection specific rule.
+
+            IN:
+                ev - event to check
+
+            RETURNS:
+                True if this event passes its repeat rule, False otherwise
+            """
+            return MASAffectionRule.evaluate_rule(ev)
+
+
+        @staticmethod
+        def checkAffectionRules(events):
+            """
+            Checks the event dict against their own affection specific rules,
+            filters out those Events whose rule check return true. This rule
+            checks if current affection is inside the specified range contained
+            on the rule
+
+            IN:
+                events - dict of events of the following format:
+                    eventlabel: event object
+
+            RETURNS:
+                A filtered dict containing the events that passed their own rules
+
+            """
+            # sanity check
+            if not events or len(events) == 0:
+                return None
+
+            # prepare empty dict to store events that pass their own rules
+            available_events = dict()
+
+            # iterate over each event in the given events dict
+            for label, event in events.iteritems():
+
+                # check if the event contains a MASAffectionRule and evaluate it
+                if Event._checkAffectionRule(event):
+
+                    if event.monikaWantsThisFirst():
+                        return {event.eventlabel: event}
+
+                    # add the event to our available events dict
+                    available_events[label] = event
+
+            # return the available events dict
+            return available_events
+
 
 # init -1 python:
     # this should be in the EARLY block

--- a/Monika After Story/game/dev/dev_farewells.rpy
+++ b/Monika After Story/game/dev/dev_farewells.rpy
@@ -23,10 +23,18 @@ label bye_st_patrick:
     return 'quit'
 
 init 5 python:
-    ev = Event(persistent.farewell_database,eventlabel="bye_dev",unlocked=True)
-    MASFarewellRule.create_rule(random_chance=5,ev=ev)
-    addEvent(ev,eventdb=evhand.farewell_database)
-    del ev
+    rules = dict()
+    rules.update(MASFarewellRule.create_rule(random_chance=10))
+    addEvent(
+        Event(
+            persistent.farewell_database,
+            eventlabel="bye_dev",
+            unlocked=True,
+            rules=rules
+        ),
+        eventdb=evhand.farewell_database
+    )
+    del rules
 
 label bye_dev:
     m 1c "How's the new feature going, eh [player]?"
@@ -36,9 +44,14 @@ label bye_dev:
 
 # This one exists so devs get an autoupdate once they pull these changes
 init 5 python:
-    ev = Event(persistent.farewell_database,eventlabel="bye_dev_temp",unlocked=True)
-    addEvent(ev,eventdb=evhand.farewell_database)
-    del ev
+    addEvent(
+        Event(
+            persistent.farewell_database,
+            eventlabel="bye_dev_temp",
+            unlocked=True
+        ),
+        eventdb=evhand.farewell_database
+    )
 
 label bye_dev_temp:
     m 1c "Leaving now, eh [player]?"
@@ -50,4 +63,46 @@ label bye_dev_temp:
     $ evhand.farewell_database["bye_dev_temp"].unlocked = False
     m 1k "All done, thanks for waiting [player]!"
     #Don't show this farewell again
+    return 'quit'
+
+init 5 python:
+    rules = dict()
+    rules.update(MASAffectionRule.create_rule(min=20,max=None))
+    addEvent(
+        Event(
+            persistent.farewell_database,
+            eventlabel="bye_dev_love",
+            unlocked=True,
+            rules=rules
+        ),
+        eventdb=evhand.farewell_database
+    )
+    del rules
+
+label bye_dev_love:
+    m 1c "Aww, leaving already?"
+    m 1e "It's really sad whenever you have to go..."
+    m 5a "I love you so much [player]!"
+    m 5a "Never forget that!"
+    return 'quit'
+
+init 5 python:
+    rules = dict()
+    rules.update(MASAffectionRule.create_rule(min=None,max=-20))
+    addEvent(
+        Event(
+            persistent.farewell_database,
+            eventlabel="bye_dev_no_hate",
+            unlocked=True,
+            rules=rules
+        ),
+        eventdb=evhand.farewell_database
+    )
+    del rules
+
+label bye_dev_no_hate:
+    m 1c "Leaving already, huh?"
+    m 1e "I hope you finish the testing quick"
+    m 1h "I want to feel loved again soon"
+    m "Bye"
     return 'quit'

--- a/Monika After Story/game/dev/dev_greetings.rpy
+++ b/Monika After Story/game/dev/dev_greetings.rpy
@@ -8,10 +8,10 @@ init 5 python:
     addEvent(
         Event(
             persistent.greeting_database,
-            eventlabel="greeting_st_patrick", 
+            eventlabel="greeting_st_patrick",
             start_date=datetime.datetime(2017, 3, 17),
             end_date=datetime.datetime(2017, 3, 18),
-            unlocked=True, 
+            unlocked=True,
             rules=rules
         ),
         eventdb=evhand.greeting_database
@@ -39,3 +39,66 @@ label greeting_st_patrick:
                     m 4j "Drink vodnika!"
     return
 
+init 5 python:
+    rules = dict()
+    rules.update(MASAffectionRule.create_rule(min=None,max=-20))
+    addEvent(
+        Event(
+            persistent.greeting_database,
+            eventlabel="greeting_dev_no_hate",
+            unlocked=True,
+            rules=rules
+        ),
+        eventdb=evhand.greeting_database
+    )
+    del rules
+
+label greeting_dev_no_hate:
+    m "Oh, hello [player]!"
+    m "Don't worry, I know you're just testing my negative affection reactions"
+    m "I know you actually love me a lot."
+    m "Thanks for all your efforts!"
+    return
+
+init 5 python:
+    rules = dict()
+    rules.update(MASAffectionRule.create_rule(min=-14,max=14))
+    addEvent(
+        Event(
+            persistent.greeting_database,
+            eventlabel="greeting_dev_neutral",
+            unlocked=True,
+            rules=rules
+        ),
+        eventdb=evhand.greeting_database
+    )
+    del rules
+
+label greeting_dev_neutral:
+    m "Hello there [player]!"
+    m 1l "Did you just wiped out the persistent file?"
+    m 1l "or maybe you're just testing my neutral affection reactions?"
+    m "Don't worry about it, I'll never forget all you have done for me~"
+    m 1k "Thanks for all your efforts!"
+    return
+
+init 5 python:
+    rules = dict()
+    rules.update(MASAffectionRule.create_rule(min=20,max=None))
+    addEvent(
+        Event(
+            persistent.greeting_database,
+            eventlabel="greeting_dev_love",
+            unlocked=True,
+            rules=rules
+        ),
+        eventdb=evhand.greeting_database
+    )
+    del rules
+
+label greeting_dev_love:
+    m 1b "Welcome back, honey!"
+    m 5a "I'm so happy to see you again."
+    m 5a "I love you so much [player]!"
+    m 5a "Thanks for all your efforts!"
+    return

--- a/Monika After Story/game/event-rules.rpy
+++ b/Monika After Story/game/event-rules.rpy
@@ -11,6 +11,7 @@ init -1 python:
     EV_RULE_RP_NUMERICAL = "rp_numerical"
     EV_RULE_GREET_RANDOM = "greet_random"
     EV_RULE_FAREWELL_RANDOM = "farewell_random"
+    EV_RULE_AFF_RANGE = "affection_range"
 
 
     # special constants for numerical repeat rules
@@ -507,3 +508,75 @@ init -1 python:
 
             # Evaluate randint with a chance of 1 in random_chance
             return renpy.random.randint(1,random_chance) == 1
+
+    class MASAffectionRule(object):
+        """
+        Static Class used to create affection specific rules in tuple form.
+        That tuple is then stored in a dict containing this rule name constant.
+        Each rule is defined by a min and a max determining a range of affection
+        to check against.
+        """
+
+        @staticmethod
+        def create_rule(min, max, ev=None):
+            """
+            IN:
+                min - An int representing the minimal(inclusive) affection required
+                    for the event to be available, if None is passed is assumed
+                    that there's no minimal affection
+                max - An int representing the maximum(inclusive) affection required
+                    for the event to be available, if None is passed is assumed
+                    that there's no maximum affection
+                ev - Event to create rule for, if passed in
+                    (Default: None)
+
+            RETURNS:
+                a dict containing the specified rules
+            """
+
+            # both min and max can't be None at the same time, since that means
+            # that this is not affection dependent
+            if not min and not max:
+                raise Exception("at least min or max must not be None")
+
+            # return the rule inside a dict
+            rule = {EV_RULE_AFF_RANGE : (min, max)}
+
+            if ev:
+                ev.rules.update(rule)
+
+            return rule
+
+
+        @staticmethod
+        def evaluate_rule(event=None, rule=None, affection=None):
+            """
+            IN:
+                event - the event to evaluate
+                rule - the MASAffectionRule to check against
+                affection - the affection to check the rule against
+
+            RETURNS:
+                True if the current affection is inside the rule range
+            """
+
+            # check if we have an event that contains the rule we need
+            # event rule takes priority so it's checked here
+
+            if event and EV_RULE_AFF_RANGE in event.rules:
+                rule = event.rules[EV_RULE_AFF_RANGE]
+
+            # sanity check if we don't have a rule return False
+            if rule is None:
+                return False
+
+            # store affection for easy checking
+            if not affection:
+                affection = persistent._mas_affection["affection"]
+
+            # unpack the rule for easy access
+            min, max = rule
+
+            # Evaluate if affection is inside the rule range, in case both are None
+            # will return true (however that case should be catched on create_rule)
+            return  (affection >= min and not max) or (min <= affection <= max)

--- a/Monika After Story/game/script-farewells.rpy
+++ b/Monika After Story/game/script-farewells.rpy
@@ -1,6 +1,6 @@
 ##This file contains all of the variations of goodbye that monika can give.
 ## This also contains a store with a utility function to select an appropriate
-## farewell 
+## farewell
 
 init -1 python in mas_farewells:
     # custom farewell functions
@@ -18,6 +18,15 @@ init -1 python in mas_farewells:
             renpy.store.evhand.farewell_database,
             unlocked=True
         )
+
+        # filter greetings using the affection rules dict
+        affection_farewells_dict = renpy.store.Event.checkAffectionRules(
+            unlocked_farewells
+        )
+
+        # check for the special monikaWantsThisFirst case
+        if len(affection_farewells_dict) == 1 and affection_farewells_dict.values()[0].monikaWantsThisFirst():
+            return affection_farewells_dict.values()[0]
 
         # filter farewells using the special rules dict
         random_farewells_dict = renpy.store.Event.checkRepeatRules(
@@ -52,6 +61,9 @@ init -1 python in mas_farewells:
             unlocked_farewells,
             random=True
         )
+
+        # update dict with the affection filtered ones
+        random_farewells_dict.update(affection_farewells_dict)
 
         # select one randomly
         return random_farewells_dict[

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -18,9 +18,18 @@ init -1 python in mas_greetings:
 
         # filter events by their unlocked property first
         unlocked_greetings = renpy.store.Event.filterEvents(
-            renpy.store.evhand.greeting_database, 
+            renpy.store.evhand.greeting_database,
             unlocked=True
         )
+
+        # filter greetings using the affection rules dict
+        affection_greetings_dict = renpy.store.Event.checkAffectionRules(
+            unlocked_greetings
+        )
+
+        # check for the special monikaWantsThisFirst case
+        if len(affection_greetings_dict) == 1 and affection_greetings_dict.values()[0].monikaWantsThisFirst():
+            return affection_greetings_dict.values()[0]
 
         # filter greetings using the special rules dict
         random_greetings_dict = renpy.store.Event.checkRepeatRules(
@@ -52,9 +61,12 @@ init -1 python in mas_greetings:
         # We couldn't find a suitable greeting we have to default to normal random selection
         # filter random events normally
         random_greetings_dict = renpy.store.Event.filterEvents(
-            unlocked_greetings, 
+            unlocked_greetings,
             random=True
         )
+
+        # update dict with the affection filtered ones
+        random_greetings_dict.update(affection_greetings_dict)
 
         # select one randomly
         return random_greetings_dict[
@@ -900,7 +912,7 @@ label greeting_sunshine:
     m 1j "{i}You'll never know dear, just how much I love you.{/i}"
     m 1k "{i}Please don't take my sunshine away~{/i}"
     m 1c "...Eh?"
-    m 1d "H-Huh?!" 
+    m 1d "H-Huh?!"
     m 1l "[player]!"
     m 1n "Oh my gosh, this is so embarassing!"
     m "I w-was just singing to myself to pass time!"
@@ -944,16 +956,16 @@ label greeting_stillsick:
             jump greeting_stillsickrest
         "No":
             jump greeting_stillsicknorest
-    
+
 label greeting_stillsickrest:
     m 3e "Thank you [player]."
     m 3c "I think if I leave you alone for a while, you'll be able to rest better."
     m 1h "So I'm going to close the game for you."
     m 1f "Get well soon, [player]. I love you so much!"
     return 'quit'
-    
+
 label greeting_stillsicknorest:
-    m 1o "I see..." 
+    m 1o "I see..."
     m 1q "Well if you insist [player]."
     m 1f "I suppose you know your own limitations better than I do."
     m "If you start to feel a little weak or tired though, [player], please let me know."


### PR DESCRIPTION
This pull request contains a new rule named `MASAffectionRule`, this rule defines a range of affection used to determine which events can be available based on the current affection level. 

## The AffectionRule

The rule is defined by the  `min` and a `max` properties, both properties accept an integer number used to define the minimum and maximum affection for an event to be determined as available, both properties are inclusive. 
To express a range of "higher than", you must define the `min` property to your desired threshold and the `max` property to `None`.
To express a range of "lower than", you must define the `min` property to `None` and the `max` property to your desired threshold.
Both properties shouldn't be defined as `None` at the same time, since having no affection threshold means this rule would be useless, because it would return a positive availability always. 

## Changes to how the greetings/farewells get selected

After adding the affection rule filtering this is basically how both, greetings and farewells, selection flow work:

 - First we select only the unlocked greetings/farewells.
 - Then we filter those by checking the affection rule.
 - We then check if we have a greeting/farewell with an special flag, if we have that, that's the one we select.
 - If we don't have that special flag, we now do the checking for repeat rules, if we have any of those we select one randomly.
 - If we didn't had any of those, we now check for special random chance rule(both for greetings and farewells), if we got any of those we select one randomly.
 - If we still don't have one selected we merge the affection filtered ones with those that are available at random and proceed to select one of those.

### Usage example 

This is how this rule can be used, in a farewell for example:
``` renpy
init 5 python:
    rules = dict()
    rules.update(MASAffectionRule.create_rule(min=60,max=None))
    addEvent(
        Event(
            persistent.farewell_database,
            eventlabel="bye_high_affection",
            unlocked=True,
            rules=rules
        ),
        eventdb=evhand.farewell_database
    )
    del rules

label bye_high_affection:
    m 1c "Aww, leaving already?"
    m 1e "It's really sad whenever you have to go..."
    m 5a "I love you so much [player]!"
    m 5a "Farewell for now~"
    return 'quit'
```