### PR TITLE
Updater Fixes

### DIFF
--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -1047,7 +1047,7 @@ screen preferences():
 
             hbox:
                 textbutton _("Update Version"):
-                    action [SetVariable('check_wait',0), Jump('update_now')]
+                    action [SetVariable('check_wait',0), Jump('forced_update_now')]
                     style "navigation_button"
 
                 textbutton _("Import DDLC Save Data"):
@@ -1553,7 +1553,7 @@ style confirm_button_text is navigation_button_text:
 
 ##Updating screen
 
-screen update_check(ok_action,cancel_action,update_link,check_interval):
+screen update_check(ok_action,cancel_action,mode):
 
     ## Ensure other screens do not get input while this screen is displayed.
     modal True
@@ -1571,16 +1571,22 @@ screen update_check(ok_action,cancel_action,update_link,check_interval):
             yalign .5
             spacing 30
 
-            $latest_version = updater.UpdateVersion(update_link, check_interval=check_interval)
-            if latest_version != None:
+            if mode == 0:
                 label _('An update is now avalable!'):
                     style "confirm_prompt"
                     xalign 0.5
-            elif not timeout:
+
+            elif mode == 1:
+                label _("No update available."):
+                    style "confirm_prompt"
+                    xalign 0.5
+
+            elif mode == 2:
                 label _('Checking for updates...'):
                     style "confirm_prompt"
                     xalign 0.5
             else:
+                # otherwise, we assume a timeout
                 label _('Timeout occured while checking for updates. Try again later.'):
                     style "confirm_prompt"
                     xalign 0.5
@@ -1589,11 +1595,11 @@ screen update_check(ok_action,cancel_action,update_link,check_interval):
                 xalign 0.5
                 spacing 100
 
-                textbutton _("Install") action [ok_action, SensitiveIf(latest_version)]
+                textbutton _("Install") action [ok_action, SensitiveIf(mode == 0)]
 
                 textbutton _("Cancel") action cancel_action
 
-    timer 10.0 action [SetVariable("timeout",True), renpy.restart_interaction]
+    timer 1.0 action Return("None")
 
     ## Right-click and escape answer "no".
     #key "game_menu" action no_action
@@ -1626,14 +1632,25 @@ screen updater:
 
             vbox:
 
+
                 if u.state == u.ERROR:
                     text _("An error has occured:")
                 elif u.state == u.CHECKING:
-                    text _("Checking for updates.")
+                    if mas_updater.timeout <= 0:
+                        $renpy.return_statement()
+
+                    else:
+                        $ mas_updater.timeout -= 1                   
+                        text _("Checking for updates.")
+                elif u.state == u.UPDATE_AVAILABLE:
+                    if u.version == config.version:
+                        $ u.can_proceed = False
+                        text _("Monika After Story is up to date.")
+                    else:
+                        text _("Version [u.version] is available. Do you want to install it?")
+
                 elif u.state == u.UPDATE_NOT_AVAILABLE:
                     text _("Monika After Story is up to date.")
-                elif u.state == u.UPDATE_AVAILABLE:
-                    text _("Version [u.version] is available. Do you want to install it?")
                 elif u.state == u.PREPARING:
                     text _("Preparing to download the updates.")
                 elif u.state == u.DOWNLOADING:
@@ -1643,6 +1660,7 @@ screen updater:
                 elif u.state == u.FINISHING:
                     text _("Finishing up.")
                 elif u.state == u.DONE:
+                    $ persistent.closed_self = True
                     text _("The updates have been installed. Please reopen Monika After Story.")
                 elif u.state == u.DONE_NO_RESTART:
                     text _("The updates have been installed.")

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -1047,7 +1047,7 @@ screen preferences():
 
             hbox:
                 textbutton _("Update Version"):
-                    action [SetVariable('check_wait',0), Jump('forced_update_now')]
+                    action Jump('forced_update_now')
                     style "navigation_button"
 
                 textbutton _("Import DDLC Save Data"):

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -1047,7 +1047,7 @@ screen preferences():
 
             hbox:
                 textbutton _("Update Version"):
-                    action Jump('forced_update_now')
+                    action Function(renpy.call, 'forced_update_now')
                     style "navigation_button"
 
                 textbutton _("Import DDLC Save Data"):

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -1047,7 +1047,7 @@ screen preferences():
 
             hbox:
                 textbutton _("Update Version"):
