### PR TITLE
0.8.0 update scripts

### DIFF
--- a/Monika After Story/game/options.rpy
+++ b/Monika After Story/game/options.rpy
@@ -23,7 +23,7 @@ define gui.show_name = False
 
 ## The version of the game.
 
-define config.version = "0.7.4-hotfix.2"
+define config.version = "0.8.0"
 
 ## Text that is placed on the game's about screen. To insert a blank line
 ## between paragraphs, write \n\n.

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -222,8 +222,15 @@ label v0_8_0(version="v0_8_0"):
             ):
             evhand.event_database["monika_changename"].unlocked = True
 
-        # TODO anniversary force seen
-        # NOTE: this is awaiting the date functions
+        annis = (
+            "anni_1week",
+            "anni_1month",
+            "anni_3month",
+            "anni_6month"
+        ) # impossible to reach a year
+        for anni in annis:
+            if isPast(evhand.event_database[anni]):
+                persistent._seen_ever[anni] = True
 
         persistent = updateTopicIDs(version)
 

--- a/Monika After Story/game/updates_topics.rpy
+++ b/Monika After Story/game/updates_topics.rpy
@@ -62,7 +62,7 @@ label vv_updates_topics:
         # update this dict accordingly to every new version
         # k:old version number -> v:new version number
         # some version changes skip some numbers because no major updates
-#        updates.version_updates[vv0_7_4] = vv0_8_0
+        updates.version_updates[vv0_7_4] = vv0_8_0
         updates.version_updates[vv0_7_3] = vv0_7_4
         updates.version_updates[vv0_7_2] = vv0_7_4
         updates.version_updates[vv0_7_1] = vv0_7_2
@@ -91,6 +91,11 @@ label vv_updates_topics:
         # do NOT use this to update the IDs
         # All conflicts should be handled in an individual script block in
         # updates.rpy. (SEE updates.rpy)
+
+        # 0.7.4 -> 0.8.0
+        updates.topics[vv0_8_0] = {
+            "monika_love2": None
+        }
 
         # (0.7.0 - 0.7.3) -> 0.7.4
         updates.topics[vv0_7_4] = {


### PR DESCRIPTION
Topics that were removed in previous version (0.7.4) should be removed from their databases as well.
```
- monika_love2
- monika_bad_day
- monika_playerhappy
```

Annivesaries that past already should be set to seen.