### PR TITLE
Updater fixes

### DIFF
--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -1,5 +1,6 @@
 # enabling unstable mode
 default persistent._mas_unstable_mode = False
+default persistent._mas_can_update = True
 define mas_updater.regular = "http://updates.monikaafterstory.com/updates.json"
 define mas_updater.unstable = "http://unstable.monikaafterstory.com/updates.json"
 define mas_updater.force = False
@@ -675,12 +676,16 @@ init python in mas_updater:
                 )
                 can_update = renpy.store.updater.can_update()
 
+                if not can_update:
+                    # still cant move the update folder. notify user
+                    renpy.game.persistent._mas_can_update = False
+
             except:
-                # we cant write to the update folder?
-                # should we notify user?
-                # actually lets just dump some log
-                with open("cannotmoveupdatefolder", "w") as outfile:
-                    outfile.write("do it manually\n")
+                # we cant move the update folder. We should notify user
+                renpy.game.persistent._mas_can_update = False
+
+        else:
+            renpy.game.persistent._mas_can_update = True
 
         if force:
             check_wait = 0
@@ -756,7 +761,17 @@ label update_now:
 
     $ update_link = store.mas_updater.checkUpdate()
 
-    if update_link:
+    if not persistent._mas_can_update:
+        # updates are currently disabled
+        python:
+            no_update_dialog = (
+                "Error: Failed to move 'update/' folder. Please manually " +
+                "move the update folder from 'game/' to the base 'ddlc/' " +
+                "directory and try again."
+            )
+        call screen dialog(message=no_update_dialog, ok_action=Return())
+
+    elif update_link:
 
         # call the updater displayable
         python:
@@ -774,3 +789,4 @@ label update_now:
             # just update the last checked, regardless of issue
             $ persistent._update_last_checked[update_link] = time.time()
     return
+

--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -667,14 +667,20 @@ init python in mas_updater:
         #Make sure the update folder is where it should be
         can_update = renpy.store.updater.can_update()
         if not can_update:
-            try: renpy.file("../update/current.json")
+
+            try:
+                os.rename(
+                    renpy.config.basedir + "/game/update", 
+                    renpy.config.basedir + "/update"
+                )
+                can_update = renpy.store.updater.can_update()
+
             except:
-                try:
-                    os.rename(
-                        renpy.config.basedir + "/game/update", 
-                        renpy.config.basedir + "/update"
-                    )
-                except: pass
+                # we cant write to the update folder?
+                # should we notify user?
+                # actually lets just dump some log
+                with open("cannotmoveupdatefolder", "w") as outfile:
+                    outfile.write("do it manually\n")
 
         if force:
             check_wait = 0


### PR DESCRIPTION
Cleaned up the updater logic so we only attempt to move the updater folder appropriately instead of trying the renpy file check. 

Also made sure to update `can_update` after making the move.

Also added a dialogue message that will show up if the `update/` folder could not be moved to the base `ddlc/` directory. This only happens if "Update Version" is clicked. The background updater will not prompt the user about a failed update folder move.

@aldoram5 when you test this, please make sure to test it on a fully compiled / distributed version in addition to regular testing.