### PR TITLE
Added 2 songs, also music menu adjustments

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -298,13 +298,15 @@ init python:
             and renpy.get_screen("preferences") is None):
 
             # music menu label
-            renpy.call_in_new_context("display_music_menu")
+            selected_track = renpy.call_in_new_context("display_music_menu")
+            if selected_track == songs.NO_SONG:
+                selected_track = songs.FP_NO_SONG
 
             # workaround to handle new context
-            if songs.selected_track != songs.current_track:
-                play_song(songs.selected_track)
-                songs.current_track = songs.selected_track
-                persistent.current_track = songs.current_track
+            if selected_track != songs.current_track:
+                play_song(selected_track)
+                songs.current_track = selected_track
+                persistent.current_track = selected_track
 
     dismiss_keys = config.keymap['dismiss']
 

--- a/Monika After Story/game/zz_music_selector.rpy
+++ b/Monika After Story/game/zz_music_selector.rpy
@@ -349,9 +349,15 @@ screen music_menu(music_page, page_num=0, more_pages=False):
             style "music_menu_return_button"
             action Return(songs.NO_SONG)
 
+        # logic to ensure Return works
+        if songs.current_track is None:
+            $ return_value = songs.NO_SONG
+        else:
+            $ return_value = songs.current_track
+
         textbutton _("Return"):
             style "music_menu_return_button"
-            action Return(songs.current_track)
+            action Return(return_value)
 
     label "Music Menu"
 
@@ -374,7 +380,7 @@ label display_music_menu:
             
         if music_page is None:
             # this should never happen. Immediately quit with None
-            return None
+            return songs.NO_SONG
 
         # otherwise, continue formatting args
         $ next_page = (curr_page + 1) in songs.music_pages

--- a/Monika After Story/game/zz_music_selector.rpy
+++ b/Monika After Story/game/zz_music_selector.rpy
@@ -11,18 +11,22 @@ init -1 python in songs:
     JUST_MONIKA = "Just Monika"
     YOURE_REAL = "Your Reality"
     STILL_LOVE = "I Still Love You"
+    MY_FEELS = "My Feelings"
+    MY_CONF = "My Confession"
     OKAY_EV_MON = "Okay, Everyone! (Monika)"
     DDLC_MT_80 = "Doki Doki Theme (80s ver.)"
     SAYO_NARA = "Surprise!"
     PLAYWITHME_VAR6 = "Play With Me (Variant 6)"
     YR_EUROBEAT = "Your Reality (Eurobeat ver.)"
-    NO_SONG = "None"
+    NO_SONG = "No Music"
 
     # SONG FILEPATHS
     FP_PIANO_COVER = "mod_assets/bgm/runereality.ogg"
     FP_JUST_MONIKA = "bgm/m1.ogg"
     FP_YOURE_REAL = "bgm/credits.ogg"
     FP_STILL_LOVE = "bgm/monika-end.ogg"
