### PR TITLE
Changed Algorithm for random topic selection

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -3044,8 +3044,8 @@ default persistent.playerxp = 0
 default persistent.idlexp_total = 0
 default persistent.random_seen = 0
 default seen_random_limit = False
-default persistent._mas_enable_random_repeats = False
-default persistent._mas_monika_repeated_herself = False
+#default persistent._mas_enable_random_repeats = False
+#default persistent._mas_monika_repeated_herself = False
 default persistent._mas_player_bday = None
 
 # rain
@@ -3059,7 +3059,7 @@ default persistent._mas_likes_hairdown = False
 default persistent._mas_hair_changed = False
 
 define mas_checked_update = False
-define mas_monika_repeated = False
+#define mas_monika_repeated = False
 define random_seen_limit = 30
 define times.REST_TIME = 6*3600
 define times.FULL_XP_AWAY_TIME = 24*3600

--- a/Monika After Story/game/dev/zz_dump.rpy
+++ b/Monika After Story/game/dev/zz_dump.rpy
@@ -5,14 +5,14 @@ init 3000 python:
     outtext = (
         "mrt: {0}\nmerr: {1}\nmmrh: {2}\nrs: {3}\n"
     )
-    basedir = config.basedir.replace("\\", "/")
-    with open(basedir + "/dumps.log", "w") as dump_file:
-        dump_file.write(outtext.format(
-            len(monika_random_topics),
-            persistent._mas_enable_random_repeats,
-            persistent._mas_monika_repeated_herself,
-            persistent.random_seen
-        )
-    )
-    del outtext
+#    basedir = config.basedir.replace("\\", "/")
+#    with open(basedir + "/dumps.log", "w") as dump_file:
+#        dump_file.write(outtext.format(
+#            len(monika_random_topics),
+#            persistent._mas_enable_random_repeats,
+#            persistent._mas_monika_repeated_herself,
+#            persistent.random_seen
+#        )
+#    )
+#    del outtext
 

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -527,12 +527,19 @@ init python:
         """
         import datetime
         now = datetime.datetime.now()
+        cleaned_list = list();
         
-        return [
-            ev
-            for ev in ev_list
-            if now - ev.last_seen >= store.evhand.LAST_SEEN_DELTA
-        ]
+        for ev in ev_list:
+            if ev.last_seen is not None:
+                # this topic has been seen before, must check time
+                if now - ev.last_seen >= store.evhand.LAST_SEEN_DELTA:
+                    cleaned_list.append(ev)
+
+            else:
+                # topic never seen before, its clean!
+                cleaned_list.append(ev)
+
+        return cleaned_list
 
 
 # This calls the next event in the list. It returns the name of the

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -513,6 +513,28 @@ init python:
         return cleanlist
 
 
+    def mas_cleanJustSeenEV(ev_list):
+        """
+        Cleans the given event list (of events) of just seen items
+        (within the THRESHOLD). Returns not just seen items.
+        Basically the same as mas_cleanJustSeen, except for Event object lists
+
+        IN:
+            ev_list - list of event objects
+
+        RETURNS:
+            cleaned list of events (stuff not in the tiem THRESHOLD)
+        """
+        import datetime
+        now = datetime.datetime.now()
+        
+        return [
+            ev
+            for ev in ev_list
+            if now - ev.last_seen >= store.evhand.LAST_SEEN_DELTA
+        ]
+
+
 # This calls the next event in the list. It returns the name of the
 # event called or None if the list is empty or the label is invalid
 #

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -970,10 +970,10 @@ screen preferences():
                     textbutton _("Change Renderer") action Function(renpy.call_in_new_context, "mas_gmenu_start")
 
 
-                vbox:
-                    style_prefix "check"
-                    label _("Gameplay")
-                    textbutton _("Repeat Topics") action ToggleField(persistent,"_mas_enable_random_repeats", True, False)
+#                vbox:
+#                    style_prefix "check"
+#                    label _("Gameplay")
+#                    textbutton _("Repeat Topics") action ToggleField(persistent,"_mas_enable_random_repeats", True, False)
 
                 ## Additional vboxes of type "radio_pref" or "check_pref" can be
                 ## added here, to add additional creator-defined preferences.

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -719,55 +719,20 @@ label ch30_loop:
         # Pick a random Monika topic
         if persistent.random_seen < random_seen_limit:
             label pick_random_topic:
-            python:
-                if len(monika_random_topics) > 0:  # still have topics
+                # randomize selection
+                $ chance = renpy.random.randint(1, 100)
 
-                    if mas_monika_repeated:
-                        # monika has reaached the reepated flow
-                        if persistent._mas_enable_random_repeats:
-                            sel_ev = monika_random_topics.pop(0)
+                if chance <= store.mas_topics.UNSEEN:
+                    # unseen topic shoud be selected
+                    jump mas_ch30_select_unseen
 
-                        else:
-                            # otherwise we shouldnt be repeating
-                            monika_random_topics = list()
-                            mas_monika_repeated = False
-                            renpy.jump("post_pick_random_topic")
+                elif chance <= store.mas_topics.SEEN:
+                    # seen topic should be seelcted
+                    jump mas_ch30_select_seen
 
-                    else:
-                        sel_ev = renpy.random.choice(monika_random_topics)
-                        monika_random_topics.remove(sel_ev)
+                # most seen topic should be selected
+                jump mas_ch30_select_mostseen
 
-                    pushEvent(sel_ev)
-                    persistent.random_seen += 1
-
-                elif persistent._mas_enable_random_repeats:
-                    # user wishes for reptitive monika. We will oblige, but
-                    # a somewhat intelligently.
-                    # NOTE: these are ordered using the shown_count property
-                    # NOTE: These start off as list of event objects and then
-                    # sorted differently. WATCH OUT
-                    monika_random_topics = Event.filterEvents(
-                        evhand.event_database,
-                        random=True
-                    ).values()
-                    monika_random_topics.sort(key=Event.getSortShownCount)
-                    monika_random_topics = mas_cleanJustSeen(
-                        [ev.eventlabel for ev in monika_random_topics],
-                        evhand.event_database
-                    )
-                    # NOTE: now the monika random topics are back to being
-                    #   labels. Safe to do normal operation.
-
-                    persistent._mas_monika_repeated_herself = True
-                    mas_monika_repeated = True
-                    sel_ev = monika_random_topics.pop(0)
-                    pushEvent(sel_ev)
-                    persistent.random_seen += 1
-
-                elif not seen_random_limit: # no topics left
-#                    monika_random_topics = list(all_random_topics)
-#                    pushEvent(renpy.random.choice(monika_random_topics))
-                    pushEvent("random_limit_reached")
         elif not seen_random_limit:
             $pushEvent('random_limit_reached')
 
@@ -776,6 +741,40 @@ label post_pick_random_topic:
     $_return = None
 
     jump ch30_loop
+
+# topic selection labels
+label mas_ch30_select_unseen:
+    # unseen selection
+
+    if len(mas_rev_unseen) == 0:
+        jump mas_ch30_select_seen
+
+    $ mas_randomSelectAndPush(mas_rev_unseen)
+
+    jump post_pick_random_topic
+
+
+label mas_ch30_select_seen:
+    # seen selection
+
+    if len(mas_rev_seen) == 0:
+        # rebuild the event lists
+        $ mas_rev_seen, mas_rev_mostseen = mas_buildSeenEventLists()
+
+    $ mas_randomSelectAndPush(mas_rev_seen)
+
+    jump post_pick_random_topic
+
+
+label mas_ch30_select_mostseen:
+    # most seen selection
+    
+    if len(mas_rev_mostseen) == 0:
+        jump mas_ch30_select_seen
+
+    $ mas_randomSelectAndPush(mas_rev_mostseen)
+
+    jump post_pick_random_topic
 
 # adding this label so people get redirected to main
 # this probably occurs when people install the mod right after deleting

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -294,34 +294,35 @@ label random_limit_reached:
         ]
         limit_quip=renpy.random.choice(limit_quips)
     m 1m "[limit_quip]"
-    if len(monika_random_topics)>0 or persistent._mas_enable_random_repeats:
-        m 1f "I'm sure I'll have something to talk about after a little rest."
-    else:
-        if not renpy.seen_label("mas_random_ask"):
-            call mas_random_ask from _mas_random_ask_call
-            if _return:
-                m "Now let me think of something to talk about."
-                return
-        m 1f "Hopefully I'll think of something fun to talk about soon."
+#    if len(mas_rev_unseen)>0 or persistent._mas_enable_random_repeats:
+    m 1f "I'm sure I'll have something to talk about after a little rest."
+#    else:
+#        if not renpy.seen_label("mas_random_ask"):
+#            call mas_random_ask from _mas_random_ask_call
+#            if _return:
+#                m "Now let me think of something to talk about."
+#                return
+#        m 1f "Hopefully I'll think of something fun to talk about soon."
     return
 
-label mas_random_ask:
-    m 1m "...{w} [player],"
-    menu:
-        m "Is it okay with you if I repeat stuff that I've said?"
-        "Yes":
-            m 1a "Great!"
-            m "If you get tired of watching me talk about the same things over and over,{w} just open up the settings and uncheck 'Repeat Topics'."
-            # TODO: this really should be a smug or wink face
-            m "That tells me when {cps=*2}you're bored of me{/cps}{nw}"
-            m "That tells me when {fast}you just want to quietly spend time with me."
-            $ persistent._mas_enable_random_repeats = True
-            return True
-        "No":
-            m 1e "I see."
-            m 1a "If you change your mind, just open up the settings and click 'Repeat Topics'."
-            m "That tells me if you're okay with me repeating anything I've said."
-            return 
+# NOTE: DEPRECATED
+#label mas_random_ask:
+#    m 1m "...{w} [player],"
+#    menu:
+#        m "Is it okay with you if I repeat stuff that I've said?"
+#        "Yes":
+#            m 1a "Great!"
+#            m "If you get tired of watching me talk about the same things over and over,{w} just open up the settings and uncheck 'Repeat Topics'."
+#            # TODO: this really should be a smug or wink face
+#            m "That tells me when {cps=*2}you're bored of me{/cps}{nw}"
+#            m "That tells me when {fast}you just want to quietly spend time with me."
+#            $ persistent._mas_enable_random_repeats = True
+#            return True
+#        "No":
+#            m 1e "I see."
+#            m 1a "If you change your mind, just open up the settings and click 'Repeat Topics'."
+#            m "That tells me if you're okay with me repeating anything I've said."
+#            return 
 
 # TODO think about adding additional dialogue if monika sees that you're running
 # this program often. Basically include a stat to keep track, but atm we don't

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -135,6 +135,9 @@ init -1 python:
             [0] - seen list of events
             [1] - most seen list of events
         """
