### PR TITLE
Farewell Menu

### DIFF
--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -420,7 +420,7 @@ label prompt_menu:
         if len(repeatable_events)>0:
             talk_menu.append(("Repeat conversation.", "repeat"))
         talk_menu.append(("I'm feeling...", "moods"))
-        talk_menu.append(("Goodbye.", "goodbye"))
+        talk_menu.append(("Goodbye", "goodbye"))
         talk_menu.append(("Nevermind.","nevermind"))
 
         renpy.say(m, "What would you like to talk about?", interact=False)
@@ -441,7 +441,7 @@ label prompt_menu:
             jump prompt_menu
 
     elif madechoice == "goodbye":
-        call select_farewell from _call_select_farewell
+        call mas_farewell_start from _call_select_farewell
 
     else: #nevermind
         $_return = None
@@ -618,9 +618,3 @@ label prompts_categories(pool=True):
 
     return
 
-label select_farewell:
-    python:
-        farewell = store.mas_farewells.selectFarewell()
-        pushEvent(farewell.eventlabel)
-
-    return

--- a/Monika After Story/game/script-farewells.rpy
+++ b/Monika After Story/game/script-farewells.rpy
@@ -17,7 +17,8 @@ init -1 python in mas_farewells:
         # filter events by their unlocked property first
         unlocked_farewells = renpy.store.Event.filterEvents(
             renpy.store.evhand.farewell_database,
-            unlocked=True
+            unlocked=True,
+            pool=False
         )
 
         # filter farewells using the special rules dict
@@ -67,7 +68,7 @@ label mas_farewell_start:
     python:
         # preprocessing menu
         bye_pool_events = Event.filterEvents(
-            evhand.event_database,
+            evhand.farewell_database,
             unlocked=True,
             pool=True
         )
@@ -85,10 +86,10 @@ label mas_farewell_start:
             bye_prompt_list.append(("Goodbye", -1, False, False))
 
             # setup the last option
-            bye_prompt_back = ("Nevermind", False, False, False)
+            bye_prompt_back = ("Nevermind", False, False, False, 20)
 
         # call the menu
-        call screen mas_gen_scrollable_menu(bye_prompt_list, evhand.UNSE_AREA, UNSE_XALIGN, bye_prompt_back)
+        call screen mas_gen_scrollable_menu(bye_prompt_list, evhand.UNSE_AREA, evhand.UNSE_XALIGN, bye_prompt_back)
 
         if not _return:
             # user its nevermind


### PR DESCRIPTION
Since the farewells system was overhauled, we can now select farewells again.

This relatively small change adds a menu to the farewell selection and a quick farewell saying that you want to sleep. Dialogue probably doesn't need review, but a quick once over would be appropriate.

## Technical:
- Farewells with `pool` set to True will show up in the prompt selection. `prompt` is used for the button text.
- If no unlocked + pool farewells exist, the regular random farewell selection is used.
- It still is possible to select a random farewell, currently the button just says `goodbye`, but we should probably change that at some point.
