### PR TITLE
Chnaged writing tips unlock logic

### DIFF
--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -935,9 +935,9 @@ label monika_yuri:
 
 
 init 5 python:
-    addEvent(Event(persistent.event_database,eventlabel="monika_writingtip",category=['writing tips'],prompt="Writing Tip #1",pool=True))
+    addEvent(Event(persistent.event_database,eventlabel="monika_writingtip1",category=['writing tips'],prompt="Writing Tip #1",pool=True))
 
-label monika_writingtip:
+label monika_writingtip1:
     m 1a "You know, it's been a while since we've done one of these..."
     m 1j "...so let's go for it!"
     m 3b "Here's Monika's Writing Tip of the Day!"
@@ -3414,9 +3414,9 @@ label monika_closet:
     return
 
 init 5 python:
-    addEvent(Event(persistent.event_database,eventlabel="monika_writingtip1",category=['writing tips'],prompt="Writing Tip #2",conditional="seen_event('monika_writingtip')",action=EV_ACT_POOL))
+    addEvent(Event(persistent.event_database,eventlabel="monika_writingtip2",category=['writing tips'],prompt="Writing Tip #2",conditional="seen_event('monika_writingtip1')",action=EV_ACT_POOL))
 
-label monika_writingtip1:
+label monika_writingtip2:
     m 3a "You know..."
     m "We really don't do enough of these, so here's another one!"
     m 3b "Here's Monika's Writing Tip of the Day!"
@@ -4545,9 +4545,9 @@ label monika_otaku:
     return
 
 init 5 python:
-    addEvent(Event(persistent.event_database,eventlabel="monika_write",category=['writing tips'],prompt="Writing tip #3",conditional="seen_event('monika_writingtip1')",action=EV_ACT_POOL))
+    addEvent(Event(persistent.event_database,eventlabel="monika_writingtip3",category=['writing tips'],prompt="Writing tip #3",conditional="seen_event('monika_writingtip2')",action=EV_ACT_POOL))
 
-label monika_write:
+label monika_writingtip3:
     m 1a "I'm having fun doing these, so..."
     m 3b "Here's Monika's Writing Tip of the Day!"
     m 1a "Make sure you always write down any ideas you think of."
@@ -4570,7 +4570,7 @@ label monika_write:
     return
 
 init 5 python:
-      addEvent(Event(persistent.event_database,eventlabel="monika_writingtip4",category=['writing tips'],prompt="Writing tip #4",conditional="seen_event('monika_write')",action=EV_ACT_POOL))
+      addEvent(Event(persistent.event_database,eventlabel="monika_writingtip4",category=['writing tips'],prompt="Writing tip #4",conditional="seen_event('monika_writingtip3')",action=EV_ACT_POOL))
 
 label monika_writingtip4:
      m 3b "Here's Monika's Writing Tip of the Day!"

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -4545,7 +4545,7 @@ label monika_otaku:
     return
 
 init 5 python:
-    addEvent(Event(persistent.event_database,eventlabel="monika_write",category=['writing tips'],prompt="Writing tip #3",pool=True))
+    addEvent(Event(persistent.event_database,eventlabel="monika_write",category=['writing tips'],prompt="Writing tip #3",conditional="seen_event('monika_writingtip1')",action=EV_ACT_POOL))
 
 label monika_write:
     m 1a "I'm having fun doing these, so..."
@@ -4570,7 +4570,7 @@ label monika_write:
     return
 
 init 5 python:
-      addEvent(Event(persistent.event_database,eventlabel="monika_writingtip4",category=['writing tips'],prompt="Writing tip #4",pool=True))
+      addEvent(Event(persistent.event_database,eventlabel="monika_writingtip4",category=['writing tips'],prompt="Writing tip #4",conditional="seen_event('monika_write')",action=EV_ACT_POOL))
 
 label monika_writingtip4:
      m 3b "Here's Monika's Writing Tip of the Day!"
@@ -4592,7 +4592,7 @@ label monika_writingtip4:
      return
 
 init 5 python:
-      addEvent(Event(persistent.event_database,eventlabel="monika_writingtip5",category=['writing tips'],prompt="Writing tip #5",pool=True))
+      addEvent(Event(persistent.event_database,eventlabel="monika_writingtip5",category=['writing tips'],prompt="Writing tip #5",conditional="seen_event('monika_writingtip4')",action=EV_ACT_POOL))
 
 label monika_writingtip5:
      m 3b "Here's Monika's Writing Tip of the Day!"

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -61,6 +61,45 @@ init python:
             Event.INIT_LOCKDB.pop(topicID)
 
 