+        if len(sorted_seen) == 0:
+            return ([], [])
+
         # now calculate the most / top seen counts
         most_count = int(len(sorted_seen) * store.mas_topics.S_MOST_SEEN)
         top_count = store.mas_topics.topSeenEvents(

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -4,10 +4,46 @@
 #or date-dependent event with an appropriate action
 
 define monika_random_topics = []
+define mas_rev_unseen = []
+define mas_rev_seen = []
+define mas_rev_mostseen = []
 define testitem = 0
 define numbers_only = "0123456789"
 define letters_only = "abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 define mas_did_monika_battery = False
+
+init -2 python in mas_topics:
+  
+    # CONSTANTS
+    # most / top weights
+    S_MOST_SEEN = 0.1
+    S_TOP_SEEN = 0.2
+
+    # selection weights (out of 100)
+    UNSEEN = 50
+    SEEN = UNSEEN + 49
+    MOST_SEEN = SEEN + 1
+
+    def topSeenEvents(sorted_ev_list, shown_count):
+        """
+        counts the number of events with a > shown_count than the given
+        shown_count
+
+        IN:
+            sorted_ev_list - an event list sorted by shown_counts
+            shown_count - shown_count to compare to
+
+        RETURNS:
+            number of events with shown_counts that are higher than the given
+            shown_count
+        """
+        index = len(sorted_ev_list) - 1
+        ev_count = 0
+        while index >= 0 and sorted_ev_list[index].shown_count > shown_count:
+            ev_count += 1
+            index -= 1
+
+        return ev_count
 
 # we are going to define removing seen topics as a function,
 # as we need to call it dynamically upon import
@@ -29,6 +65,184 @@ init -1 python:
             if renpy.seen_label(pool[index]):
                 pool.pop(index)
 
+
+    def mas_randomSelectAndRemove(sel_list):
+        """
+        Randomly selects an element from the given list
+        This also removes the element from that list.
+
+        IN:
+            sel_list - list to select from
+
+        RETURNS:
+            selected element
+        """
+        endpoint = len(sel_list) - 1
+        
+        if endpoint < 0:
+            return None
+
+        # otherwise we have at least 1 element
+        return sel_list.pop(renpy.random.randint(0, endpoint))
+
+
+    def mas_randomSelectAndPush(sel_list):
+        """
+        Randomly selects an element from the the given list and pushes the event
+        This also removes the element from that list.
+
+        IN:
+            sel_list - list to select from
+
+        ASSUMES:
+            persistent.random_seen
+        """
+        sel_ev = mas_randomSelectAndRemove(sel_list)
+        if sel_ev:
+            pushEvent(sel_ev.eventlabel)
+            persistent.random_seen += 1
+
+
+    def mas_insertSort(sort_list, item, key):
+        """
+        Performs a round of insertion sort.
+        This does least to greatest sorting
+
+        IN:
+            sort_list - list to insert + sort
+            item - item to sort and insert
+            key - function to call using the given item to retrieve sort key
+
+        OUT:
+            sort_list - list with 1 additonal element, sorted
+        """
+        index = len(sort_list) - 1
+        while index >= 0 and key(sort_list[index]) > key(item):
+            index -= 1
+            
+        sort_list.insert(index + 1, item)
+
+
+    def mas_splitSeenEvents(sorted_seen):
+        """
+        Splits the seen_list into seena nd most seen
+
+        IN:
+            sorted_seen - list of seen events, sorted by shown_count
+
+        RETURNS:
+            tuple of thef ollowing format:
+            [0] - seen list of events
+            [1] - most seen list of events
+        """
+        # now calculate the most / top seen counts
+        most_count = int(len(sorted_seen) * store.mas_topics.S_MOST_SEEN)
+        top_count = store.mas_topics.topSeenEvents(
+            sorted_seen, 
+            int(
+                sorted_seen[len(sorted_seen) - 1].shown_count 
+                * store.mas_topics.S_TOP_SEEN
+            )
+        )
+
+        # now decide how to do the split
+        if most_count < top_count:
+            split_point = most_count * -1
+        else:
+            split_point = top_count * -1
+
+        # and then do the split
+        return (sorted_seen[:split_point], sorted_seen[split_point:])
+
+
+    def mas_splitRandomEvents(events_dict):
+        """
+        Splits the given random events dict into 2 lists of events
+        NOTE: cleans the seen list
+
+        RETURNS:
+            tuple of the following format:
+            [0] - unseen list of events
+            [1] - seen list of events, sorted by shown_count
+
+        """
+        # split these into 2 lists
+        unseen = list()
+        seen = list()
+        for k in events_dict:
+            ev = events_dict[k]
+
+            if renpy.seen_label(k):
+                # seen event
+                mas_insertSort(seen, ev, Event.getSortShownCount)
+
+            else:
+                # unseen event
+                unseen.append(ev)
+
+        # clean the seen_topics list
+        seen = mas_cleanJustSeenEV(seen)
+
+        return (unseen, seen)
+
+
+    def mas_buildEventLists():
+        """
+        Builds the unseen / most seen / seen event lists
+
+        RETURNS:
+            tuple of the following format:
+            [0] - unseen list of events
+            [1] - seen list of events
+            [2] - most seen list of events
+
+        ASSUMES:
+            evhand.event_database
+        """
+        # retrieve all randoms
+        all_random_topics = Event.filterEvents(
+            evhand.event_database,
+            random=True
+        )
+
+        # split randoms into unseen and sorted seen events
+        unseen, sorted_seen = mas_splitRandomEvents(all_random_topics)
+
+        # split seen into regular seen and the most seen events
+        seen, mostseen = mas_splitSeenEvents(sorted_seen)
+
+        return (unseen, seen, mostseen)
+
+
+    def mas_buildSeenEventLists():
+        """
+        Builds the seen / most seen event lists
+
+        RETURNS:
+            tuple of the following format:
+            [0] - seen list of events
+            [1] - most seen list of events
+
+        ASSUMES:
+            evhand.event_database
+        """
+        # retrieve all seen (values list)
+        all_seen_topics = Event.filterEvents(
+            evhand.event_database,
+            random=True,
+            seen=True
+        ).values()
+
+        # clean the seen topics from early repeats
+        cleaned_seen = mas_cleanJustSeenEV(all_seen_topics)
+
+        # sort the seen by shown_count
+        cleaned_seen.sort(key=Event.getSortShownCount)
+
+        # split the seen into regular seen and most seen
+        return mas_splitSeenEvents(cleaned_seen)
+
+
     # EXCEPTION CLass incase of bad labels
     class MASTopicLabelException(Exception):
         def __init__(self, msg):
@@ -37,15 +251,18 @@ init -1 python:
             return "MASTopicLabelException: " + self.msg
 
 init 11 python:
-    #List of all random topics
-    all_random_topics = Event.filterEvents(evhand.event_database,random=True,seen=False).keys()
+
+    # sort out the seen / most seen / unseen
+    mas_rev_unseen, mas_rev_seen, mas_rev_mostseen = mas_buildEventLists()
 
     # for compatiblity purposes:
-    monika_random_topics = all_random_topics
+#    monika_random_topics = all_random_topics
 
-    if len(monika_random_topics) == 0:
+    if len(mas_rev_unseen) == 0:
         # you've seen everything?! here, higher session limit
-        random_seen_limit = 100
+        # NOTE: 1000 is arbitrary. Basically, endless monika topics
+        # I think we'll deal with this better once we hve a sleeping sprite
+        random_seen_limit = 1000
 
     #Remove all previously seen random topics.
        #remove_seen_labels(monika_random_topics)

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -306,7 +306,10 @@ label v0_8_1(version="v0_8_1"):
         new_t = "monika_writingtip1"
         mas_transferTopicSeen(old_t, new_t)
         mas_transferTopic(old_t, new_t, persistent.event_database)
-       
+      
+        ## dropping repeats
+        persistent._mas_enable_random_repeats = None
+        persistent._mas_monika_repeated_herself = None
 
     return
 

--- a/Monika After Story/game/updates_topics.rpy
+++ b/Monika After Story/game/updates_topics.rpy
@@ -96,7 +96,8 @@ label vv_updates_topics:
 
         # 0.8.0 -> 0.8.1
         updates.topics[vv0_8_1] = {
-            "monika_write": "monika_writingtip3"
+            "monika_write": "monika_writingtip3",
+            "mas_random_ask": None
         }
 
         # 0.7.4 -> 0.8.0


### PR DESCRIPTION
#1504 #1365 

This algorithm is probably better than the old one. _probably_

The algorithm runs as follows:
1. On startup, get the list of events that are random and have not been seen recently.
2. Divide that list of events into 3 groups:
    1. Unseen events
    2. The most seen topics
         - Most seen are either the 10% most seen, or the events where `shown_count` is in the top 20%
         - We select the fewer number of events for most seen from the above criteria
    3. The rest
3. When a random topic is ready for selection, we use the following weights for selection:
    1. Unseen - 50%
    2. Most seen - 1%
    3. Seen - 49%
4. When a list is selected, an event is randomly selected from that list and subsequently removed from that list.
5. When a list is empty:
    1. Unseen - jump to seen selection
    2. Most seen - jump to seen selection
    3. Seen - rebuild most seen / seen event lists

As a result of this new algorithm, we are dropping the Repeating Topics option from the settings menu. Instead, Monika will repeat topics by default, but will respect a 2 hour recently said rule and the random seen limit per session.

If you've seen all monika random topics, your random seen limit has been increased to 1000. This number is arbitrary.