### PR TITLE
Fixed template mismatch crash

### DIFF
--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -60,6 +60,9 @@ init -500 python:
             lock_row[0:len(stored_lock_row)] = list(stored_lock_row)
             persistent._mas_event_init_lockdb[ev_key] = tuple(lock_row)
 
+        # now set the new template
+        persistent._mas_event_init_lockdb_template = mas_init_lockdb_template
+
     # set db defaults
     if persistent._mas_event_init_lockdb is None:
         persistent._mas_event_init_lockdb = dict()

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -46,10 +46,11 @@ init -500 python:
     )
 
     # set defaults
-    if persistent._mas_event_init_lockdb_template is None:
-        persistent._mas_event_init_lockdb_template = mas_init_lockdb_template
-
-    elif len(persistent._mas_event_init_lockdb_template) != len(mas_init_lockdb_template):
+    if (
+            persistent._mas_event_init_lockdb_template is not None 
+            and len(persistent._mas_event_init_lockdb_template) 
+                != len(mas_init_lockdb_template)
+        ):
         # differing lengths mean we have new items to deal with
 
         for ev_key in persistent._mas_event_init_lockdb:
@@ -60,8 +61,8 @@ init -500 python:
             lock_row[0:len(stored_lock_row)] = list(stored_lock_row)
             persistent._mas_event_init_lockdb[ev_key] = tuple(lock_row)
 
-        # now set the new template
-        persistent._mas_event_init_lockdb_template = mas_init_lockdb_template
+    # set the new template
+    persistent._mas_event_init_lockdb_template = mas_init_lockdb_template
 
     # set db defaults
     if persistent._mas_event_init_lockdb is None:


### PR DESCRIPTION
This is an issue found internally.
The error is a `tuple index` out of range error.

Steps to reproduce crash:
1. Edit an event's lockdb template by shrinking its tuple size.
2. **DONT** change the `persistent._mas_event_init_lockdb_template` size.
3. Restart MAS. You should encounter the crash. 

Root Cause:
1. When the template's length was increased, the persistent's template length was not increased, so new Events's lock db template would be the wrong length (aka, they wouldn't migrate successfully to the correct size)

### Technical:
* the `persistent` template is now always set.