-                    action Function(renpy.call, 'forced_update_now')
+                    action Function(renpy.call_in_new_context, 'forced_update_now')
                     style "navigation_button"
 
                 textbutton _("Import DDLC Save Data"):
@@ -1632,24 +1632,12 @@ screen updater:
 
             vbox:
 
-                $ up_to_date = False
-
                 if u.state == u.ERROR:
                     text _("An error has occured:")
                 elif u.state == u.CHECKING:
-                    if mas_updater.timeout <= 0:
-                        $renpy.return_statement()
-
-                    else:
-                        $ mas_updater.timeout -= 1                   
-                        text _("Checking for updates.")
+                    text _("Checking for updates.")
                 elif u.state == u.UPDATE_AVAILABLE:
-                    if u.version == config.version:
-                        $ u.can_proceed = False
-                        $ up_to_date = True
-                        text _("Monika After Story is up to date.")
-                    else:
-                        text _("Version [u.version] is available. Do you want to install it?")
+                    text _("Version [u.version] is available. Do you want to install it?")
 
                 elif u.state == u.UPDATE_NOT_AVAILABLE:
                     text _("Monika After Story is up to date.")
@@ -1662,7 +1650,6 @@ screen updater:
                 elif u.state == u.FINISHING:
                     text _("Finishing up.")
                 elif u.state == u.DONE:
-                    $ persistent.closed_self = True
                     text _("The updates have been installed. Please reopen Monika After Story.")
                 elif u.state == u.DONE_NO_RESTART:
                     text _("The updates have been installed.")
@@ -1684,11 +1671,9 @@ screen updater:
             if u.can_proceed:
                 textbutton _("Proceed") action u.proceed
 
-            if u.can_cancel and not up_to_date:
+            if u.can_cancel:
                 textbutton _("Cancel") action Return()
 
-            elif up_to_date:
-                textbutton _("Ok") action Return()
 
 style updater_button_text is navigation_button_text
 style updater_button is confirm_button

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -1632,6 +1632,7 @@ screen updater:
 
             vbox:
 
+                $ up_to_date = False
 
                 if u.state == u.ERROR:
                     text _("An error has occured:")
@@ -1645,6 +1646,7 @@ screen updater:
                 elif u.state == u.UPDATE_AVAILABLE:
                     if u.version == config.version:
                         $ u.can_proceed = False
+                        $ up_to_date = True
                         text _("Monika After Story is up to date.")
                     else:
                         text _("Version [u.version] is available. Do you want to install it?")
@@ -1682,8 +1684,11 @@ screen updater:
             if u.can_proceed:
                 textbutton _("Proceed") action u.proceed
 
-            if u.can_cancel:
+            if u.can_cancel and not up_to_date:
                 textbutton _("Cancel") action Return()
+
+            elif up_to_date:
+                textbutton _("Ok") action Return()
 
 style updater_button_text is navigation_button_text
 style updater_button is confirm_button

