### PR TITLE
Disable Music 2 topic

### DIFF
--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -4251,8 +4251,8 @@ label monika_daydream:
     m 5a "Let's hope we can make that a reality one of these days, ehehe~"
     return
 
-init 5 python:
-     addEvent(Event(persistent.event_database,eventlabel="monika_music2",category=['misc'],prompt="Current song",random=True))
+# init 5 python:
+#     addEvent(Event(persistent.event_database,eventlabel="monika_music2",category=['misc'],prompt="Current song",random=True))
 
 label monika_music2:
     if songs.getVolume("music") == 0.0:

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -326,6 +326,11 @@ label v0_8_1(version="v0_8_1"):
                 persistent._seen_ever[anni] = True
                 anni_ev.unlocked = True
 
+        ### temporarily disable music2 topic
+        music_ev = Event(persistent.event_database, eventlabel="monika_music2")
+        music_ev.unlocked = False
+        music_ev.random = False
+
     return
 
 # 0.8.0


### PR DESCRIPTION
Because it needs updates for it to be viable. This will disable it upon a version change.