### PR TITLE
Added support for custom sunrise / sunset times

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -1765,6 +1765,38 @@ init -1 python:
 
         return is_file
 
+
+    def mas_cvToHM(mins):
+        """
+        Converts the given minutes into hour / minutes
+
+        IN:
+            mins - number of minutes
+
+        RETURNS:
+            tuple of the following format:
+                [0] - hours
+                [1] - minutes
+        """
+        return (int(mins / 60), int(mins % 60))
+
+
+    def mas_cvToDHM(mins):
+        """
+        Converts the given minutes into a displayable hour / minutes
+        HH:MM
+        NOTE: 24 hour format only
+
+        IN:
+            mins - number of minutes
+
+        RETURNS:
+            string time perfect for displaying
+        """
+        s_hour, s_min = mas_cvToHM(mins)
+        return "{0:0>2d}:{1:0>2d}".format(s_hour, s_min)
+
+
     def get_pos(channel='music'):
         pos = renpy.music.get_pos(channel=channel)
         if pos: return pos
@@ -3057,6 +3089,18 @@ default persistent._mas_monika_clothes = "def"
 default persistent._mas_monika_hair = "def"
 default persistent._mas_likes_hairdown = False
 default persistent._mas_hair_changed = False
+
+# times
+# they are stored in minutes so we can use bar nicely
+default persistent._mas_sunrise = 6 * 60
+default persistent._mas_sunset = 18 * 60
+define mas_max_suntime = (24 * 60) - 1# 24 hours x 60 minutes
+define mas_sunrise_prev = persistent._mas_sunrise
+define mas_sunset_prev = persistent._mas_sunset
+define mas_suntime.NO_CHANGE = 0
+define mas_suntime.RISE_CHANGE = 1
+define mas_suntime.SET_CHANGE = 2
+define mas_suntime.change_state = mas_suntime.NO_CHANGE
 
 define mas_checked_update = False
 #define mas_monika_repeated = False

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -1001,6 +1001,70 @@ screen preferences():
                 style_prefix "slider"
                 box_wrap True
 
+                python:
+                    # sunrise / sunset preprocessing
+                    # figure out which value is changing (if any)
+                    if mas_suntime.change_state == mas_suntime.RISE_CHANGE:
+                        # we are modifying sunrise
+
+                        if persistent._mas_sunrise > persistent._mas_sunset:
+                            # ensure sunset remains >= than sunrise
+                            persistent._mas_sunset = persistent._mas_sunrise
+
+                        if mas_sunrise_prev == persistent._mas_sunrise:
+                            # if no change since previous, then switch state
+                            mas_suntime.change_state = mas_suntime.NO_CHANGE
+
+                        mas_sunrise_prev = persistent._mas_sunrise
+
+                    elif mas_suntime.change_state == mas_suntime.SET_CHANGE:
+                        # we are modifying sunset
+
+                        if persistent._mas_sunset < persistent._mas_sunrise:
+                            # ensure sunrise remains <= than sunset
+                            persistent._mas_sunrise = persistent._mas_sunset
+
+                        if mas_sunset_prev == persistent._mas_sunset:
+                            # if no change since previous, then switch state
+                            mas_suntime.change_state = mas_suntime.NO_CHANGE
+
+                        mas_sunset_prev = persistent._mas_sunset
+                    else:
+                        # decide if we are modifying sunrise or sunset
+
+                        if mas_sunrise_prev != persistent._mas_sunrise:
+                            mas_suntime.change_state = mas_suntime.RISE_CHANGE
+
+                        elif mas_sunset_prev != persistent._mas_sunset:
+                            mas_suntime.change_state = mas_suntime.SET_CHANGE
+
+                        # set previous values
+                        mas_sunrise_prev = persistent._mas_sunrise
+                        mas_sunset_prev = persistent._mas_sunset
+
+                vbox:
+
+                    hbox:
+                        label _("Sunrise   ")
+
+                        # display time
+                        $ sr_display = mas_cvToDHM(persistent._mas_sunrise)
+                        label _("[[ " + sr_display + " ]")
+
+                    bar value FieldValue(persistent, "_mas_sunrise", range=mas_max_suntime, style="slider")
+
+
+                vbox:
+
+                    hbox:
+                        label _("Sunset   ")
+
+                        # display time
+                        $ ss_display = mas_cvToDHM(persistent._mas_sunset)
+                        label _("[[ " + ss_display + " ]")
+
+                    bar value FieldValue(persistent, "_mas_sunset", range=mas_max_suntime, style="slider")
+
                 vbox:
 
                     label _("Text Speed")
@@ -1046,6 +1110,7 @@ screen preferences():
                         textbutton _("Mute All"):
                             action Preference("all mute", "toggle")
                             style "mute_all_button"
+
 
             hbox:
                 textbutton _("Update Version"):

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -338,7 +338,16 @@ init python:
             renpy.display.behavior.clear_keymap_cache()
     morning_flag = None
     def is_morning():
-        return (datetime.datetime.now().time().hour > 6 and datetime.datetime.now().time().hour < 18)
+        # generate the times we need
+        sr_hour, sr_min = mas_cvToHM(persistent._mas_sunrise)
+        ss_hour, ss_min = mas_cvToHM(persistent._mas_sunset)
+        sr_time = datetime.time(sr_hour, sr_min)
+        ss_time = datetime.time(ss_hour, ss_min)
+
+        now_time = datetime.datetime.now().time()
+
+        return sr_time <= now_time < ss_time
+
 
 # IN:
 #   start_bg - the background image we want to start with. Use this for


### PR DESCRIPTION
#1585 #1388 (sorta)

You ask, we listen, usually about a month later.

This adds support for customizable sunrise / sunset times. These are changed in the settings screen.

The sunrise / sunset times are saved in `persistent`. I've also made it so you can't set a sunrise time thats after the current sunset or a sunset time thats before the current sunrise. This also means you cannot do a thing where "night time" is the middle portion of the day. **Night time must always cross midnight**

All times are in 24 hour format. 

### NOTE
* Because of a limitation with how we handle scene changing, the spaceroom will only reflect the new times after a `ch30_loop` call. These means you'd need to open the talk menu or play menu to refresh the spaceroom with new day / night times.