+    def mas_transferTopic(old_topicID, new_topicID, per_eventDB):
+        """
+        Transfers a topic's data from the old topic ID to the new one int he
+        given database as well as the lock database.
+
+        NOTE: If the new topic ID already exists in the given databases,
+        the data is OVERWRITTEN
+
+        IN:
+            old_topicID - old topic ID to transfer
+            new_topicID - new topic ID to receieve
+            per_eventDB - persistent databse this topic is in
+        """
+        if old_topicID in per_eventDB:
+
+            # listify old data so we can replace the eventlabel attribute
+            # EVENTLABEL is piece 0. NOTE: PLEASE DO NOT CHANGE
+            old_data = list(per_eventDB.pop(old_topicID))
+            old_data[0] = new_topicID
+            per_eventDB[new_topicID] = tuple(old_data)
+
+        if old_topicID in Event.INIT_LOCKDB:
+            Event.INIT_LOCKDB[new_topicID] = Event.INIT_LOCKDB.pop(old_topicID)
+
+
+    def mas_transferTopicSeen(old_topicID, new_topicID):
+        """
+        Tranfers persistent seen ever data. This is separate because of complex
+        topic adjustments
+
+        IN:
+            old_topicID - old topic ID to tranfer
+            new_topicID - new topic ID to receieve
+        """
+        if old_topicID in persistent._seen_ever:
+            persistent._seen_ever.pop(old_topicID)
+            persistent._seen_ever[new_topicID] = True
+
+
     def adjustTopicIDs(changedIDs,updating_persistent=persistent):
         #
         # Changes labels in persistent._seen_ever
@@ -221,6 +260,53 @@ label v0_8_1(version="v0_8_1"):
         if m_ff:
             hideEvent(m_ff, derandom=True)
             m_ff.pool = True
+
+        # regular topic update
+        persistent = updateTopicIDs(version)
+
+        ## writing topic adjustments
+
+        # writing tip 5
+        writ_5 = evhand.event_database.get("monika_writingtip5", None)
+        if writ_5 and not renpy.seen_label(writ_5.eventlabel):
+            writ_5.pool = False
+            writ_5.conditional = "seen_event('monika_writingtip4')"
+            writ_5.action = EV_ACT_POOL
+
+        # writing tip 4
+        writ_4 = evhand.event_database.get("monika_writingtip4", None)
+        if writ_4 and not renpy.seen_label(writ_4.eventlabel):
+            writ_4.pool = False
+            writ_4.conditional = "seen_event('monika_writingtip3')"
+            writ_4.action = EV_ACT_POOL
+
+        # writing tip 3
+        mas_transferTopic(
+            "monika_write", 
+            "monika_writingtip3",
+            persistent.event_database
+        )
+        writ_3 = evhand.event_database.get("monika_writingtip3", None)
+        if writ_3 and not renpy.seen_label(writ_3.eventlabel):
+            writ_3.pool = False
+            writ_3.conditional = "seen_event('monika_writingtip2')"
+            writ_3.action = EV_ACT_POOL
+
+        # writing tip 2
+        old_t = "monika_writingtip1"
+        new_t = "monika_writingtip2"
+        mas_transferTopicSeen(old_t, new_t)
+        mas_transferTopic(old_t, new_t, persistent.event_database)
+        writ_2 = evhand.event_database.get(new_t, None)
+        if writ_2 and not renpy.seen_label(new_t):
+            writ_2.conditional = "seen_event('monika_writingtip1')"
+
+        # writing tip 1
+        old_t = "monika_writingtip"
+        new_t = "monika_writingtip1"
+        mas_transferTopicSeen(old_t, new_t)
+        mas_transferTopic(old_t, new_t, persistent.event_database)
+       
 
     return
 

--- a/Monika After Story/game/updates_topics.rpy
+++ b/Monika After Story/game/updates_topics.rpy
@@ -94,6 +94,11 @@ label vv_updates_topics:
         # All conflicts should be handled in an individual script block in
         # updates.rpy. (SEE updates.rpy)
 
+        # 0.8.0 -> 0.8.1
+        updates.topics[vv0_8_1] = {
+            "monika_write": "monika_writingtip3"
+        }
+
         # 0.7.4 -> 0.8.0
         updates.topics[vv0_8_0] = {
             "monika_love2": None


### PR DESCRIPTION
Writing tips from `#3` onwards were unlocked and available without checking if the player had seen the others before. This pull request changes that so they use a conditional property to unlock themselves once you see the others in order.