### PR TITLE
Added a new flow for greetings, now it has types

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -77,8 +77,8 @@ image room_mask2 = Movie(channel="window_2", play="mod_assets/window_2.webm",mas
 image room_mask3 = Movie(channel="window_3", play="mod_assets/window_3.webm",mask=None,image="mod_assets/window_3_fallback.png")
 image room_mask4 = Movie(channel="window_4", play="mod_assets/window_4.webm",mask=None,image="mod_assets/window_4_fallback.png")
 image rain_mask_left = Movie(
-    channel="window_5", 
-    play="mod_assets/window_5.webm", 
+    channel="window_5",
+    play="mod_assets/window_5.webm",
     mask=None,
     image="mod_assets/window_5_fallback.png"
 )
@@ -144,8 +144,8 @@ init python:
 
     # we need a new music channel for background audio (like rain!)
     renpy.music.register_channel(
-        "background", 
-        mixer="music", 
+        "background",
+        mixer="music",
         loop=True,
         stop_on_mute=True,
         tight=True
@@ -257,7 +257,7 @@ init python:
         game.
 
         ASSUMES:
-            morning_flag 
+            morning_flag
             mas_is_raining
         """
         if mas_is_raining:
@@ -410,7 +410,7 @@ label pick_a_game:
             import datetime
             _hour = datetime.timedelta(hours=1)
             _now = datetime.datetime.now()
-            
+
             # chess has timed disabling
             if persistent._mas_chess_timed_disable is not None:
                 if persistent._mas_chess_timed_disable - _now >= _hour:
@@ -575,7 +575,12 @@ label ch30_autoload:
         else:
             python:
 
-                sel_greeting_event = store.mas_greetings.selectGreeting()
+                # we select a greeting depending on the type that we should select
+                sel_greeting_event = store.mas_greetings.selectGreeting(persistent._mas_greeting_type)
+
+                # reset the greeting type flag back to None
+                persistent._mas_greeting_type = None
+
                 selected_greeting = sel_greeting_event.eventlabel
 
                 # store if we have to skip visuals ( used to prevent visual bugs)
@@ -656,7 +661,7 @@ label ch30_loop:
 
     else:
         $ mas_skip_visuals = False
-    
+
 
     $ persistent.autoload = "ch30_autoload"
     if not persistent.tried_skip:
@@ -792,7 +797,7 @@ label ch30_reset:
     # reset mas mood bday
     python:
         if (
-                persistent._mas_mood_bday_last 
+                persistent._mas_mood_bday_last
                 and persistent._mas_mood_bday_last < today
             ):
             persistent._mas_mood_bday_last = None
@@ -808,8 +813,8 @@ label ch30_reset:
             lockEventLabel("monika_rain_stop")
 #            lockEventLabel("monika_rain_holdme")
             unlockEventLabel("monika_rain")
-            
-       
+
+
     # reset hair / clothes
     python:
         # setup hair / clothes
@@ -831,7 +836,7 @@ label ch30_reset:
                 # "bun": "monika_hair_bun"
             }
 
-          
+
             for hair in hair_map:
                 # this is so we kind of automate the locking / unlocking prcoess
                 if hair == monika_chr.hair:

--- a/Monika After Story/game/script-farewells.rpy
+++ b/Monika After Story/game/script-farewells.rpy
@@ -1,6 +1,6 @@
 ##This file contains all of the variations of goodbye that monika can give.
 ## This also contains a store with a utility function to select an appropriate
-## farewell 
+## farewell
 
 init -1 python in mas_farewells:
 
@@ -78,7 +78,7 @@ label mas_farewell_start:
         python:
             # build a prompt list
             bye_prompt_list = [
-                (ev.prompt, ev, False, False) 
+                (ev.prompt, ev, False, False)
                 for k,ev in bye_pool_events.iteritems()
             ]
 
@@ -198,6 +198,7 @@ label bye_prompt_to_class:
     m 1j "Study hard, [player]!"
     m 1 "Nothing is more attractive than a [guy] with good grades."
     m 1j "See you later!"
+    $ persistent._mas_greeting_type = store.mas_greetings.TYPE_SCHOOL
     return 'quit'
 
 init 5 python:
@@ -216,6 +217,7 @@ label bye_prompt_to_work:
     m 1j "Work hard, [player]!"
     m 1 "I'll be here for you when you get home from work."
     m 1j "Bye-bye!"
+    $ persistent._mas_greeting_type = store.mas_greetings.TYPE_WORK
     return 'quit'
 
 init 5 python:
@@ -304,22 +306,23 @@ label bye_prompt_sleep:
 # tie this with affection later
 #            "No.":
 #                m 2r "..."
-#                m "Fine."  
+#                m "Fine."
     else:
         # otheerwise
         m "Alright, [player]."
         m 1j "Sweet dreams!"
 
+    $ persistent._mas_greeting_type = store.mas_greetings.TYPE_SLEEP
     return 'quit'
-    
+
 init 5 python:
     addEvent(Event(persistent.farewell_database,eventlabel="bye_illseeyou",random=True),eventdb=evhand.farewell_database)
-    
+
 label bye_illseeyou:
     m 1b "I'll see you tomorrow, [player]."
     m 1k "Don't forget about me, okay?"
     return 'quit'
-    
+
 init 5 python: ## Implementing Date/Time for added responses based on the time of day
     rules = dict()
     rules.update(MASSelectiveRepeatRule.create_rule(hours=range(6,11)))
@@ -337,10 +340,10 @@ init 5 python: ## Implementing Date/Time for added responses based on the time o
 label bye_haveagoodday:
     m 1b "Have a good day today, [player]."
     m 1b "I hope you accomplish everything you had planned for today."
-    m 1b "I'll be here waiting for you when you get back."  
+    m 1b "I'll be here waiting for you when you get back."
     return 'quit'
- 
-init 5 python: 
+
+init 5 python:
     rules = dict()
     rules.update(MASSelectiveRepeatRule.create_rule(hours=range(12,16)))
     addEvent(
@@ -375,7 +378,7 @@ init 5 python:
     )
     del rules
 
-label bye_goodevening:    
+label bye_goodevening:
     m 1k "I had fun today."
     m 1a "Thank you for spending so much time with me, [player]."
     m 1j "Until then, have a good evening."
@@ -394,7 +397,7 @@ init 5 python:
         eventdb=evhand.farewell_database
     )
     del rules
-    
+
 label bye_goodnight:
     m 1a "Goodnight, [player]."
     m 1e "I'll see you tomorrow, okay?"

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1086,11 +1086,12 @@ label greeting_back_from_school:
              m 1k "Aww, that's nice!"
              m 1b "I can't help but feel happy when you do~"
              m 1a "I hope you learned a lot of useful things."
-             m 1k "Ehehe, I love you, [player]."
+             m 1j "Ehehe~"
+             m 1k "I love you, [player]~"
          "No.":
              m 1g "Oh..."
              m "I'm sorry to hear that."
-             m "Just remember that no matter what happens, I'll be here for you, [player]."
+             m "Just remember that no matter what happens, I'll be here for you."
              m 1e "I love you so, so much."
      return
 
@@ -1111,16 +1112,19 @@ label greeting_back_from_work:
      menu:
          m "Did you have a good day at work today?"
          "Yes.":
-             m 1k "Aww, that's nice!"
-             m 1b "I can't help but feel happy when you do..."
-             m "I love you so much, [player]."
+             m 1k "That's good!"
+             m 1a "Remember to rest first, okay?"
+             m "That way, you'd at least have some energy before you work more on stuff."
+             m 3a "But if not, you can relax with me!"
+             m 1j "Best thing to do after a long day from, don't you think?"
              m 1k "Ahaha!"
+             
          "No.":
-             m 1g "Oh dear..."
-             m "I'm sorry to hear that."
-             m "Just remember that no matter what happens, no matter what anyone says or does..."
-             m "I'm here for you."
-             m 1e "I love you so, so much."
+             m 1q "..."
+             m 2f "I'd hug you right now if I were there, [player]."
+             m 2g"I'm sorry you had a bad work day..."
+             m 4e "Just remember that I'm here when you need me, okay?"
+             m 1j "I love you so much, [player]."
      return
 
 init 5 python:
@@ -1136,7 +1140,7 @@ init 5 python:
     )
 
 label greeting_back_from_sleep:
-     m "Oh, hello [player]!"
+     m "Oh hello, [player]!"
      m 1k "I hope you had a good rest!"
-     m "let's spend some time together~"
+     m "Let's spend some more time together~"
      return

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1031,7 +1031,7 @@ label greeting_hairdown:
     call spaceroom
     m 1a "Hi there, [player]!"
     m 4j "Notice anything different today?"
-    m 1k "I decided to try something new today~"
+    m 1k "I decided to try something new~"
     menu:
         m "Do you like it?"
         "Yes":
@@ -1054,7 +1054,7 @@ label greeting_hairdown:
 
             $ monika_chr.reset_hair()
 
-            m 1h "There we go."
+            m 1h "Done."
             # you will never get this chance again
 
     # lock this greeting forever.
@@ -1081,17 +1081,16 @@ init 5 python:
 label greeting_back_from_school:
      m 1b "Oh, welcome back [player]!"
      menu:
-         m "Did you have a good day at school today?"
+         m "Did you have a good day at school?"
          "Yes.":
              m 1k "Aww, that's nice!"
-             m 1b "I can't help but feel happy when you do..."
-             m "I hope you learned a lot."
-             m 1k "I love you so much, [player]."
+             m 1b "I can't help but feel happy when you do~"
+             m 1a "I hope you learned a lot of useful things."
+             m 1k "Ehehe, I love you, [player]."
          "No.":
-             m 1g "Oh dear..."
+             m 1g "Oh..."
              m "I'm sorry to hear that."
-             m "Just remember that no matter what happens, no matter what anyone says or does..."
-             m "I'm here for you."
+             m "Just remember that no matter what happens, I'll be here for you, [player]."
              m 1e "I love you so, so much."
      return
 

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -5,9 +5,19 @@
 # persistents that greetings use
 default persistent._mas_you_chr = False
 
+# persistent containing the greeting type
+# that should be selected None means default
+default persistent._mas_greeting_type = None
+
 init -1 python in mas_greetings:
+
+    # TYPES:
+    TYPE_SCHOOL = "school"
+    TYPE_WORK = "work"
+    TYPE_SLEEP = "sleep"
+
     # custom greeting functions
-    def selectGreeting():
+    def selectGreeting(type=None):
         """
         Selects a greeting to be used. This evaluates rules and stuff
         appropriately.
@@ -15,12 +25,23 @@ init -1 python in mas_greetings:
         RETURNS:
             a single greeting (as an Event) that we want to use
         """
+        # check first if we have to select from a special type
+        if type is not None:
 
-        # filter events by their unlocked property first
-        unlocked_greetings = renpy.store.Event.filterEvents(
-            renpy.store.evhand.greeting_database,
-            unlocked=True
-        )
+            # filter them using the type as filter
+            unlocked_greetings = renpy.store.Event.filterEvents(
+                renpy.store.evhand.greeting_database,
+                unlocked=True,
+                category=(True,[type])
+            )
+
+        else:
+
+            # filter events by their unlocked property only
+            unlocked_greetings = renpy.store.Event.filterEvents(
+                renpy.store.evhand.greeting_database,
+                unlocked=True
+            )
 
         # filter greetings using the special rules dict
         random_greetings_dict = renpy.store.Event.checkRepeatRules(
@@ -47,6 +68,14 @@ init -1 python in mas_greetings:
             # select on label randomly
             return random_greetings_dict[
                 renpy.random.choice(random_greetings_dict.keys())
+            ]
+
+        # check if we have greetings available to display with current filter
+        if len(unlocked_greetings) > 0:
+
+            # select one randomly if we have at least one
+            return unlocked_greetings[
+                renpy.random.choice(unlocked_greetings.keys())
             ]
 
         # We couldn't find a suitable greeting we have to default to normal random selection
@@ -956,15 +985,15 @@ label greeting_stillsicknorest:
     m 1e "Don't worry, I'll still be here when you wake up."
     m 3j "Then we can have some more fun together without me worrying about you in the back of my mind."
     return
-    
-#Time Concern  
+
+#Time Concern
 init 5 python:
     rules = dict()
     rules.update(MASSelectiveRepeatRule.create_rule(hours =range(0,6)))
     rules.update({"monika wants this first":""})
     addEvent(Event(persistent.greeting_database,eventlabel="greeting_timeconcern",unlocked=False, rules=rules),eventdb=evhand.greeting_database)
     del rules
-    
+
 label greeting_timeconcern:
     jump monika_timeconcern
 
@@ -973,8 +1002,8 @@ init 5 python:
     rules.update(MASSelectiveRepeatRule.create_rule(hours =range(6,24)))
     rules.update({"monika wants this first":""})
     addEvent(Event(persistent.greeting_database,eventlabel="greeting_timeconcern_day",unlocked=False, rules=rules),eventdb=evhand.greeting_database)
-    del rules  
-    
+    del rules
+
 label greeting_timeconcern_day:
     jump monika_timeconcern_day
 
@@ -1027,10 +1056,88 @@ label greeting_hairdown:
 
             m 1h "There we go."
             # you will never get this chance again
-            
+
     # lock this greeting forever.
     $ lockEventLabel("greeting_hairdown", evhand.greeting_database)
     $ persistent._mas_hair_changed = True # menas we have seen this
 
     # monikaroom greeting cleanup can handle this part
     jump monikaroom_greeting_cleanup
+
+# special type greetings
+
+init 5 python:
+    addEvent(
+        Event(
+            persistent.greeting_database,
+            eventlabel="greeting_back_from_school",
+            unlocked=True,
+            category=[store.mas_greetings.TYPE_SCHOOL],
+            random=True
+        ),
+        eventdb=evhand.greeting_database
+    )
+
+label greeting_back_from_school:
+     m 1b "Oh, welcome back [player]!"
+     menu:
+         m "Did you have a good day at school today?"
+         "Yes.":
+             m 1k "Aww, that's nice!"
+             m 1b "I can't help but feel happy when you do..."
+             m "I hope you learned a lot."
+             m 1k "I love you so much, [player]."
+         "No.":
+             m 1g "Oh dear..."
+             m "I'm sorry to hear that."
+             m "Just remember that no matter what happens, no matter what anyone says or does..."
+             m "I'm here for you."
+             m 1e "I love you so, so much."
+     return
+
+init 5 python:
+    addEvent(
+        Event(
+            persistent.greeting_database,
+            eventlabel="greeting_back_from_work",
+            unlocked=True,
+            category=[store.mas_greetings.TYPE_WORK],
+            random=True
+        ),
+        eventdb=evhand.greeting_database
+    )
+
+label greeting_back_from_work:
+     m 1b "Oh, welcome back [player]!"
+     menu:
+         m "Did you have a good day at work today?"
+         "Yes.":
+             m 1k "Aww, that's nice!"
+             m 1b "I can't help but feel happy when you do..."
+             m "I love you so much, [player]."
+             m 1k "Ahaha!"
+         "No.":
+             m 1g "Oh dear..."
+             m "I'm sorry to hear that."
+             m "Just remember that no matter what happens, no matter what anyone says or does..."
+             m "I'm here for you."
+             m 1e "I love you so, so much."
+     return
+
+init 5 python:
+    addEvent(
+        Event(
+            persistent.greeting_database,
+            eventlabel="greeting_back_from_sleep",
+            unlocked=True,
+            category=[store.mas_greetings.TYPE_SLEEP],
+            random=True
+        ),
+        eventdb=evhand.greeting_database
+    )
+
+label greeting_back_from_sleep:
+     m "Oh, hello [player]!"
+     m 1k "I hope you had a good rest!"
+     m "let's spend some time together~"
+     return


### PR DESCRIPTION
This pull request addresses the suggestion on https://github.com/Monika-After-Story/MonikaModDev/issues/1402, which basically let's Monika greet the player accordingly to how exactly them said goodbye to her.

## Technical

These are the changes done to the greeting selection flow:
 - At the beginning of selectGreeting it will check for the value of `persistent._mas_greeting_type` if it is set it will use the value defined there to filter greetings by category using `filterEvents`, otherwise it will just filter by the `unlocked` flag, like it already does.
- Flow is kept the same, so every type can be affected/filtered by the existing greeting/rules system.
- `persistent._mas_greeting_type` will be set by the selected farewell and will be reset to `None` after filtering.
- Three new constants have been added to the `mas_greetings` store: `TYPE_SCHOOL`, `TYPE_WORK` and `TYPE_SLEEP`. These should be used as category names for greetings according to what type of greeting it will be. 

## Additional Notes

 This is an example of how more greetings can be added to an specific type:

```
init 5 python:
    addEvent(
        Event(
            persistent.greeting_database,
            eventlabel="greeting_back_from_sleep",
            unlocked=True,
            category=[store.mas_greetings.TYPE_SLEEP],
            random=True
        ),
        eventdb=evhand.greeting_database
    )

label greeting_back_from_sleep:
     m "Oh, hello [player]!"
     m 1k "I hope you had a good rest!"
     m "let's spend some time together~"
     return
```