### PR TITLE
Readded Enable/Disable Repeating

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -3045,7 +3045,7 @@ default persistent.playerxp = 0
 default persistent.idlexp_total = 0
 default persistent.random_seen = 0
 default seen_random_limit = False
-#default persistent._mas_enable_random_repeats = False
+default persistent._mas_enable_random_repeats = False
 #default persistent._mas_monika_repeated_herself = False
 default persistent._mas_player_bday = None
 

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -983,10 +983,7 @@ screen preferences():
                             action [Show(screen="dialog", message=layout.UNSTABLE, ok_action=Hide(screen="dialog")), SetField(persistent, "_mas_unstable_mode", True)]
                             selected persistent._mas_unstable_mode
 
-#                vbox:
-#                    style_prefix "check"
-#                    label _("Gameplay")
-#                    textbutton _("Repeat Topics") action ToggleField(persistent,"_mas_enable_random_repeats", True, False)
+                    textbutton _("Repeat Topics") action ToggleField(persistent,"_mas_enable_random_repeats", True, False)
 
                 ## Additional vboxes of type "radio_pref" or "check_pref" can be
                 ## added here, to add additional creator-defined preferences.

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -783,7 +783,11 @@ label mas_ch30_select_unseen:
     if len(mas_rev_unseen) == 0:
         
         if not persistent._mas_enable_random_repeats:
-            # no repeats means we should just stay silent for now
+            # no repeats means we should push randomlimit if appropriate,
+            # otherwise stay slient
+            if not seen_random_limit:
+                $ pushEvent("random_limit_reached")
+
             jump post_pick_random_topic
 
         # otherwise we can go to repeats as usual

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -748,6 +748,11 @@ label ch30_loop:
         # Pick a random Monika topic
         if persistent.random_seen < random_seen_limit:
             label pick_random_topic:
+
+                # check if we have repeats enabled
+                if not persistent._mas_enable_random_repeats:
+                    jump mas_ch30_select_unseen
+
                 # randomize selection
                 $ chance = renpy.random.randint(1, 100)
 
@@ -776,6 +781,12 @@ label mas_ch30_select_unseen:
     # unseen selection
 
     if len(mas_rev_unseen) == 0:
+        
+        if not persistent._mas_enable_random_repeats:
+            # no repeats means we should just stay silent for now
+            jump post_pick_random_topic
+
+        # otherwise we can go to repeats as usual
         jump mas_ch30_select_seen
 
     $ mas_randomSelectAndPush(mas_rev_unseen)

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -294,35 +294,34 @@ label random_limit_reached:
         ]
         limit_quip=renpy.random.choice(limit_quips)
     m 1m "[limit_quip]"
-#    if len(mas_rev_unseen)>0 or persistent._mas_enable_random_repeats:
-    m 1f "I'm sure I'll have something to talk about after a little rest."
-#    else:
-#        if not renpy.seen_label("mas_random_ask"):
-#            call mas_random_ask from _mas_random_ask_call
-#            if _return:
-#                m "Now let me think of something to talk about."
-#                return
-#        m 1f "Hopefully I'll think of something fun to talk about soon."
+    if len(mas_rev_unseen)>0 or persistent._mas_enable_random_repeats:
+        m 1f "I'm sure I'll have something to talk about after a little rest."
+    else:
+        if not renpy.seen_label("mas_random_ask"):
+            call mas_random_ask from _mas_random_ask_call
+            if _return:
+                m "Now let me think of something to talk about."
+                return
+        m 1f "Hopefully I'll think of something fun to talk about soon."
     return
 
-# NOTE: DEPRECATED
-#label mas_random_ask:
-#    m 1m "...{w} [player],"
-#    menu:
-#        m "Is it okay with you if I repeat stuff that I've said?"
-#        "Yes":
-#            m 1a "Great!"
-#            m "If you get tired of watching me talk about the same things over and over,{w} just open up the settings and uncheck 'Repeat Topics'."
-#            # TODO: this really should be a smug or wink face
-#            m "That tells me when {cps=*2}you're bored of me{/cps}{nw}"
-#            m "That tells me when {fast}you just want to quietly spend time with me."
-#            $ persistent._mas_enable_random_repeats = True
-#            return True
-#        "No":
-#            m 1e "I see."
-#            m 1a "If you change your mind, just open up the settings and click 'Repeat Topics'."
-#            m "That tells me if you're okay with me repeating anything I've said."
-#            return 
+label mas_random_ask:
+    m 1m "...{w} [player],"
+    menu:
+        m "Is it okay with you if I repeat stuff that I've said?"
+        "Yes":
+            m 1a "Great!"
+            m "If you get tired of watching me talk about the same things over and over,{w} just open up the settings and uncheck 'Repeat Topics'."
+            # TODO: this really should be a smug or wink face
+            m "That tells me when {cps=*2}you're bored of me{/cps}{nw}"
+            m "That tells me when {fast}you just want to quietly spend time with me."
+            $ persistent._mas_enable_random_repeats = True
+            return True
+        "No":
+            m 1e "I see."
+            m 1a "If you change your mind, just open up the settings and click 'Repeat Topics'."
+            m "That tells me if you're okay with me repeating anything I've said."
+            return 
 
 # TODO think about adding additional dialogue if monika sees that you're running
 # this program often. Basically include a stat to keep track, but atm we don't


### PR DESCRIPTION
Found a good spot (by the cheerleaders eating) to reinsert disabling / enabling repeat topics.

This also re-adds the bit of dialogue that prompts the user for topic repeating.

To clarify, #1624 , controls frequency of random chatter.
This controls whether or not topics are allowed to be repeated.

No dialogue review needed since we are just uncommenting what was already here.