### PR TITLE
Renpy file/exists fixes

### DIFF
--- a/Monika After Story/game/chess.rpy
+++ b/Monika After Story/game/chess.rpy
@@ -1297,6 +1297,7 @@ label demo_minigame_chess:
         python:
             import StringIO # python 2 
             import chess.pgn
+            import os
 
             quicksaved_game = chess.pgn.read_game(
                 StringIO.StringIO(persistent._mas_chess_quicksave)
@@ -1376,7 +1377,7 @@ label demo_minigame_chess:
             ).replace("\\", "/")
 
             try:
-                if renpy.file(quicksaved_filename_clean):
+                if os.access(quicksaved_filename_clean, os.R_OK):
                     quicksaved_file = mas_chess.isInProgressGame(
                         quicksaved_filename,
                         mas_monika_twitter_handle
@@ -1391,7 +1392,6 @@ label demo_minigame_chess:
             $ ur_nice_today = False
             # save the filename of what the game should have been
             python:
-                import os
 
                 mas_chess.loaded_game_filename = quicksaved_filename_clean
 
@@ -1401,7 +1401,7 @@ label demo_minigame_chess:
             if _return == mas_chess.CHESS_GAME_CONT:
                 python:
                     try:
-                        if renpy.file(quicksaved_filename_clean):
+                        if os.access(quicksaved_filename_clean, os.R_OK):
                             quicksaved_file = mas_chess.isInProgressGame(
                                 quicksaved_filename,
                                 mas_monika_twitter_handle
@@ -2019,14 +2019,15 @@ label mas_chess_dlg_qf_lost_may_2_found:
 
 # maybe monika file checking parts
 label mas_chess_dlg_qf_lost_may_filechecker:
+    $ import os 
     $ import store.mas_chess as mas_chess
     $ game_file = mas_chess.loaded_game_filename
 
-    if renpy.exists(game_file):
+    if os.access(game_file, os.F_OK):
         jump mas_chess_dlg_qf_lost_may_gen_found
 
     m 1e "Can you put the save back so we can play?"
-    if renpy.exists(game_file):
+    if os.access(game_file, os.F_OK):
         jump mas_chess_dlg_qf_lost_may_gen_found
 
     show monika 1a
@@ -2037,7 +2038,7 @@ label mas_chess_dlg_qf_lost_may_filechecker:
         file_found = False
         seconds = 0
         while not file_found and seconds < 60:
-            if renpy.exists(game_file):
+            if os.access(game_file, os.F_OK):
                 file_found = True
             else:
                 renpy.pause(1.0, hard=True)

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -819,8 +819,7 @@ label greeting_youarereal:
     python:
         try:
             renpy.file(
-                config.basedir.replace("\\","/") +
-                "/characters/" + persistent.playername.lower() + ".chr"
+                "../characters/" + persistent.playername.lower() + ".chr"
             )
             persistent._mas_you_chr = True
         except:

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -3347,7 +3347,7 @@ label monika_surprise:
     m 3c "You know what? Maybe I should do it again..."
     m 1b "Yeah, that's a good idea."
     python:
-        try: renpy.file(config.basedir + "/surprise.txt")
+        try: renpy.file("../surprise.txt")
         except: open(config.basedir + "/surprise.txt", "w").write("I love you.")
     m 2q "..."
     m 1j "Alright!"

--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -651,7 +651,7 @@ label update_now:
     #Make sure the update folder is where it should be
     if not updater.can_update():
         python:
-            try: renpy.file(config.basedir + "/update/current.json")
+            try: renpy.file("../update/current.json")
             except:
                 try: os.rename(config.basedir + "/game/update", config.basedir + "/update")
                 except: pass


### PR DESCRIPTION
`renpy.file` and `renpy.exists` rely on relative paths, while `open`, and any `os` operation use absolute paths.

Not knowing this has resulted in not being able to detect files on non-windows systems (basically any system with a **good** filesystem).

This is somewhat game breaking, so we'll be pushing a hotfix directly after this gets merged.

For testing, just testing the chess save part is sufficient. 

#1389 