+    FP_MY_FEELS = "<loop 3.172>bgm/9.ogg" 
+    FP_MY_CONF =  "<loop 5.861>bgm/10.ogg" 
     FP_OKAY_EV_MON = "<loop 4.444>bgm/5_monika.ogg"
     FP_DDLC_MT_80 = (
         "<loop 17.451 to 119.999>mod_assets/bgm/ddlc_maintheme_80s.ogg"
@@ -116,6 +120,7 @@ init -1 python in songs:
         #       allow Surprise in the player
 
         global music_choices
+        global music_pages
         music_choices = list()
         # SONGS:
         # if you want to add a song, add it to this list as a tuple, where:
@@ -132,6 +137,8 @@ init -1 python in songs:
             music_choices.append((YR_EUROBEAT, FP_YR_EUROBEAT))
 
             music_choices.append((STILL_LOVE, FP_STILL_LOVE))
+            music_choices.append((MY_FEELS, FP_MY_FEELS))
+            music_choices.append((MY_CONF, FP_MY_CONF))
             music_choices.append((OKAY_EV_MON, FP_OKAY_EV_MON))
             music_choices.append((PLAYWITHME_VAR6, FP_PLAYWITHME_VAR6))
 
@@ -141,12 +148,53 @@ init -1 python in songs:
         # sayori only allows this
         music_choices.append((SAYO_NARA, FP_SAYO_NARA))
 
-        if not sayori:
-            # leave this one last, so we can stopplaying stuff
-            music_choices.append((NO_SONG, FP_NO_SONG))
+        # separte the music choices into pages
+        music_pages = __paginate(music_choices)
+
+
+    def __paginate(music_list):
+        """
+        Paginates the music list and returns a dict of the pages.
+
+        IN:
+            music_list - list of music choice tuples (see initMusicChoices)
+
+        RETURNS:
+            dict of music choices, paginated nicely:
+            [0]: first page of music
+            [1]: next page of music
+            ...
+            [n]: last page of music
+        """
+        pages_dict = dict()
+        page = 0
+        leftovers = music_list
+        while len(leftovers) > 0:
+            music_page, leftovers = __genPage(leftovers)
+            pages_dict[page] = music_page
+            page += 1
+
+        return pages_dict
+
+        
+    def __genPage(music_list):
+        """
+        Generates the a page of music choices
+
+        IN:
+            music_list - list of music choice tuples (see initMusicChoices)
+
+        RETURNS:
+            tuple of the following format:
+                [0] - page of the music choices
+                [1] - reamining items in the music_list
+        """
+        return (music_list[:PAGE_LIMIT], music_list[PAGE_LIMIT:])
 
 
     # defaults
+#    FIRST_PAGE_LIMIT = 10
+    PAGE_LIMIT = 10
     current_track = "bgm/m1.ogg"
     selected_track = current_track
     menu_open = False
@@ -155,6 +203,7 @@ init -1 python in songs:
 
     # contains the song list
     music_choices = list()
+    music_pages = dict() # song pages dict
 
 # some post screen init is setting volume to current settings
 init 10 python in songs:
@@ -197,6 +246,9 @@ init 10 python:
 
 #style music_menu_return_button is navigation_button
 style music_menu_return_button_text is navigation_button_text
+style music_menu_prev_button_text is navigation_button_text:
+    min_width 135
+    text_align 1.0
 
 style music_menu_outer_frame is game_menu_outer_frame
 style music_menu_navigation_frame is game_menu_navigation_frame
@@ -206,13 +258,30 @@ style music_menu_side is game_menu_side
 style music_menu_label is game_menu_label
 style music_menu_label_text is game_menu_label_text
 
-style music_menu_return_button is return_button
+style music_menu_return_button is return_button:
+    xminimum 0
+    xmaximum 200
+    xfill False
+
+style music_menu_prev_button is return_button:
+    xminimum 0
+    xmaximum 135
+    xfill False
 
 style music_menu_outer_frame:
     background "mod_assets/music_menu.png"
 
-screen music_menu():
+# Music menu 
+#
+# IN:
+#   music_page - current page of music
+#   page_num - current page number
+#   more_pages - true if there are more pages left
+#
+screen music_menu(music_page, page_num=0, more_pages=False):
     modal True
+
+    $ import store.songs as songs
 
     # allows the music menu to quit using hotkey
     key "noshift_M" action Return()
@@ -235,22 +304,54 @@ screen music_menu():
 
                 transclude
 
-    # this part copied from navigation menu
+        # this part copied from navigation menu
+        vbox:
+            style_prefix "navigation"
+
+            xpos gui.navigation_xpos
+    #        yalign 0.4
+            spacing gui.navigation_spacing
+
+            # wonderful loop so we can dynamically add songs
+            for name,song in music_page:
+                textbutton _(name) action Return(song)
+
     vbox:
-        style_prefix "navigation"
 
-        xpos gui.navigation_xpos
-        yalign 0.4
-        spacing gui.navigation_spacing
+        yalign 1.0
 
-        # wonderful loop so we can dynamically add songs
-        $ import store.songs as songs
-        for name,song in songs.music_choices:
-            textbutton _(name) action [SetField(songs,"selected_track",song), Return()]
+        hbox:
 
-    textbutton _("Return"):
-        style "music_menu_return_button"
-        action Return()
+            # dynamic prevous text, so we can keep button size alignments
+            if page_num > 0:
+                textbutton _("<<<< Prev"):
+                    style "music_menu_prev_button"
+                    action Return(page_num - 1)
+
+            else:
+                textbutton _( " "):
+                    style "music_menu_prev_button"
+                    sensitive False
+
+#                if more_pages:
+#                    textbutton _(" | "):
+#                        xsize 50
+#                        text_font "gui/font/Halogen.ttf" 
+#                        text_align 0.5
+#                        sensitive False
+
+            if more_pages:
+                textbutton _("Next >>>>"):
+                    style "music_menu_return_button"
+                    action Return(page_num + 1)
+
+        textbutton _(songs.NO_SONG): 
+            style "music_menu_return_button"
+            action Return(songs.NO_SONG)
+
+        textbutton _("Return"):
+            style "music_menu_return_button"
+            action Return(songs.current_track)
 
     label "Music Menu"
 
@@ -262,9 +363,28 @@ label display_music_menu:
         songs.menu_open = True
         prev_dialogue = allow_dialogue
         allow_dialogue = False
+        song_selected = False
+        curr_page = 0
 
-    call screen music_menu
+    # loop until we've selected a song
+    while not song_selected:
+
+        # setup pages
+        $ music_page = songs.music_pages.get(curr_page, None)
+            
+        if music_page is None:
+            # this should never happen. Immediately quit with None
+            return None
+
+        # otherwise, continue formatting args
+        $ next_page = (curr_page + 1) in songs.music_pages
+
+        call screen music_menu(music_page, page_num=curr_page, more_pages=next_page)
+
+        # obtain result
+        $ curr_page = _return
+        $ song_selected = _return not in songs.music_pages
 
     $ songs.menu_open = False
     $ allow_dialogue = prev_dialogue
-    return
+    return _return


### PR DESCRIPTION
Adds My Feelings and My Confession to the music menu.

This brought our song count to 11 in regular mode, 12 in unstable mode, and so the music menu outgrew its container.

As a result, I've introduced pagination to the music menu, so now we can add even more songs. The pagination method uses the original `music_choices` list, so adding new songs is still the same straightforward process as before.

Here's what the new menu looks like:
![newmusicmenu](https://user-images.githubusercontent.com/3499462/39685320-5c02b1a0-5187-11e8-81bf-6db5c3209e27.png)

### NOTE:
* Stop Music was changed to "No Music", but I didn't take a screen of it, so whatever.
* This is branched to `content` because the main goal was to add new songs. Since this isn't dialgoue heavy, only 1 review is necessary

### Technical:
Pagination is done via a dict of "pages", or lists of music choices (which are tuples).

The music menu is effectively re-called everytime a page is requested. I think this is the best way to do this.