--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -161,7 +161,7 @@ init -1 python:
 
             # top left, center button x y
             button_center_x = (
-                int((self.VIEW_WIDTH - self.BUTTON_WIDTH) / 2) +
+                int((self.FRAME_WIDTH - self.BUTTON_WIDTH) / 2) +
                 self._confirm_x
             )
             button_center_y = (
@@ -306,16 +306,26 @@ init -1 python:
             if self._state == self.STATE_CHECKING:
                 # checking for updates
                 
-                if time.time() - self._prev_time > self.TIMEOUT:
-                    # we've timed out!
-                    self._state = self.STATE_TIMEOUT
-                    return
-
                 # check for new version
                 latest_version = updater.UpdateVersion(
                     self.update_link,
                     0
                 )
+
+                if time.time() - self._prev_time > self.TIMEOUT:
+                    # we've timed out! (maybe)
+                    
+                    if latest_version == config.version:
+                        # we're actually on the current version.
+                        # this is a workaround because UpdateVersion does not
+                        # return None when no new update is available
+                        self._state = self.STATE_UPDATED
+
+                    else:
+                        # we actually timed out, i swear
+                        self._state = self.STATE_TIMEOUT
+
+                    return
 
                 if (
                         latest_version is not None and 
@@ -328,6 +338,7 @@ init -1 python:
                 elif (
                         latest_version is None and
                         self.update_link in persistent._update_version
+                        
                     ):
                     # if update_link is in the update version (which means
                     # we have checked for an update using this url before),

--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -540,6 +540,8 @@ label update_now:
             ui.add(MASUpdaterDisplayable(update_link))
             updater_selection = ui.interact()
 
+#        "hold up"
+
         if updater_selection > 0:
             # user wishes to update
             $ persistent.closed_self = True # we take updates as self closed

--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -47,6 +47,7 @@ label update_now:
 
 
         $ mas_updater.timeout = 10 # set timeout var
+        $ persistent._update_last_checked[update_link] = time.time()
         $ updater.update(update_link, restart=True)
 
         # if we reach here, no update occured, probably

--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -10,12 +10,20 @@ init -1 python:
     class MASUpdaterDisplayable(renpy.Displayable):
         # this displayable will handle UpdateVersion on its own while enabling
         # interactions
-        # in particular, we want a cancel button and a sensistive update
-        # button as well an Okay
-        # well, we'll figure it out as we go along.
+        # since UpdateVersion occurs in a background thread, we want to 
+        # handle most logic in the render function, despite the 
+        # event-driven framework
+        # we will return -1 upon cancel / ok
+        # 1 upon update
+
+        import pygame # mouse stuff
+        import time # for timeouts
        
+        # CONSTANTS
         BUTTON_WIDTH = 120
         BUTTON_HEIGHT = 35
+        BUTTON_BOT_SPACE = 50
+        BUTTON_SPACING = 10
 
         FRAME_WIDTH = 500
         FRAME_HEIGHT = 250
@@ -23,10 +31,43 @@ init -1 python:
         VIEW_WIDTH = 1280
         VIEW_HEIGHT = 720
 
+        TEXT_YOFFSET = -15
+
+        MOUSE_EVENTS = (
+            pygame.MOUSEMOTION,
+            pygame.MOUSEBUTTONUP,
+            pygame.MOUSEBUTTONDOWN
+        )
+
+        TIMEOUT = 10 # 10 seconds
+
+        # STATES
+
+        # checknig for an update. This should also be the inital state
+        # update button disabled, cancel button clickable
+        STATE_CHECKING = 0
+
+        # update found
+        # we found an update.
+        # update and cancel enabled
+        STATE_BEHIND = 1
+
+        # no update found
+        # we are at the current verison
+        # update and cancel hidden, ok button is shown and enabled
+        STATE_UPDATED = 2
+
+        # timeout
+        # we timed out.
+        # Update button becomes try again and is enabled. Cancel button enabled
+        STATE_TIMEOUT = 3
+
         def __init__(self, update_link):
             """
             Constructor
             """
+            super(renpy.Displayable, self).__init__()
+
             self.update_link = update_link
 
             # background tile
@@ -43,6 +84,11 @@ init -1 python:
                 xsize=self.FRAME_WIDTH,
                 ysize=self.FRAME_HEIGHT
             )
+
+            # button backs
+            button_idle = Image("mod_assets/hkb_idle_background.png")
+            button_hover = Image("mod_assets/hkb_hover_background.png")
+            button_disabled = Image("mod_assets/hkb_disabled_background.png")
 
             # ok button text
             button_text_ok_idle = Text(
@@ -92,10 +138,349 @@ init -1 python:
                 outlines=[]
             )
 
+            # retry button text
+            button_text_retry_idle = Text(
+                "Retry",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#000",
+                outlines=[]
+            )
+            button_text_retry_hover = Text(
+                "Retry",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#fa9",
+                outlines=[]
+            )
+
             # calculate positions
-            self._confirm_x = self.
+            # top left x, y
+            self._confirm_x = int((self.VIEW_WIDTH - self.FRAME_WIDTH) / 2)
+            self._confirm_y = int((self.VIEW_HEIGHT - self.FRAME_HEIGHT) / 2)
+
+            # top left, center button x y
+            button_center_x = (
+                int((self.VIEW_WIDTH - self.BUTTON_WIDTH) / 2) +
+                self._confirm_x
+            )
+            button_center_y = (
+                (self._confirm_y + self.FRAME_HEIGHT) - 
+                self.BUTTON_BOT_SPACE
+            )
+
+            # top left, left button x y
+            button_left_x = (
+                int(
+                    (
+                        self.FRAME_WIDTH - 
+                        (
+                            (2 * self.BUTTON_WIDTH) +
+                            self.BUTTON_SPACING
+                        )
+                    ) / 2
+                ) +
+                self._confirm_x
+            )
+            button_left_y = button_center_y
+
+            # create the buttons
+            self._button_ok = MASButtonDisplayable(
+                button_text_ok_idle,
+                button_text_ok_hover,
+                button_text_ok_idle,
+                button_idle,
+                button_hover,
+                button_idle,
+                button_center_x,
+                button_center_y,
+                self.BUTTON_WIDTH,
+                self.BUTTON_HEIGHT,
+                hover_sound=gui.hover_sound,
+                activate_sound=gui.activate_sound
+            )
+
+            self._button_cancel = MASButtonDisplayable(
+                button_text_cancel_idle,
+                button_text_cancel_hover,
+                button_text_cancel_idle,
+                button_idle,
+                button_hover,
+                button_idle,
+                button_left_x + self.BUTTON_WIDTH + self.BUTTON_SPACING,
+                button_left_y,
+                self.BUTTON_WIDTH,
+                self.BUTTON_HEIGHT,
+                hover_sound=gui.hover_sound,
+                activate_sound=gui.activate_sound
+            )
+
+            self._button_update = MASButtonDisplayable(
+                button_text_update_idle,
+                button_text_update_hover,
+                button_text_update_idle,
+                button_idle,
+                button_hover,
+                button_disabled,
+                button_left_x,
+                button_left_y,
+                self.BUTTON_WIDTH,
+                self.BUTTON_HEIGHT,
+                hover_sound=gui.hover_sound,
+                activate_sound=gui.activate_sound
+            )
+
+            self._button_retry = MASButtonDisplayable(
+                button_text_retry_idle,
+                button_text_retry_hover,
+                button_text_retry_idle,
+                button_idle,
+                button_hover,
+                button_disabled,
+                button_left_x,
+                button_left_y,
+                self.BUTTON_WIDTH,
+                self.BUTTON_HEIGHT,
+                hover_sound=gui.hover_sound,
+                activate_sound=gui.activate_sound
+            )
+
+            # confirm text
+            self._text_checking = Text(
+                "Checking for updates...",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#ffe6f4",
+                outlines=[]
+            )
+            self._text_update = Text(
+                "New update available!",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#ffe6f4",
+                outlines=[]
+            )
+            self._text_noupdate = Text(
+                "No update found.",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#ffe6f4",
+                outlines=[]
+            )
+            self._text_timeout = Text(
+                "Connection timed out.",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#ffe6f4",
+                outlines=[]
+            )
+
+            # grouped buttons
+            self._checking_buttons = [
+                self._button_update,
+                self._button_cancel
+            ]
+            self._behind_buttons = self._checking_buttons
+            self._updated_buttons = [self._button_ok]
+            self._timeout_buttons = [
+                self._button_retry,
+                self._button_cancel
+            ]
+
+            # inital state
+            self._state = self.STATE_CHECKING
+
+            # inital button states
+            self._button_update.disable()
+
+            # inital time 
+            self._prev_time = time.time()
 
 
+        def _checkUpdate(self):
+            """
+            Does the purely logical update checking
+            This will set the appropriate states
+            """
+
+            if self._state == self.STATE_CHECKING:
+                # checking for updates
+                
+                if time.time() - self._prev_time > self.TIMEOUT:
+                    # we've timed out!
+                    self._state = self.STATE_TIMEOUT
+                    return
+
+                # check for new version
+                latest_version = updater.UpdateVersion(
+                    self.update_link,
+                    0
+                )
+
+                if (
+                        latest_version is not None and 
+                        latest_version != config.version
+                    ):
+                    # UpdateVersion returns the new version when update found
+                    self._state = self.STATE_BEHIND
+                    self._button_update.enable()
+                
+                elif (
+                        latest_version is None and
+                        self.update_link in persistent._update_version
+                    ):
+                    # if update_link is in the update version (which means
+                    # we have checked for an update using this url before),
+                    # and UpdateVersion returns None, then no update is
+                    # available
+                    self._state = self.STATE_UPDATED
+
+                # otherwise
+                # UpdateVersion has either:
+                # - returned the current verison, which means its still
+                #   processing
+                # - returned None and has never contacted the server 
+                #   before (which means update_link is not in 
+                #   update_version)
+
+
+        def render(self, width, height, st, at):
+            """
+            RENDER
+            """
+
+            # check states
+            self._checkUpdate()
+
+            # now render
+            r = renpy.Render(width, height)
+
+            # starting with backgrounds 
+            back = renpy.render(self.background, width, height, st, at)
+            confirm = renpy.render(self.confirm, width, height, st, at)
+
+            if self._state == self.STATE_CHECKING:
+                # checking for updates
+                display_text = renpy.render(
+                    self._text_checking,
+                    width,
+                    height,
+                    st,
+                    at
+                )
+                display_buttons = self._checking_buttons
+
+            elif self._state == self.STATE_UPDATED:
+                # no update avaiable
+                display_text = renpy.render(
+                    self._text_noupdate,
+                    width,
+                    height,
+                    st,
+                    at
+                )
+                display_buttons = self._updated_buttons
+
+            elif self._state == self.STATE_BEHIND:
+                # update available
+                display_text = renpy.render(
+                    self._text_update,
+                    width,
+                    height,
+                    st,
+                    at
+                )
+                display_buttons = self._behind_buttons
+
+            else:
+                # timed out
+                display_text = renpy.render(
+                    self._text_timeout,
+                    width,
+                    height,
+                    st,
+                    at
+                )
+                display_buttons = self._timeout_buttons
+
+            # render the buttons
+            rendered_buttons = [
+                (
+                    x.render(width, height, st, at),
+                    (x.xpos, x.ypos)
+                )
+                for x in display_buttons
+            ]
+
+            # get display text blit coords
+            pw, ph = display_text.get_size()
+
+            # now blit em all
+            r.blit(back, (0, 0))
+            r.blit(confirm, (self._confirm_x, self._confirm_y))
+            r.blit(
+                display_text, 
+                (
+                    int((width - pw) / 2),
+                    int((height - ph) / 2) + self.TEXT_YOFFSET
+                )
+            )
+            for vis_b, xy in rendered_buttons:
+                r.blit(vis_b, xy)
+
+            # force a redraww so we keep checking udpater
+            renpy.redraw(self, 1.0)
+
+            return r
+
+
+        def event(self, ev, x, y, st):
+            """
+            EVENT
+            """
+            if ev.type in self.MOUSE_EVENTS:
+
+                if self._state == self.STATE_CHECKING:
+                    # checking for an update state
+
+                    if self._button_cancel.event(ev, x, y, st):
+                        # cancel clicked! return -1
+                        return -1
+
+                elif self._state == self.STATE_UPDATED:
+                    # no update found
+                    
+                    if self._button_ok.event(ev, x, y, st):
+                        # ok clicked! return -1
+                        return -1
+
+                elif self._state == self.STATE_BEHIND:
+                    # found an update
+
+                    if self._button_update.event(ev, x, y, st):
+                        # update clicked! return 1
+                        return 1
+
+                    if self._button_cancel.event(ev, x, y, st):
+                        # cancel clicked! return -1
+                        return -1
+
+                else:
+                    # timeout state
+
+                    if self._button_cancel.event(ev, x, y, st):
+                        # cancel clicked! return -1
+                        return -1
+
+                    if self._button_retry.event(ev, x, y, st):
+                        # retry clicked! go back to checking
+                        self._button_update.disable()
+                        self._prev_time = time.time()
+                        self._state = self.STATE_CHECKING
+
+                renpy.redraw(self, 0)
+
+            raise renpy.IgnoreEvent()
 
 
 label forced_update_now:
@@ -139,55 +524,13 @@ label update_now:
             $ update_link = mas_updater.regular
 
 
-        $ mas_updater.timeout = 10 # set timeout var
-#        $ persistent._update_last_checked[update_link] = time.time()
-#        $ updater.update(update_link, restart=True)
+        # call the updater displayable
+        python:
+            ui.add(MASUpdaterDisplayable(update_link))
+            updater_selection = ui.interact()
 
-        # if we reach here, no update occured, probably
-#        if mas_updater.timeout <= 0:
-            # timeout is empty, show a confirm screen
-#            call screen dialog("Timeout occured while checking for updates. Try again later.", Return(True))
-            
-
-#        $timeout = 10 # 10 second timeout
-#        $ sel_option = None
-
-#        while timeout > 0 and sel_option is None:
-            # 10 seconds of update processing
-#            $ latest_version = updater.UpdateVersion(update_link, 0)
-#            if latest_version is not None and latest_version != config.version:
-                # UpdateVersion returns the new version when an update is found
-#                $ mode = 0 # version found    
-
-#            elif latest_version is None and update_link in persistent._update_version:
-                # if the update_link is in the update version (which means we
-                # have checked for an update using this url before), and 
-                # UpdateVersion returns None, then no update is available.
-#                $ mode = 1 # no update found
-
-#            elif timeout > 0:
-                # UpdateVersion has either:
-                # - returned the current version, which means its still processing
-                # - returned None and has never contacted the server before
-                #   ( which means update_link is not in update_version)
-#                $ mode = 2 # checking for update
-
-#            else:
-                # otherwise, we assume a timeout
-#                $ mode = 3 # timeout
-
-#            call screen update_check(Return(True),Return(False),mode)
-
-            # refresh this value
-#            if _return != "None":
-#                $ sel_option = _return
-
-#            else:
-                # wait a second
-#                pause 1.0
-#                $ timeout -= 1
-
-#        if _sel_option
-#            $ persistent.closed_self = True # we take updates as self closed
-#            $updater.update(update_link, restart=True)
+        if updater_selection > 0:
+            # user wishes to update
+            $ persistent.closed_self = True # we take updates as self closed
+            $ updater.update(update_link, restart=True)
     return

--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -2,6 +2,11 @@
 default persistent._mas_unstable_mode = False
 define mas_updater.regular = "http://updates.monikaafterstory.com/updates.json"
 define mas_updater.unstable = "http://unstable.monikaafterstory.com/updates.json"
+define mas_updater.force = False
+define mas_updater.timeout = 10 # timeout default
+
+label forced_update_now:
+    $ mas_updater.force = True
 
 #This file goes through the actions for updating Monika After story
 label update_now:
@@ -26,7 +31,12 @@ label update_now:
                 try: os.rename(config.basedir + "/game/update", config.basedir + "/update")
                 except: pass
 
-    default check_wait = 21600
+    if mas_updater.force:
+        $ check_wait = 0
+    else:
+        # wait 24 hours before updating
+        $ check_wait = 3600 * 24
+
     if time.time()-last_updated > check_wait and updater.can_update():
         if persistent._mas_unstable_mode:
             # use unstabel stuff
@@ -35,11 +45,55 @@ label update_now:
             # use regular updates
             $ update_link = mas_updater.regular
 
-        $timeout = False
-#        $latest_version = updater.UpdateVersion(update_link, check_interval=0)
-        call screen update_check(Return(True),Return(False), update_link, 0)
 
-        if _return:
-            $ persistent.closed_self = True # we take updates as self closed
-            $updater.update(update_link, restart=True)
+        $ mas_updater.timeout = 10 # set timeout var
+        $ updater.update(update_link, restart=True)
+
+        # if we reach here, no update occured, probably
+        if mas_updater.timeout <= 0:
+            # timeout is empty, show a confirm screen
+            call screen dialog("Timeout occured while checking for updates. Try again later.", Return(True))
+            
+
+#        $timeout = 10 # 10 second timeout
+#        $ sel_option = None
+
+#        while timeout > 0 and sel_option is None:
+            # 10 seconds of update processing
+#            $ latest_version = updater.UpdateVersion(update_link, 0)
+#            if latest_version is not None and latest_version != config.version:
+                # UpdateVersion returns the new version when an update is found
+#                $ mode = 0 # version found    
+
+#            elif latest_version is None and update_link in persistent._update_version:
+                # if the update_link is in the update version (which means we
+                # have checked for an update using this url before), and 
+                # UpdateVersion returns None, then no update is available.
+#                $ mode = 1 # no update found
+
+#            elif timeout > 0:
+                # UpdateVersion has either:
+                # - returned the current version, which means its still processing
+                # - returned None and has never contacted the server before
+                #   ( which means update_link is not in update_version)
+#                $ mode = 2 # checking for update
+
+#            else:
+                # otherwise, we assume a timeout
+#                $ mode = 3 # timeout
+
+#            call screen update_check(Return(True),Return(False),mode)
+
+            # refresh this value
+#            if _return != "None":
+#                $ sel_option = _return
+
+#            else:
+                # wait a second
+#                pause 1.0
+#                $ timeout -= 1
+
+#        if _sel_option
+#            $ persistent.closed_self = True # we take updates as self closed
+#            $updater.update(update_link, restart=True)
     return

--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -5,6 +5,99 @@ define mas_updater.unstable = "http://unstable.monikaafterstory.com/updates.json
 define mas_updater.force = False
 define mas_updater.timeout = 10 # timeout default
 
+init -1 python:
+    # custom displayable for the updater screen
+    class MASUpdaterDisplayable(renpy.Displayable):
+        # this displayable will handle UpdateVersion on its own while enabling
+        # interactions
+        # in particular, we want a cancel button and a sensistive update
+        # button as well an Okay
+        # well, we'll figure it out as we go along.
+       
+        BUTTON_WIDTH = 120
+        BUTTON_HEIGHT = 35
+
+        FRAME_WIDTH = 500
+        FRAME_HEIGHT = 250
+
+        VIEW_WIDTH = 1280
+        VIEW_HEIGHT = 720
+
+        def __init__(self, update_link):
+            """
+            Constructor
+            """
+            self.update_link = update_link
+
+            # background tile
+            # hangman frame color (50% trans)
+            self.background = Solid(
+                "#FFE6F47F", 
+                xsize=self.VIEW_WIDTH,
+                ysize=self.VIEW_HEIGHT
+            )
+
+            # confirm screen (black, 70%)
+            self.confirm = Solid(
+                "#000000B2",
+                xsize=self.FRAME_WIDTH,
+                ysize=self.FRAME_HEIGHT
+            )
+
+            # ok button text
+            button_text_ok_idle = Text(
+                "Ok",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#000",
+                outlines=[]
+            )
+            button_text_ok_hover = Text(
+                "Ok",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#fa9",
+                outlines=[]
+            )
+
+            # cancel button text
+            button_text_cancel_idle = Text(
+                "Cancel",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#000",
+                outlines=[]
+            )
+            button_text_cancel_hover = Text(
+                "Cancel",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#fa9",
+                outlines=[]
+            )
+
+            # update button text
+            button_text_update_idle = Text(
+                "Update",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#000",
+                outlines=[]
+            )
+            button_text_update_hover = Text(
+                "Update",
+                font=gui.default_font,
+                size=gui.text_size,
+                color="#fa9",
+                outlines=[]
+            )
+
+            # calculate positions
+            self._confirm_x = self.
+
+
+
+
 label forced_update_now:
     $ mas_updater.force = True
 
@@ -47,13 +140,13 @@ label update_now:
 
 
         $ mas_updater.timeout = 10 # set timeout var
-        $ persistent._update_last_checked[update_link] = time.time()
-        $ updater.update(update_link, restart=True)
+#        $ persistent._update_last_checked[update_link] = time.time()
+#        $ updater.update(update_link, restart=True)
 
         # if we reach here, no update occured, probably
-        if mas_updater.timeout <= 0:
+#        if mas_updater.timeout <= 0:
             # timeout is empty, show a confirm screen
-            call screen dialog("Timeout occured while checking for updates. Try again later.", Return(True))
+#            call screen dialog("Timeout occured while checking for updates. Try again later.", Return(True))
             
 
 #        $timeout = 10 # 10 second timeout


### PR DESCRIPTION
~~The in-game updater is actually pretty robust, but the original implementation of it was flawed.~~

~~I've removed the middle-man screen which causes inconsistencies and made the updater rely solely on the built-in one, which handles screen refreshes just fine. I've kept the timeout to 10 seconds, hopefully this is enough for most people.~~

Correction:

The in-game updater works well at being an updater. If we never cared about timeouts, it probably would have been fine on its own.

That being said, the timeout part is somewhat important, also using `UpdateVersion` instead of just `update` allows for some `persistent` values to be set properly. So instead, I'm going to build a custom update-check displayable. Actual updating will still occur via renpy, so those issues **cannot** be fixed so easily.

Checkboxes:
- [x] build custom displayable for update check
- [x] ensure the custom displayable is called correctly
- [x] test the update check displayable