### PR TITLE
Added a Random Chatter Frequency setting

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -3116,6 +3116,90 @@ default guy = "guy"
 default him = "him"
 default himself = "himself"
 
+
+# default is NORMAL
+default persistent._mas_randchat_freq = 1
+define mas_randchat_prev = persistent._mas_randchat_freq
+init 1 python in mas_randchat:
+    ### random chatter frequencies
+
+    # these numbers are the low end of how many seconds to wait between 
+    # random topics
+    NORMAL = 20
+    OFTEN = 4
+    RARE = 36
+    NEVER = 0
+
+    # this is the added to the low end to get the upper end of seconds
+    SPAN = 24
+
+    ## to better work with the sliders, we will create a range from 0 to 3
+    # (inclusive)
+    # these values will be utilized in script-ch30 as well as screens
+    SLIDER_MAP = {
+        0: OFTEN,
+        1: NORMAL,
+        2: RARE,
+        3: NEVER
+    }
+
+    ## slider map for displaying
+    SLIDER_MAP_DISP = {
+        0: "Often",
+        1: "Normal",
+        2: "Less Often",
+        3: "Never"
+    }
+
+    # current frequency times
+    # also default to NORMAL, will get recaluated in reset
+    rand_low = NORMAL
+    rand_high = NORMAL + SPAN
+
+    def adjustRandFreq(slider_value):
+        """
+        Properly adjusts the random limits given the slider value
+
+        IN:
+            slider_value - slider value given from the slider
+                Should be between 0 - 3
+        """
+        slider_setting = SLIDER_MAP.get(slider_value, 1)
+
+        # otherwise set up the times
+        # globalize
+        global rand_low
+        global rand_high
+
+        rand_low = slider_setting
+        rand_high = slider_setting + SPAN
+        renpy.game.persistent._mas_randchat_freq = slider_value
+
+
+    def getRandChatDisp(slider_value):
+        """
+        Retrieves the random chatter display string using the given slider
+        value
+
+        IN:
+            slider_value - slider value given from the slider
+
+        RETURNS:
+            displayable string that reprsents the current random chatter
+            setting
+        """
+        randchat_disp = SLIDER_MAP_DISP.get(slider_value, None)
+
+        if slider_value is None:
+            return "Never"
+
+        return randchat_disp
+
+
+# stores that need to be globally available
+init 4 python:
+    import store.mas_randchat as mas_randchat
+
 return
 
 #Gender specific word replacement

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -970,20 +970,9 @@ screen preferences():
                     textbutton _("Change Renderer") action Function(renpy.call_in_new_context, "mas_gmenu_start")
 
 
-#                vbox:
-#                    style_prefix "check"
-#                    label _("Gameplay")
-#                    textbutton _("Repeat Topics") action ToggleField(persistent,"_mas_enable_random_repeats", True, False)
-
-                ## Additional vboxes of type "radio_pref" or "check_pref" can be
-                ## added here, to add additional creator-defined preferences.
-
-            hbox:
-                box_wrap True
-
                 vbox:
                     style_prefix "check"
-                    label _("Dev")
+                    label _("Gameplay")
                     if persistent._mas_unstable_mode:
                         textbutton _("Unstable"):
                             action SetField(persistent, "_mas_unstable_mode", False)
@@ -994,6 +983,14 @@ screen preferences():
                             action [Show(screen="dialog", message=layout.UNSTABLE, ok_action=Hide(screen="dialog")), SetField(persistent, "_mas_unstable_mode", True)]
                             selected persistent._mas_unstable_mode
 
+#                vbox:
+#                    style_prefix "check"
+#                    label _("Gameplay")
+#                    textbutton _("Repeat Topics") action ToggleField(persistent,"_mas_enable_random_repeats", True, False)
+
+                ## Additional vboxes of type "radio_pref" or "check_pref" can be
+                ## added here, to add additional creator-defined preferences.
+
 
             null height (4 * gui.pref_spacing)
 
@@ -1002,8 +999,23 @@ screen preferences():
                 box_wrap True
 
                 python:
-                    # sunrise / sunset preprocessing
+                    ### random chatter preprocessing
+                    if mas_randchat_prev != persistent._mas_randchat_freq:
+                        # adjust the randoms if it changed
+                        mas_randchat.adjustRandFreq(
+                            persistent._mas_randchat_freq
+                        )
 
+                    # setup the display string
+                    rc_display = mas_randchat.getRandChatDisp(
+                        persistent._mas_randchat_freq
+                    )
+
+                    # setup previous values
+                    mas_randchat_prev = persistent._mas_randchat_freq
+
+
+                    ### sunrise / sunset preprocessing
                     # figure out which value is changing (if any)
                     if mas_suntime.change_state == mas_suntime.RISE_CHANGE:
                         # we are modifying sunrise
@@ -1061,8 +1073,6 @@ screen preferences():
                     bar value FieldValue(mas_suntime, "sunrise", range=mas_max_suntime, style="slider")
 
 
-                vbox:
-
                     hbox:
                         label _("Sunset   ")
 
@@ -1070,6 +1080,19 @@ screen preferences():
                         label _("[[ " + ss_display + " ]")
 
                     bar value FieldValue(mas_suntime, "sunset", range=mas_max_suntime, style="slider")
+
+
+                vbox:
+                    
+                    hbox:
+                        label _("Random Chatter   ")
+
+                        # display str
+                        label _("[[ " + rc_display + " ]")
+
+                    bar value FieldValue(persistent, "_mas_randchat_freq",
+                    range=3, style="slider")
+
 
                 vbox:
 

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -725,7 +725,14 @@ label ch30_loop:
     if not _return:
         # Wait 20 to 45 seconds before saying something new
         window hide(config.window_hide_transition)
-        $ waittime = renpy.random.randint(20, 45)
+
+        if mas_randchat.rand_low == 0:
+            # we are not repeating for now
+            # we'll wait 60 seconds inbetween loops
+            $ renpy.pause(60, hard=True)
+            jump post_pick_random_topic
+
+        $ waittime = renpy.random.randint(mas_randchat.rand_low, mas_randchat.rand_high)
         $ renpy.pause(waittime, hard=True)
         window auto
 
@@ -888,5 +895,8 @@ label ch30_reset:
             monika_chr.acs[MASMonika.PST_ACS].append(
                 store.mas_sprites.ACS_MAP[acs_name]
         )
+
+    ## random chatter frequency reset
+    $ mas_randchat.adjustRandFreq(persistent._mas_randchat_freq)
 
     return


### PR DESCRIPTION
#1504 #479
(#1598)

_Finally getting around to the easy small additions_

This adds a new setting to the setting menu that controls how often Monika's random chatter occurs.
The are 4 settings:
- Often (between 4 - 28 seconds)
- Normal (between 20 - 44 seconds)
- Less Often (between 36 - 60 seconds)
- Never (between inf to inf+1 seconds)

### NOTE:
While this works as a setting, I think we can gain significantly more value in making this some sort of interactive event. We'll look into adding Ask a Question dialogue that can change these settings in a more fun way. But for now, this will suffice.

### Additional
* also moved the unstable setting to Gameplay