### PR TITLE
Increased random seen limit

### DIFF
--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -41,6 +41,10 @@ init 11 python:
     # for compatiblity purposes:
     monika_random_topics = all_random_topics
 
+    if len(monika_random_topics) == 0:
+        # you've seen everything?! here, higher session limit
+        random_seen_limit = 100
+
     #Remove all previously seen random topics.
        #remove_seen_labels(monika_random_topics)
 #    monika_random_topics = [


### PR DESCRIPTION
Somewhat general consensus is that monika random topics per session is not enough for our hardcore fans. And by hardcore fans, _people who have seen every topic_. This is a quick adjustment that increases the max per session by more than 3x the exisitng amount.

Pending balance discussion.

(May partially address #1298 )