### PR TITLE
Force LOCK db checks

### DIFF
--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -53,6 +53,10 @@ init -500 python:
 #        ):
         # differing lengths mean we have new items to deal with
 
+    # set db defaults
+    if persistent._mas_event_init_lockdb is None:
+        persistent._mas_event_init_lockdb = dict()
+
     for ev_key in persistent._mas_event_init_lockdb:
         stored_lock_row = persistent._mas_event_init_lockdb[ev_key]
 
@@ -66,8 +70,8 @@ init -500 python:
     persistent._mas_event_init_lockdb_template = mas_init_lockdb_template
 
     # set db defaults
-    if persistent._mas_event_init_lockdb is None:
-        persistent._mas_event_init_lockdb = dict()
+#    if persistent._mas_event_init_lockdb is None:
+#        persistent._mas_event_init_lockdb = dict()
 
     # initalizes LOCKDB for the Event class
     Event.INIT_LOCKDB = persistent._mas_event_init_lockdb

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -46,16 +46,17 @@ init -500 python:
     )
 
     # set defaults
-    if (
-            persistent._mas_event_init_lockdb_template is not None
-            and len(persistent._mas_event_init_lockdb_template)
-                != len(mas_init_lockdb_template)
-        ):
+#    if (
+#            persistent._mas_event_init_lockdb_template is not None
+#            and len(persistent._mas_event_init_lockdb_template)
+#                != len(mas_init_lockdb_template)
+#        ):
         # differing lengths mean we have new items to deal with
 
-        for ev_key in persistent._mas_event_init_lockdb:
-            stored_lock_row = persistent._mas_event_init_lockdb[ev_key]
+    for ev_key in persistent._mas_event_init_lockdb:
+        stored_lock_row = persistent._mas_event_init_lockdb[ev_key]
 
+        if len(mas_init_lockdb_template) != len(stored_lock_row):
             # splice and dice
             lock_row = list(mas_init_lockdb_template)
             lock_row[0:len(stored_lock_row)] = list(stored_lock_row)


### PR DESCRIPTION
#1666 

I don't understand why the migrator is failing to update the lockdb entries, but this will fix that issue with a workaround.

Basically just force the lock entry checks at startup always instead of the optimized route.

### Testing
* use a persistent from the linked issue. If you load it in an unpatched game, you will get a crash. If you load it with these changes, no crash.