### PR TITLE
Piano Curly Brace Fix

### DIFF
--- a/Monika After Story/game/zz_pianokeys.rpy
+++ b/Monika After Story/game/zz_pianokeys.rpy
@@ -360,6 +360,7 @@ init -3 python in mas_piano_keys:
     # noncharable keymaps and display text dict
     NONCHAR_TEXT = {
         pygame.K_LEFTBRACKET: "[[",
+        123: "{{", # { 
         pygame.K_BACKSPACE: "\\b",
         pygame.K_TAB: "\\t",
         pygame.K_CLEAR: "Cr",


### PR DESCRIPTION
#1521 

Left curly braces break Text objects.

Use the broken `persistent` in the linked issue or add a mapping of `chr(123)` to the keymaps dict to trigger a crash. This fixes that crash.