### PR TITLE
Adding Last Seen Property

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -85,6 +85,8 @@ python early:
     #       NOTE: refer to RULES documentation in event-rules
     #       NOTE: if you set this to None, you will break this forever
     #       (Default: empty dict)
+    #   last_seen - datetime of the last time this topic has been seen
+    #       (Default: None)
     class Event(object):
 
         # tuple constants
@@ -103,7 +105,8 @@ python early:
             "unlock_date":11,
             "shown_count":12,
             "diary_entry":13,
-            "rules":14
+            "rules":14,
+            "last_seen":15
         }
 
         # name constants
@@ -137,7 +140,8 @@ python early:
                 end_date=None,
                 unlock_date=None,
                 diary_entry=None,
-                rules=dict()
+                rules=dict(),
+                last_seen=None
             ):
 
             # setting up defaults
@@ -186,7 +190,8 @@ python early:
                 unlock_date,
                 0, # shown_count
                 diary_entry,
-                rules
+                rules,
+                last_seen
             )
 
             stored_data_row = self.per_eventdb.get(eventlabel, None)

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -41,7 +41,8 @@ init -500 python:
         True, # unlock_date
         True, # shown_count
         False, # diary_entry
-        False # rules
+        False, # rules
+        True # last_seen
     )
 
     # set defaults
@@ -112,6 +113,10 @@ init -1 python in evhand:
     UNSE_H = 640
     UNSE_XALIGN = -0.05
     UNSE_AREA = (UNSE_X, UNSE_Y, UNSE_W, UNSE_H)
+
+    # time stuff
+    import datetime
+    LAST_SEEN_DELTA = datetime.timedelta(hours=2)
 
     # as well as special functions
     def addIfNew(items, pool):
@@ -338,6 +343,27 @@ init python:
         return
 
 
+    def mas_cleanJustSeen(eventlist, db):
+        """
+        Cleans the given event list of just seen items (withitn the THRESHOLD)
+        retunrs not just seen items
+
+        IN:
+            eventlist - list of event labels to pick from
+            db - database these events are tied to
+
+        RETURNS:
+            cleaned list of events (stuff not in the time THREASHOLD)
+        """
+        import datetime
+        now = datetime.datetime.now()
+        return [
+            db[evlabel].eventlabel
+            for evlabel in eventlist
+            if now - db[evlabel].last_seen >= store.evhand.LAST_SEEN_DELTA
+        ]
+
+
 
 # This calls the next event in the list. It returns the name of the
 # event called or None if the list is empty or the label is invalid
@@ -366,6 +392,7 @@ label call_next_event:
 
             # increment shown count
             $ ev.shown_count += 1
+            $ ev.last_seen = datetime.datetime.now()
 
         if _return == 'quit':
             $persistent.closed_self = True #Monika happily closes herself

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -357,12 +357,20 @@ init python:
         """
         import datetime
         now = datetime.datetime.now()
-        return [
-            db[evlabel].eventlabel
-            for evlabel in eventlist
-            if now - db[evlabel].last_seen >= store.evhand.LAST_SEEN_DELTA
-        ]
+        cleanlist = list()
 
+        for evlabel in eventlist:
+            ev = db.get(evlabel, None)
+
+            if ev:
+                if ev.last_seen:
+                    if now - ev.last_seen >= store.evhand.LAST_SEEN_DELTA:
+                        cleanlist.append(evlabel)
+
+                else:
+                    cleanlist.append(evlabel)
+
+        return cleanlist
 
 
 # This calls the next event in the list. It returns the name of the

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -697,9 +697,10 @@ label ch30_loop:
                         random=True
                     ).values()
                     monika_random_topics.sort(key=Event.getSortShownCount)
-                    monika_random_topics = [
-                        ev.eventlabel for ev in monika_random_topics
-                    ]
+                    monika_random_topics = mas_cleanJustSeen(
+                        [ev.eventlabel for ev in monika_random_topics],
+                        evhand.event_database
+                    )
                     # NOTE: now the monika random topics are back to being
                     #   labels. Safe to do normal operation.
 


### PR DESCRIPTION
#1365 

The `last_seen` property contains a `datetime` of the last time an Event has been seen (via `call_next_event`). This is primarily to prevent topics from repeating too soon.

The threshold is 2 hours.

The function `mas_cleanJustSeen` is for cleaning a list of eventlabels according to the `last_seen` property. This function is solely meant for random events.