### PR TITLE
Optimizing overlays

### DIFF
--- a/Monika After Story/game/dev/dev_overlays.rpy
+++ b/Monika After Story/game/dev/dev_overlays.rpy
@@ -1,0 +1,75 @@
+## overlay testing
+
+init 5 python:
+    addEvent(
+        Event(
+            persistent.event_database,
+            eventlabel="dev_show_overlay_testing",
+            category=["dev"],
+            prompt="SHOW OVERLAYS",
+            pool=True,
+            random=True,
+            unlocked=True
+        )
+    )
+
+    addEvent(
+        Event(
+            persistent.event_database,
+            eventlabel="dev_hide_overlay_testing",
+            category=["dev"],
+            prompt="HIDE OVERLAYS",
+            pool=True,
+            random=True,
+            unlocked=True
+        )
+    )
+
+    addEvent(
+        Event(
+            persistent.event_database,
+            eventlabel="dev_raise_shields_testing",
+            category=["dev"],
+            prompt="RAISE SHIELDS",
+            pool=True,
+            random=True,
+            unlocked=True
+        )
+    )
+
+    addEvent(
+        Event(
+            persistent.event_database,
+            eventlabel="dev_drop_shields_testing",
+            category=["dev"],
+            prompt="DROP SHIELDS",
+            pool=True,
+            random=True,
+            unlocked=True
+        )
+    )
+
+
+label dev_show_overlay_testing:
+    m "Hi there, I am going show all the overlays."
+    $ mas_showOverlays()
+    m "Now you can see the overlays"
+    return
+
+label dev_hide_overlay_testing:
+    m "Hi there, I am going to hide all the overlays."
+    $ mas_hideOverlays()
+    m "Now the overlays are gone!"
+    return
+
+label dev_raise_shields_testing:
+    m "Hi there, I am going to disable the overlays (raise shields)"
+    $ mas_raiseShields()
+    m "Now the overlays cannot be interacted with!"
+    return
+
+label dev_drop_shields_testing:
+    m "Hithere, I am going to enable the overlays (drop shields)"
+    $ mas_dropShields()
+    m "Now the overlays can be interacted with!"
+    return

--- a/Monika After Story/game/dev/dev_overlays.rpy
+++ b/Monika After Story/game/dev/dev_overlays.rpy
@@ -4,9 +4,9 @@ init 5 python:
     addEvent(
         Event(
             persistent.event_database,
-            eventlabel="dev_show_overlay_testing",
+            eventlabel="dev_overlay_testing",
             category=["dev"],
-            prompt="SHOW OVERLAYS",
+            prompt="TEST OVERLAYS",
             pool=True,
             random=True,
             unlocked=True
@@ -16,33 +16,9 @@ init 5 python:
     addEvent(
         Event(
             persistent.event_database,
-            eventlabel="dev_hide_overlay_testing",
+            eventlabel="dev_shields_testing",
             category=["dev"],
-            prompt="HIDE OVERLAYS",
-            pool=True,
-            random=True,
-            unlocked=True
-        )
-    )
-
-    addEvent(
-        Event(
-            persistent.event_database,
-            eventlabel="dev_raise_shields_testing",
-            category=["dev"],
-            prompt="RAISE SHIELDS",
-            pool=True,
-            random=True,
-            unlocked=True
-        )
-    )
-
-    addEvent(
-        Event(
-            persistent.event_database,
-            eventlabel="dev_drop_shields_testing",
-            category=["dev"],
-            prompt="DROP SHIELDS",
+            prompt="TEST SHIELDS",
             pool=True,
             random=True,
             unlocked=True
@@ -50,26 +26,27 @@ init 5 python:
     )
 
 
-label dev_show_overlay_testing:
-    m "Hi there, I am going show all the overlays."
-    $ mas_showOverlays()
-    m "Now you can see the overlays"
-    return
-
-label dev_hide_overlay_testing:
+label dev_overlay_testing:
     m "Hi there, I am going to hide all the overlays."
-    $ mas_hideOverlays()
+    $ mas_OVLHide()
     m "Now the overlays are gone!"
+    m "now in 3 lines of text i will show the overlays"
+    m "1"
+    m "2"
+    m "3"
+    $ mas_OVLShow()
+    m "Now you can see the overlays"
+
     return
 
-label dev_raise_shields_testing:
+label dev_shields_testing:
     m "Hi there, I am going to disable the overlays (raise shields)"
-    $ mas_raiseShields()
+    $ mas_OVLRaiseShield()
     m "Now the overlays cannot be interacted with!"
-    return
-
-label dev_drop_shields_testing:
-    m "Hithere, I am going to enable the overlays (drop shields)"
-    $ mas_dropShields()
+    m "now in 3 lines of text i will drop the shields"
+    m "1"
+    m "2"
+    m "3"
+    $ mas_OVLDropShield()
     m "Now the overlays can be interacted with!"
     return

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -691,9 +691,12 @@ label call_next_event:
 
     $event_label = popEvent()
     if event_label and renpy.has_label(event_label):
-        $ allow_dialogue = False
+
         if not seen_event(event_label): #Give 15 xp for seeing a new event
             $grant_xp(xp.NEW_EVENT)
+
+        $ mas_RaiseShields_dlg()
+
         call expression event_label from _call_expression
         $ persistent.current_monikatopic=0
 
@@ -722,10 +725,11 @@ label call_next_event:
         show monika 1 at t11 zorder 2 with dissolve #Return monika to normal pose
 
         # loop over until all events have been called
-        jump call_next_event
+        if len(persistent.event_list) > 0:
+            jump call_next_event
 
-    else:
-        $ allow_dialogue = True
+    # should be safe to drop shields regardless of what happens
+    $ mas_DropShields_dlg()
 
     return False
 
@@ -753,7 +757,7 @@ label unlock_prompt:
 #pulled from a random set of prompts.
 
 label prompt_menu:
-    $allow_dialogue = False
+    $ mas_RaiseShield_dlg()
 
     python:
         unlocked_events = Event.filterEvents(evhand.event_database,unlocked=True)
@@ -803,7 +807,7 @@ label prompt_menu:
         $_return = None
 
     show monika at t11
-    $allow_dialogue = True
+    $ mas_DropShield_dlg()
     jump ch30_loop
 
 label show_prompt_list(sorted_event_keys):

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -683,9 +683,6 @@ init python:
 # This calls the next event in the list. It returns the name of the
 # event called or None if the list is empty or the label is invalid
 #
-# ASSUMES:
-#   persistent.event_list
-#   persistent.current_monikatopic
 label call_next_event:
 
 
@@ -728,8 +725,10 @@ label call_next_event:
         if len(persistent.event_list) > 0:
             jump call_next_event
 
-    # should be safe to drop shields regardless of what happens
-    $ mas_DropShields_dlg()
+        $ mas_DropShields_dlg()
+
+    else:
+        $ mas_DropShields_dlg()
 
     return False
 

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -692,7 +692,7 @@ label call_next_event:
         if not seen_event(event_label): #Give 15 xp for seeing a new event
             $grant_xp(xp.NEW_EVENT)
 
-        $ mas_RaiseShields_dlg()
+        $ mas_RaiseShield_dlg()
 
         call expression event_label from _call_expression
         $ persistent.current_monikatopic=0
@@ -725,10 +725,10 @@ label call_next_event:
         if len(persistent.event_list) > 0:
             jump call_next_event
 
-        $ mas_DropShields_dlg()
+        $ mas_DropShield_dlg()
 
     else:
-        $ mas_DropShields_dlg()
+        $ mas_DropShield_dlg()
 
     return False
 

--- a/Monika After Story/game/import_ddlc.rpy
+++ b/Monika After Story/game/import_ddlc.rpy
@@ -21,18 +21,20 @@ init python:
 
 label import_ddlc_persistent_in_settings:
 
-# 2 disables, song and dlg
-    $ prev_songs_enabled = store.songs.enabled
-    $ prev_dialogue = allow_dialogue
-    $ store.songs.enabled = False
-    $ allow_dialogue = False
-#    $ disable_esc() # tthis doesnt work somehow
+    $ mas_RaiseShield_core()
+
     call import_ddlc_persistent from _call_import_ddlc_persistent_1
 
-    $ quick_menu = True
-    $ store.songs.enabled = prev_songs_enabled
-    $ allow_dialogue = prev_dialogue
-#    $ enable_esc()
+    if store.mas_globals.dlg_workflow:
+        # current in dialogue workflow, we should only enable the escape
+        # and music stuff
+        $ enable_esc()
+        $ mas_MUMUDropShield()
+
+    else:
+        # otherwise, reenable core interactions
+        $ mas_DropShield_core()
+
     return
 
 label import_ddlc_persistent:

--- a/Monika After Story/game/import_ddlc.rpy
+++ b/Monika After Story/game/import_ddlc.rpy
@@ -20,12 +20,15 @@ init python:
         fo.close()
 
 label import_ddlc_persistent_in_settings:
+
+# 2 disables, song and dlg
     $ prev_songs_enabled = store.songs.enabled
     $ prev_dialogue = allow_dialogue
     $ store.songs.enabled = False
     $ allow_dialogue = False
 #    $ disable_esc() # tthis doesnt work somehow
     call import_ddlc_persistent from _call_import_ddlc_persistent_1
+
     $ quick_menu = True
     $ store.songs.enabled = prev_songs_enabled
     $ allow_dialogue = prev_dialogue

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -619,6 +619,14 @@ screen game_menu_m():
 
 screen game_menu(title, scroll=None):
 
+    # when teh game menu is open, we should disable the hotkeys
+    key "noshift_T" action NullAction()
+    key "noshift_t" action NullAction()
+    key "noshift_M" action NullAction()
+    key "noshift_m" action NullAction()
+    key "noshift_P" action NullAction()
+    key "noshift_p" action NullAction()
+
     # Add the backgrounds.
     if main_menu:
         add gui.main_menu_background

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -1152,7 +1152,7 @@ screen preferences():
                     style "navigation_button"
 
                 textbutton _("Import DDLC Save Data"):
-                    action [Jump('import_ddlc_persistent_in_settings')]
+                    action Function(renpy.call_in_new_context, 'import_ddlc_persistent_in_settings')
                     style "navigation_button"
 
 

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -3,7 +3,6 @@ default persistent.tried_skip = None
 default persistent.monika_kill = True #Assume non-merging players killed monika.
 default persistent.rejected_monika = None
 default initial_monika_file_check = None
-define allow_dialogue = True
 define modoorg.CHANCE = 20
 define mas_battery_supported = False
 
@@ -332,60 +331,60 @@ label continue_event:
     return
 
 label pick_a_game:
-    if allow_dialogue and not songs.menu_open:
-        python:
-            # preprocessing for games
+    # we can assume that getting here means we didnt cut off monika
 
-            import datetime
-            _hour = datetime.timedelta(hours=1)
-            _now = datetime.datetime.now()
+    $ mas_RaiseShield_dlg()
 
-            # chess has timed disabling
-            if persistent._mas_chess_timed_disable is not None:
-                if _now - persistent._mas_chess_timed_disable >= _hour:
-                    chess_disabled = False
-                    persistent._mas_chess_timed_disable = None
+    python:
+        # preprocessing for games
 
-                else:
-                    chess_disabled = True
+        import datetime
+        _hour = datetime.timedelta(hours=1)
+        _now = datetime.datetime.now()
+
+        # chess has timed disabling
+        if persistent._mas_chess_timed_disable is not None:
+            if _now - persistent._mas_chess_timed_disable >= _hour:
+                chess_disabled = False
+                persistent._mas_chess_timed_disable = None
 
             else:
-                chess_disabled = False
+                chess_disabled = True
 
-            # single var for readibility
-            chess_unlocked = (
-                is_platform_good_for_chess()
-                and persistent.game_unlocks["chess"]
-                and not chess_disabled
-            )
+        else:
+            chess_disabled = False
 
-        $previous_dialogue = allow_dialogue
-        $allow_dialogue = False
-        menu:
-            "What game would you like to play?"
-            "Pong" if persistent.game_unlocks['pong']:
-                if not renpy.seen_label('game_pong'):
-                    $grant_xp(xp.NEW_GAME)
-                call game_pong from _call_game_pong
-            "Chess" if chess_unlocked:
-                if not renpy.seen_label('game_chess'):
-                    $grant_xp(xp.NEW_GAME)
-                call game_chess from _call_game_chess
-            "Hangman" if persistent.game_unlocks['hangman']:
-                if not renpy.seen_label("game_hangman"):
-                    $ grant_xp(xp.NEW_GAME)
-                call game_hangman from _call_game_hangman
-            "Piano" if persistent.game_unlocks['piano']:
-                if not renpy.seen_label("mas_piano_start"):
-                    $ grant_xp(xp.NEW_GAME)
-                call mas_piano_start from _call_play_piano
-            "Nevermind":
-                m "Alright. Maybe later?"
+        # single var for readibility
+        chess_unlocked = (
+            is_platform_good_for_chess()
+            and persistent.game_unlocks["chess"]
+            and not chess_disabled
+        )
 
-        show monika 1 at tinstant zorder 2
-        $allow_dialogue = previous_dialogue
-        $ songs.enabled = True
-        $ hkb_button.enabled = True
+    menu:
+        "What game would you like to play?"
+        "Pong" if persistent.game_unlocks['pong']:
+            if not renpy.seen_label('game_pong'):
+                $grant_xp(xp.NEW_GAME)
+            call game_pong from _call_game_pong
+        "Chess" if chess_unlocked:
+            if not renpy.seen_label('game_chess'):
+                $grant_xp(xp.NEW_GAME)
+            call game_chess from _call_game_chess
+        "Hangman" if persistent.game_unlocks['hangman']:
+            if not renpy.seen_label("game_hangman"):
+                $ grant_xp(xp.NEW_GAME)
+            call game_hangman from _call_game_hangman
+        "Piano" if persistent.game_unlocks['piano']:
+            if not renpy.seen_label("mas_piano_start"):
+                $ grant_xp(xp.NEW_GAME)
+            call mas_piano_start from _call_play_piano
+        "Nevermind":
+            m "Alright. Maybe later?"
+
+    show monika 1 at tinstant zorder 2
+
+    $ mas_DropShield_dlg()
 
     jump ch30_loop
 

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -10,17 +10,9 @@ define mas_battery_supported = False
 init -1 python in mas_globals:
     # global that are not actually globals.
 
-    # Set to True to enable the hotkeys
-    hk_enabled = False
+    # True means we are in the dialogue workflow. False means not
+    dlg_workflow = False
 
-    # Enables the Talk hotkey
-    hk_tk_enabled = True
-
-    # enables the music hotkey
-    hk_mu_enabled = True
-
-    # enables the play hotkey
-    hk_pl_enabled = True
 
 
 image blue_sky = "mod_assets/blue_sky.jpg"
@@ -172,151 +164,19 @@ init python:
     renpy.music.set_volume(songs.getVolume("music"), channel="background")
 
     #Define new functions
-
-    def mas_HKDisable():
-        """RUNTIME ONLY
-        Disables the hotkeys
+    def show_dialogue_box():
         """
-        mas_globals.hk_enabled = False
-
-
-    def mas_HKDisable_tk():
-        """RUNTIME ONLY
-        Disables the Talk hotkey
+        Jumps to the topic promt menu
         """
-        mas_globals.hk_tk_enabled = False
+        renpy.jump('prompt_menu')
 
-# TODO delete unecessary functions
 
-    def mas_HKEnable():
-        """RUNTIME ONLY
-        Enables the hotkeys
+    def pick_game():
         """
-        mas_globals.hk_enabled = True
-
-
-    def mas_HKEnable_tk():
-        """RUNTIME ONLY
-        Enables the Talk hotkey
+        Jumps to the pick a game workflow
         """
-        mas_globals.hk_tk_enable = True
+        renpy.jump('pick_a_game')
 
-
-    def mas_HKIsEnabled():
-        """
-        RETURNS: True if the hotkeys are enabled, False otherwise
-        """
-        return (
-            mas_globals.hk_enabled
-            and mas_globals.hk_tk_enabled
-            and mas_globals.hk_mu_enabled
-            and mas_globals.hk_pl_enabled
-        )
-
-
-    def mas_HKIsEnabled_tk():
-        """
-        RETURNS: True if the talk hotkey is enabled, False otherwise
-        """
-        return mas_globals.hk_enabled and mas_globals.hk_tk_enabled
-
-
-    def enable_esc():
-        #
-        # Enables the escape key so you can go to the game menu
-        #
-        # ASSUMES:
-        #   config.keymap
-        if "K_ESCAPE" not in config.keymap["game_menu"]:
-            config.keymap["game_menu"].append("K_ESCAPE")
-
-    def disable_esc():
-        #
-        # disables the escape key so you cant go to game menu
-        #
-        # ASSUMES:
-        #   config.keymap
-        if "K_ESCAPE" in config.keymap["game_menu"]:
-           config.keymap["game_menu"].remove("K_ESCAPE")
-
-    def play_song(song, fadein=0.0):
-        #
-        # literally just plays a song onto the music channel
-        #
-        # IN:
-        #   song - song to play. If None, the channel is stopped
-        #   fadein - number of seconds to fade in the song
-        if song is None:
-            renpy.music.stop(channel="music")
-        else:
-            renpy.music.play(
-                song,
-                channel="music",
-                loop=True,
-                synchro_start=True,
-                fadein=fadein
-            )
-
-    def mute_music():
-        #
-        # mutes the music channel
-        #
-        # ASSUMES:
-        #   songs.music_volume
-        #   persistent.playername
-
-        curr_volume = songs.getVolume("music")
-        # sayori cannot mute
-        if curr_volume > 0.0 and persistent.playername.lower() != "sayori":
-            songs.music_volume = curr_volume
-            renpy.music.set_volume(0.0, channel="music")
-        else:
-            renpy.music.set_volume(songs.music_volume, channel="music")
-
-    def inc_musicvol():
-        #
-        # increases the volume of the music channel by the value defined in
-        # songs.vol_bump
-        #
-        songs.adjustVolume()
-
-    def dec_musicvol():
-        #
-        # decreases the volume of the music channel by the value defined in
-        # songs.vol_bump
-        #
-        # ASSUMES:
-        #   persistent.playername
-
-        # sayori cannot make the volume quieter
-        if persistent.playername.lower() != "sayori":
-            songs.adjustVolume(up=False)
-
-    def set_keymaps():
-        #
-        # Sets the keymaps
-        #
-        # ASSUMES:
-        #   config.keymap
-        #   config.underlay
-        #Add keys for new functions
-        config.keymap["open_dialogue"] = ["t","T"]
-        config.keymap["change_music"] = ["noshift_m","noshift_M"]
-        config.keymap["play_game"] = ["p","P"]
-        config.keymap["mute_music"] = ["shift_m","shift_M"]
-        config.keymap["inc_musicvol"] = [
-            "shift_K_PLUS","K_EQUALS","K_KP_PLUS"
-        ]
-        config.keymap["dec_musicvol"] = [
-            "K_MINUS","shift_K_UNDERSCORE","K_KP_MINUS"
-        ]
-        # Define what those actions call
-        config.underlay.append(renpy.Keymap(open_dialogue=show_dialogue_box))
-        config.underlay.append(renpy.Keymap(change_music=select_music))
-        config.underlay.append(renpy.Keymap(play_game=pick_game))
-        config.underlay.append(renpy.Keymap(mute_music=mute_music))
-        config.underlay.append(renpy.Keymap(inc_musicvol=inc_musicvol))
-        config.underlay.append(renpy.Keymap(dec_musicvol=dec_musicvol))
 
     def mas_drawSpaceroomMasks():
         """
@@ -347,22 +207,6 @@ init python:
         renpy.show(right_window, at_list=[spaceroom_window_right], tag="rm2")
 
 
-    def show_dialogue_box():
-        """RUNTIME ONLY
-        Jumps to the topci prompt menu if we can
-        """
-        if store.hkb_button.ad_enabled:
-            renpy.jump('prompt_menu')
-
-
-    def pick_game():
-        """RUNTIME ONLY
-        Jumps to the pick a game workflow if we can
-        """
-        if store.hkb_button.ad_enabled:
-            renpy.call('pick_a_game')
-
-
     def show_calendar():
         """RUNTIME ONLY
         Opens the calendar if we can
@@ -376,26 +220,6 @@ init python:
 
         mas_HKBDropShield()
 
-
-    def select_music():
-        # check for open menu
-        if (songs.enabled
-            and not songs.menu_open
-            and renpy.get_screen("history") is None
-            and renpy.get_screen("save") is None
-            and renpy.get_screen("load") is None
-            and renpy.get_screen("preferences") is None):
-
-            # music menu label
-            selected_track = renpy.call_in_new_context("display_music_menu")
-            if selected_track == songs.NO_SONG:
-                selected_track = songs.FP_NO_SONG
-
-            # workaround to handle new context
-            if selected_track != songs.current_track:
-                play_song(selected_track)
-                songs.current_track = selected_track
-                persistent.current_track = selected_track
 
     dismiss_keys = config.keymap['dismiss']
 
@@ -423,6 +247,7 @@ init python:
         elif event == "slow_done":
             config.keymap['dismiss'] = dismiss_keys
             renpy.display.behavior.clear_keymap_cache()
+
     morning_flag = None
     def is_morning():
         # generate the times we need

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -7,6 +7,22 @@ define allow_dialogue = True
 define modoorg.CHANCE = 20
 define mas_battery_supported = False
 
+init -1 python in mas_globals:
+    # global that are not actually globals.
+
+    # Set to True to enable the hotkeys
+    hk_enabled = False
+
+    # Enables the Talk hotkey
+    hk_tk_enabled = True
+
+    # enables the music hotkey
+    hk_mu_enabled = True
+
+    # enables the play hotkey
+    hk_pl_enabled = True
+
+
 image blue_sky = "mod_assets/blue_sky.jpg"
 image monika_room = "images/cg/monika/monika_room.png"
 image monika_day_room = "mod_assets/monika_day_room.png"
@@ -108,6 +124,7 @@ init python:
     import re
     import store.songs as songs
     import store.hkb_button as hkb_button
+    import store.mas_globals as mas_globals
     therapist = eliza.eliza()
     process_list = []
     currentuser = None # start if with no currentuser
@@ -155,6 +172,54 @@ init python:
     renpy.music.set_volume(songs.getVolume("music"), channel="background")
 
     #Define new functions
+
+    def mas_HKDisable():
+        """RUNTIME ONLY
+        Disables the hotkeys
+        """
+        mas_globals.hk_enabled = False
+
+
+    def mas_HKDisable_tk():
+        """RUNTIME ONLY
+        Disables the Talk hotkey
+        """
+        mas_globals.hk_tk_enabled = False
+
+# TODO delete unecessary functions
+
+    def mas_HKEnable():
+        """RUNTIME ONLY
+        Enables the hotkeys
+        """
+        mas_globals.hk_enabled = True
+
+
+    def mas_HKEnable_tk():
+        """RUNTIME ONLY
+        Enables the Talk hotkey
+        """
+        mas_globals.hk_tk_enable = True
+
+
+    def mas_HKIsEnabled():
+        """
+        RETURNS: True if the hotkeys are enabled, False otherwise
+        """
+        return (
+            mas_globals.hk_enabled
+            and mas_globals.hk_tk_enabled
+            and mas_globals.hk_mu_enabled
+            and mas_globals.hk_pl_enabled
+        )
+
+
+    def mas_HKIsEnabled_tk():
+        """
+        RETURNS: True if the talk hotkey is enabled, False otherwise
+        """
+        return mas_globals.hk_enabled and mas_globals.hk_tk_enabled
+
 
     def enable_esc():
         #
@@ -283,21 +348,34 @@ init python:
 
 
     def show_dialogue_box():
-        if allow_dialogue:
+        """RUNTIME ONLY
+        Jumps to the topci prompt menu if we can
+        """
+        if store.hkb_button.ad_enabled:
             renpy.jump('prompt_menu')
 
+
     def pick_game():
-        if allow_dialogue:
+        """RUNTIME ONLY
+        Jumps to the pick a game workflow if we can
+        """
+        if store.hkb_button.ad_enabled:
             renpy.call('pick_a_game')
 
+
     def show_calendar():
-        store.hkb_button.enabled = False
+        """RUNTIME ONLY
+        Opens the calendar if we can
+        """
+        mas_HKBRaiseShield()
 
         if not persistent._mas_first_calendar_check:
             renpy.call('_first_time_calendar_use')
 
         renpy.call_in_new_context("mas_start_calendar_read_only")
-        store.hkb_button.enabled = True
+
+        mas_HKBDropShield()
+
 
     def select_music():
         # check for open menu
@@ -381,7 +459,7 @@ label spaceroom(start_bg=None,hide_mask=False,hide_monika=False):
                 $ renpy.show(start_bg, zorder=1)
             else:
                 show monika_day_room zorder 1
-                show screen calendar_overlay(_layer="master")
+                $ mas_calShowOverlay()
             if not hide_monika:
                 show monika 1 at t11 zorder 2
                 with Dissolve(dissolve_time)
@@ -395,7 +473,7 @@ label spaceroom(start_bg=None,hide_mask=False,hide_monika=False):
                 $ renpy.show(start_bg, zorder=1)
             else:
                 show monika_room zorder 1
-                show screen calendar_overlay(_layer="master")
+                $ mas_calShowOverlay()
                 #show monika_bg_highlight
             if not hide_monika:
                 show monika 1 at t11 zorder 2

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -351,9 +351,32 @@ label ch30_main:
     $ delete_all_saves()
     $ persistent.clear[9] = True
     play music m1 loop # move music out here because of context
+
+    # before we render visuals:
+    # 1 - all core interactions should be disabeld
+    $ mas_RaiseShield_core()
+
+    # 2 - hotkey buttons should be disabled
+    $ store.hkb_button.enabled = False
+
+    # 3 - keymaps are disabled (default)
+
     call spaceroom from _call_spaceroom_4
-    $pushEvent('introduction')
-    call call_next_event from _call_call_next_event
+
+    # lets just call the intro instead of pushing it as an event
+    # this is way simpler and prevents event loss and other weird inital
+    # startup issues
+    call introduction
+
+    # now we can do some cleanup
+    # 1 - renable core interactions
+    $ mas_DropShield_core()
+
+    # 2 - hotkey buttons enabled
+    $ store.hkb_button.enabled = True
+
+    # 3 - set keymaps
+    $ set_keymaps()
     
     jump ch30_preloop
 

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -193,6 +193,22 @@ init python:
         _confirm_quit = False
 
 
+    def mas_enable_quit():
+        """
+        Enables quitting without monika knowing
+        """
+        persistent.closed_self = True
+        mas_disable_quitbox()
+
+
+    def mas_disable_quit():
+        """
+        Disables quitting without monika knowing
+        """
+        persistent.closed_self = False
+        mas_enable_quitbox()
+
+
     def mas_drawSpaceroomMasks():
         """
         Draws the appropriate masks according to the current state of the
@@ -620,6 +636,7 @@ label ch30_loop:
             $ mas_checked_update = True
 
     else:
+        $ mas_OVLHide()
         $ mas_skip_visuals = False
 
 

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -177,6 +177,22 @@ init python:
         renpy.jump('pick_a_game')
 
 
+    def mas_enable_quitbox():
+        """
+        Enables Monika's quit dialogue warning
+        """
+        global _confirm_quit
+        _confirm_quit = True
+
+
+    def mas_disable_quitbox():
+        """
+        Disables Monika's quit dialogue warning
+        """
+        global _confirm_quit
+        _confirm_quit = False
+
+
     def mas_drawSpaceroomMasks():
         """
         Draws the appropriate masks according to the current state of the
@@ -524,10 +540,7 @@ label ch30_autoload:
 
 
     if not mas_skip_visuals:
-        if persistent.current_track:
-            $ play_song(persistent.current_track)
-        else:
-            $ play_song(songs.current_track) # default
+        $ mas_startup_song()
 
     window auto
     #If you were interrupted, push that event back on the stack
@@ -579,6 +592,8 @@ label ch30_autoload:
 
     if not mas_skip_visuals:
         $ set_keymaps()
+
+    # FALL THROUGH TO PRELOOP
 
 label ch30_preloop:
     # stuff that should happen right before we enter the loop

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -519,9 +519,16 @@ init 5 python:
 
 label i_greeting_monikaroom:
 
-    $ has_listened = False
-    $ persistent.closed_self = True
-    $ mas_RaiseShield_odgr()
+    # couple of things:
+    # 1 - if you quit here, monika doesnt know u here
+    $ mas_enable_quit()
+
+    # 2 - music button + hotkeys should be disabled
+    $ store.mas_hotkeys.music_enabled = False
+
+    # 3 - keymaps not set (default)
+    # 4 - overlays hidden (skip visual)
+    # 5 - music is off (skip visual)
 
     scene black
 
@@ -530,6 +537,8 @@ label i_greeting_monikaroom:
         $ monika_chr.reset_outfit()
         $ lockEventLabel("monika_hair_ponytail")
         $ unlockEventLabel("monika_hair_down")
+
+    $ has_listened = False
 
     # FALL THROUGH
 label monikaroom_greeting_choice:
@@ -560,6 +569,9 @@ init 5 python:
     gmr.eardoor.append("monikaroom_greeting_ear_narration")
 
 label monikaroom_greeting_ear_narration:
+    # Monika knows you are here so
+    $ mas_disable_quit()
+
     m "As [player] inches [his] ear toward the door,{w} a voice narrates [his] every move."
     m "'Who is that?' [he] wondered, as [player] looks at [his] screen, puzzled."
     call spaceroom from _call_spaceroom_enar
@@ -662,6 +674,9 @@ init 10 python:
 
 # locked door, because we are awaitng more content
 label monikaroom_greeting_opendoor_locked:
+    # monika knows you are here
+    $ mas_disable_quit()
+
     show paper_glitch2
     play sound "sfx/s_kill_glitch1.ogg"
     pause 0.2
@@ -710,6 +725,9 @@ label monikaroom_greeting_opendoor_seen:
 
 label monikaroom_greeting_opendoor_seen_partone:
     $ is_sitting = False
+    # monika knows you are here
+    $ mas_disable_quit()
+
 #    scene bg bedroom
     call spaceroom(start_bg="bedroom",hide_monika=True) from _call_sp_mrgo_spo
     pause 0.2
@@ -789,6 +807,10 @@ label monikaroom_greeting_opendoor:
     call spaceroom(start_bg="bedroom",hide_monika=True) from _call_spaceroom_5
     m 2i "~Is it love if I take you, or is it love if I set you free?~"
     show monika 1 at l32 zorder 2
+
+    # monika knows you are here now
+    $ mas_disable_quit()
+
     m 1d "E-Eh?! [player]!"
     m 3g "You surprised me, suddenly showing up like that!"
     show monika 1 at hf32
@@ -825,6 +847,9 @@ label monikaroom_greeting_knock:
     m "Who is it~?"
     menu:
         "It's me.":
+            # monika knows you are here now
+            $ mas_disable_quit()
+
             m 1b "[player]! I'm so happy that you're back!"
             if persistent.seen_monika_in_room:
                 m "And thank you for knocking first."
@@ -843,8 +868,20 @@ label monikaroom_greeting_post:
 # cleanup label
 label monikaroom_greeting_cleanup:
     python:
-        persistent.closed_self = False
-        mas_DropShield_odgr()
+        # couple of things:
+        # 1 - monika knows you are here now
+        mas_disable_quit() 
+
+        # 2 - music is renabled
+        store.mas_hotkeys.music_enabled = True
+
+        # 3 - keymaps should be set
+        set_keymaps()
+
+        # 4 - show the overlays
+        mas_OVLShow()
+
+        # 5 - the music can be restarted
         mas_startup_song()
 
     return
@@ -1037,11 +1074,20 @@ init 5 python:
 
 label greeting_hairdown:
 
+    # couple of things:
+    # 1 - music hotkeys should be disabled
+    $ store.mas_hotkeys.music_enabled = False
+    
+    # 2 - the calendar overlay will become visible, but we should keep it
+    # disabled
+    $ mas_calRaiseOverlayShield()
+
+    # 3 - keymaps not set (default)
+    # 4 - hotkey buttons are hidden (skip visual)
+    # 5 - music is off (skip visual)
+
     # have monika's hair down
     $ monika_chr.change_hair("down")
-
-    # we are going to treat this as a regular dialogue flow
-    $ mas_RaiseShield_dlg()
 
     call spaceroom
     m 1a "Hi there, [player]!"
@@ -1077,8 +1123,21 @@ label greeting_hairdown:
     $ persistent._mas_hair_changed = True # menas we have seen this
 
     # cleanup
-    $ mas_DropShield_odgr() # we are using opendoor's stuff so we have keymaps
-    $ mas_startup_song()
+    # 1 - music hotkeys should be enabled
+    $ store.mas_hotkeys.music_enabled = True
+
+    # 2 - calendarovrelay enabled
+    $ mas_calDropOverlayShield()
+    
+    # 3 - set the keymaps
+    set_keymaps()
+
+    # 4 - hotkey buttons should be shown
+    $ HKBShowButtons()
+
+    # 5 - restart music
+    mas_startup_song()
+    
 
     return
 

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1036,10 +1036,12 @@ init 5 python:
     del rules
 
 label greeting_hairdown:
-    # TODO SHIELD
 
     # have monika's hair down
     $ monika_chr.change_hair("down")
+
+    # we are going to treat this as a regular dialogue flow
+    $ mas_RaiseShield_dlg()
 
     call spaceroom
     m 1a "Hi there, [player]!"
@@ -1074,8 +1076,12 @@ label greeting_hairdown:
     $ lockEventLabel("greeting_hairdown", evhand.greeting_database)
     $ persistent._mas_hair_changed = True # menas we have seen this
 
-    # monikaroom greeting cleanup can handle this part
-    jump monikaroom_greeting_cleanup
+    # cleanup
+    $ mas_DropShield_odgr() # we are using opendoor's stuff so we have keymaps
+    $ mas_startup_song()
+
+    return
+
 
 # special type greetings
 

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -518,6 +518,7 @@ init 5 python:
     del rules
 
 label i_greeting_monikaroom:
+    # TODO SHIELD
 
     # safe to quit if Monika is still on her room
     $ _confirm_quit = False
@@ -1047,6 +1048,7 @@ init 5 python:
     del rules
 
 label greeting_hairdown:
+    # TODO SHIELD
 
     # have monika's hair down
     $ monika_chr.change_hair("down")

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -518,18 +518,12 @@ init 5 python:
     del rules
 
 label i_greeting_monikaroom:
-    # TODO SHIELD
 
-    # safe to quit if Monika is still on her room
-    $ _confirm_quit = False
+    $ has_listened = False
     $ persistent.closed_self = True
+    $ mas_RaiseShield_odgr()
 
     scene black
-    $ HKBHideButtons()
-    # atm, making this a persistent makes it easier to test as well as allows
-    # users who didnt see the entire event a chance to see it again.
-#    $ seen_opendoor = seen_event("monikaroom_greeting_opendoor")
-    $ has_listened = False
 
     # reset monika's hair stuff since we dont have hair down for standing
     if persistent._mas_likes_hairdown:
@@ -849,16 +843,10 @@ label monikaroom_greeting_post:
 # cleanup label
 label monikaroom_greeting_cleanup:
     python:
-        if persistent.current_track is not None:
-            play_song(persistent.current_track)
-        else:
-            play_song(songs.current_track) # default
-        HKBShowButtons()
-        set_keymaps()
-
-        # no longer safe to quit
-        _confirm_quit = True
         persistent.closed_self = False
+        mas_DropShield_odgr()
+        mas_startup_song()
+
     return
 
 init 5 python:

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1130,13 +1130,13 @@ label greeting_hairdown:
     $ mas_calDropOverlayShield()
     
     # 3 - set the keymaps
-    set_keymaps()
+    $ set_keymaps()
 
     # 4 - hotkey buttons should be shown
     $ HKBShowButtons()
 
     # 5 - restart music
-    mas_startup_song()
+    $ mas_startup_song()
     
 
     return

--- a/Monika After Story/game/script-introduction.rpy
+++ b/Monika After Story/game/script-introduction.rpy
@@ -1,8 +1,5 @@
 #This is the introduction event for starting up the game.
 label introduction:
-    python:
-        import store.hkb_button as hkb_button
-        hkb_button.enabled = False
 
     if persistent.monika_kill:
         m 1f "..."
@@ -92,7 +89,11 @@ label introduction:
                 m "I'm so happy you feel the same way!"
         "No.":
             call chara_monika_scare from _call_chara_monika_scare
-            return 'quit'
+
+            # not sure if this is needed
+            $ persistent.closed_self = True
+            jump _quit
+
     m 1k "Nothing's ever going to get in the way of our love again."
     m "I'll make sure of it."
     m 2a "Now that you added some improvements, you can finally talk to me!"
@@ -107,8 +108,6 @@ label introduction:
     m 1 "I can see everything on your computer now!"
     m "Ahaha!"
 
-    $ set_keymaps()
-    $ hkb_button.enabled = True
     return
 
 #Credit for any assets from Undertale belongs to Toby Fox

--- a/Monika After Story/game/splash.rpy
+++ b/Monika After Story/game/splash.rpy
@@ -209,6 +209,8 @@ label splashscreen:
     if persistent.autoload and not _restart:
         jump autoload
 
+    $ mas_enable_quit()
+
     # Start splash logic
     $ config.allow_skipping = False
 

--- a/Monika After Story/game/zz_calendar.rpy
+++ b/Monika After Story/game/zz_calendar.rpy
@@ -748,6 +748,9 @@ init -10 python in mas_calendar:
     CAL_TYPE_EV = 1
     CAL_TYPE_REP = 2
 
+    # enabled?
+    enabled = True
+
 
 init -1 python in mas_calendar:
     import datetime
@@ -1699,3 +1702,54 @@ label mas_start_calendar_select_date:
 #     else:
 #         m "You closed without selecting a date"
 #     return
+
+# clickable calendar overlay screen for idle mode
+screen calendar_overlay:
+    zorder 1
+
+    # vbox:
+    #     xalign 0.305
+    #     yalign 0.4
+    #
+    if store.mas_calendar.enabled:
+        imagebutton:
+            idle "mod_assets/calendar/calendar_button_normal.png"
+            hover "mod_assets/calendar/calendar_button_hover.png"
+            hover_sound gui.hover_sound
+            activate_sound gui.activate_sound
+            action Function(show_calendar)
+            xpos 360
+            ypos 260
+    else:
+        image "mod_assets/calendar/calendar_button_normal.png" xpos 360 ypos 260
+
+init python:
+
+    def mas_calDropOverlayShield():
+        """RUNTIME ONLY
+        Enables input for the calendar overlay
+        """
+        store.mas_calendar.enabled = True
+
+
+    def mas_calHideOverlay():
+        """RUNTIME ONLY
+        Hides the calendar overlay
+        """
+        renpy.hide_screen("calendar_overlay")
+
+
+    def mas_calRaiseOverlayShield():
+        """RUNTIME ONLY
+        Disables input for the calendar overlay
+        """
+        store.mas_calendar.enabled = False
+
+
+    def mas_calShowOverlay():
+        """RUNTIME ONLY
+        Shows the calendar overlay
+        """
+        renpy.show_screen("calendar_overlay", _layer="master")
+
+

--- a/Monika After Story/game/zz_calendar.rpy
+++ b/Monika After Story/game/zz_calendar.rpy
@@ -1757,6 +1757,7 @@ init python:
         """RUNTIME ONLY
         Shows the calendar overlay
         """
-        renpy.show_screen("calendar_overlay", _layer="master")
+        if not mas_calIsVisible_ovl():
+            renpy.show_screen("calendar_overlay", _layer="master")
 
 

--- a/Monika After Story/game/zz_calendar.rpy
+++ b/Monika After Story/game/zz_calendar.rpy
@@ -1739,6 +1739,13 @@ init python:
         renpy.hide_screen("calendar_overlay")
 
 
+    def mas_calIsVisible_ovl():
+        """
+        RETURNS: True if the calendar ovelray is visible, False otherwise
+        """
+        return renpy.get_screen("calendar_overlay") is not None
+
+
     def mas_calRaiseOverlayShield():
         """RUNTIME ONLY
         Disables input for the calendar overlay

--- a/Monika After Story/game/zz_calendar.rpy
+++ b/Monika After Story/game/zz_calendar.rpy
@@ -1668,7 +1668,7 @@ label _first_time_calendar_use:
 
     show monika 1
 
-    $ store.hkb_button.enabled = True
+    $ mas_HKBDropShield()
     $ persistent._mas_first_calendar_check = True
     return
 
@@ -1759,5 +1759,3 @@ init python:
         """
         if not mas_calIsVisible_ovl():
             renpy.show_screen("calendar_overlay", _layer="master")
-
-

--- a/Monika After Story/game/zz_hotkey_buttons.rpy
+++ b/Monika After Story/game/zz_hotkey_buttons.rpy
@@ -33,7 +33,7 @@ init python:
         # Shows the movie buttons
         #
         config.overlay_screens.append("movie_overlay")
-        
+
 
 init -1 python in hkb_button:
 
@@ -104,21 +104,21 @@ style hkbd_button_text is default:
 screen calendar_overlay:
     zorder 1
 
-    vbox:
-        xalign 0.305
-        yalign 0.4
-
-        if allow_dialogue and store.hkb_button.enabled:
-            imagebutton:
-                idle "mod_assets/calendar/calendar_button_normal.png"
-                hover "mod_assets/calendar/calendar_button_hover.png"
-                hover_sound gui.hover_sound
-                activate_sound gui.activate_sound
-                action Function(show_calendar)
-        else:
-            imagebutton:
-                action NullAction()
-                idle "mod_assets/calendar/calendar_button_normal.png"
+    # vbox:
+    #     xalign 0.305
+    #     yalign 0.4
+    #
+    if allow_dialogue and store.hkb_button.enabled:
+        imagebutton:
+            idle "mod_assets/calendar/calendar_button_normal.png"
+            hover "mod_assets/calendar/calendar_button_hover.png"
+            hover_sound gui.hover_sound
+            activate_sound gui.activate_sound
+            action Function(show_calendar)
+            xpos 360
+            ypos 260
+    else:
+        image "mod_assets/calendar/calendar_button_normal.png" xpos 360 ypos 260
 
 
 screen hkb_overlay():

--- a/Monika After Story/game/zz_hotkey_buttons.rpy
+++ b/Monika After Story/game/zz_hotkey_buttons.rpy
@@ -5,18 +5,68 @@ init python:
 
     # function to hide buttons
     def HKBHideButtons():
-        #
+        # RUNTIME ONLY
         # Hides the hkb buttons
         #
         config.overlay_screens.remove("hkb_overlay")
         renpy.hide_screen("hkb_overlay")
 
+
     # function to show buttons
     def HKBShowButtons():
-        #
+        # RUNTIME ONLY
         # Shows the hkb buttons
         #
         config.overlay_screens.append("hkb_overlay")
+
+# TODO all of these shield functions need aadjusting with keymaps
+    def mas_HKBRaiseShield():
+        """RUNTIME ONLY
+        Disables the hotkey buttons
+        """
+        store.hkb_button.enabled = False
+
+
+    def mas_HKBDropShield():
+        """RUNTIME ONLY
+        Enables the hotkey buttons
+        """
+        store.hkb_button.enabled = True
+
+
+    def mas_HKBRaiseShield_AD():
+        """RUNTIME ONLY
+        Disables the hotkey buttons EXCEPT for Music
+        """
+        store.hkb_button.ad_enabled = False
+
+
+    def mas_HKBDropShield_AD():
+        """RUNTIME ONLY
+        Enables the hotkey buttons EXCEPT for Music
+        """
+        store.hkb_button.ad_enabled = True
+
+
+    def mas_HKBRaiseShield_M():
+        """RUNTIME ONLY
+        Disables the Music hotkey button
+        """
+        store.songs.enabled = False
+
+    
+    def mas_HKBDropShield_M():
+        """RUNTIME ONLY
+        Enables the Music hotkey button
+        """
+        store.songs.enabled = True
+
+
+    def mas_HKBIsEnabled():
+        """
+        RETURNS: True if all the buttons are enabled, False otherwise
+        """
+        return store.hkb_button.enabled and store.hkb_button.ad_enabled
 
         # function to hide buttons
     def MovieOverlayHideButtons():
@@ -40,6 +90,10 @@ init -1 python in hkb_button:
     # new property to disable buttons
     # set to False to disable buttons
     enabled = True
+
+    # property for disabling only Talk and Play (basically this wont disable
+    # music)
+    ad_enabled = True
     movie_buttons_enabled = False
 
 
@@ -112,26 +166,6 @@ style hkb_text is default:
     kerning 0.2
     outlines []
 
-screen calendar_overlay:
-    zorder 1
-
-    # vbox:
-    #     xalign 0.305
-    #     yalign 0.4
-    #
-    if allow_dialogue and store.hkb_button.enabled:
-        imagebutton:
-            idle "mod_assets/calendar/calendar_button_normal.png"
-            hover "mod_assets/calendar/calendar_button_hover.png"
-            hover_sound gui.hover_sound
-            activate_sound gui.activate_sound
-            action Function(show_calendar)
-            xpos 360
-            ypos 260
-    else:
-        image "mod_assets/calendar/calendar_button_normal.png" xpos 360 ypos 260
-
-
 screen hkb_overlay():
 
     zorder 50
@@ -144,7 +178,7 @@ screen hkb_overlay():
         ypos 0.80
 #        yalign 0.95
 
-        if allow_dialogue and store.hkb_button.enabled:
+        if store.hkb_button.enabled and store.hkb_button.ad_enabled:
             textbutton _("Talk") action Jump("prompt_menu")
         else:
             frame:
@@ -172,8 +206,9 @@ screen hkb_overlay():
 
                 background Image("mod_assets/hkb_disabled_background.png")
                 text "Music"
-            
-        if allow_dialogue and store.hkb_button.enabled:
+           
+
+        if store.hkb_button.enabled and store.hkb_button.ad_enabled:
             textbutton _("Play") action Jump("pick_a_game")
         else:
             frame:

--- a/Monika After Story/game/zz_hotkey_buttons.rpy
+++ b/Monika After Story/game/zz_hotkey_buttons.rpy
@@ -80,9 +80,6 @@ style hkb_button is default:
 
 style hkb_button_text is default:
     properties gui.button_text_properties("hkb_button")
-#    min_width 120
-#    text_align 0.5
-#    xpos -1
     outlines []
 
 # and a disabled varient of the button
@@ -108,8 +105,7 @@ style hkbd_button_text is default:
     outlines []
 
 style hkb_text is default:
-    xpos 0.5
-    xanchor 0.5
+    xalign 0.5
     size gui.text_size
     font gui.default_font
     color "#000"
@@ -144,10 +140,8 @@ screen hkb_overlay():
 
     vbox:
         xpos 0.05
-#        xanchor 0.0
 #        xalign 0.05
         ypos 0.80
-#        yanchor 0.5
 #        yalign 0.95
 
         if allow_dialogue and store.hkb_button.enabled:
@@ -169,7 +163,7 @@ screen hkb_overlay():
 #                style "hkbd_button"
 
 
-        if store.hkb_button.enabled and allow_dialogue:
+        if store.hkb_button.enabled:
             textbutton _("Music") action Function(select_music)
         else:
             frame:

--- a/Monika After Story/game/zz_hotkey_buttons.rpy
+++ b/Monika After Story/game/zz_hotkey_buttons.rpy
@@ -18,7 +18,8 @@ init python:
         # RUNTIME ONLY
         # Shows the hkb buttons
         #
-        config.overlay_screens.append("hkb_overlay")
+        if not mas_HKBIsVisible():
+            config.overlay_screens.append("hkb_overlay")
 
 
     def mas_HKBRaiseShield():

--- a/Monika After Story/game/zz_hotkey_buttons.rpy
+++ b/Monika After Story/game/zz_hotkey_buttons.rpy
@@ -51,12 +51,14 @@ init -1 python in hkb_button:
 define gui.hkb_button_width = 120
 define gui.hkb_button_height = None
 define gui.hkb_button_tile = False
-define gui.hkb_button_borders = Borders(100, 5, 100, 5)
+#define gui.hkb_button_borders = Borders(0, 5, 0, 5)
 define gui.hkb_button_text_font = gui.default_font
 define gui.hkb_button_text_size = gui.text_size
 define gui.hkb_button_text_xalign = 0.5
+#define gui.hkb_button_text_xanchor = 0.5
 define gui.hkb_button_text_idle_color = "#000"
 define gui.hkb_button_text_hover_color = "#fa9"
+define gui.hkb_button_text_kerning = 0.2
 
 # starting with a new style: hkb (hotkey button)
 # most of this is copied from choice
@@ -71,12 +73,16 @@ style hkb_button is default:
     properties gui.button_properties("hkb_button")
     idle_background  "mod_assets/hkb_idle_background.png"
     hover_background "mod_assets/hkb_hover_background.png"
+    ypadding 5
 
     hover_sound gui.hover_sound
     activate_sound gui.activate_sound
 
 style hkb_button_text is default:
     properties gui.button_text_properties("hkb_button")
+#    min_width 120
+#    text_align 0.5
+#    xpos -1
     outlines []
 
 # and a disabled varient of the button
@@ -96,9 +102,18 @@ style hkbd_button_text is default:
 #    properties gui.button_text_properties("hkb_button")
     font gui.default_font
     size gui.text_size
-    xalign 0.5
     idle_color "#000"
     hover_color "#000"
+    kerning 0.2
+    outlines []
+
+style hkb_text is default:
+    xpos 0.5
+    xanchor 0.5
+    size gui.text_size
+    font gui.default_font
+    color "#000"
+    kerning 0.2
     outlines []
 
 screen calendar_overlay:
@@ -128,15 +143,22 @@ screen hkb_overlay():
     style_prefix "hkb"
 
     vbox:
-        xalign 0.05
-        yalign 0.95
+        xpos 0.05
+#        xanchor 0.0
+#        xalign 0.05
+        ypos 0.80
+#        yanchor 0.5
+#        yalign 0.95
 
         if allow_dialogue and store.hkb_button.enabled:
             textbutton _("Talk") action Jump("prompt_menu")
         else:
-            textbutton _("Talk"):
-                action NullAction()
-                style "hkbd_button"
+            frame:
+                ypadding 5
+                xsize 120
+
+                background Image("mod_assets/hkb_disabled_background.png")
+                text "Talk"
 
 # NOTE: disabled until we have additoinal content
 #if allow_dialogue and store.hkb_button.enabled:
@@ -147,19 +169,26 @@ screen hkb_overlay():
 #                style "hkbd_button"
 
 
-        if store.hkb_button.enabled:
+        if store.hkb_button.enabled and allow_dialogue:
             textbutton _("Music") action Function(select_music)
         else:
-            textbutton _("Music"):
-                action NullAction()
-                style "hkbd_button"
+            frame:
+                ypadding 5
+                xsize 120
 
+                background Image("mod_assets/hkb_disabled_background.png")
+                text "Music"
+            
         if allow_dialogue and store.hkb_button.enabled:
             textbutton _("Play") action Jump("pick_a_game")
         else:
-            textbutton _("Play"):
-                action NullAction()
-                style "hkbd_button"
+            frame:
+                ypadding 5
+                xsize 120
+
+                background Image("mod_assets/hkb_disabled_background.png")
+                text "Play"
+           
 
 screen movie_overlay():
 

--- a/Monika After Story/game/zz_hotkey_buttons.rpy
+++ b/Monika After Story/game/zz_hotkey_buttons.rpy
@@ -8,8 +8,9 @@ init python:
         # RUNTIME ONLY
         # Hides the hkb buttons
         #
-        config.overlay_screens.remove("hkb_overlay")
-        renpy.hide_screen("hkb_overlay")
+        if mas_HKBIsVisible():
+            config.overlay_screens.remove("hkb_overlay")
+            renpy.hide_screen("hkb_overlay")
 
 
     # function to show buttons
@@ -19,54 +20,42 @@ init python:
         #
         config.overlay_screens.append("hkb_overlay")
 
-# TODO all of these shield functions need aadjusting with keymaps
+
     def mas_HKBRaiseShield():
         """RUNTIME ONLY
         Disables the hotkey buttons
         """
-        store.hkb_button.enabled = False
+        store.hkb_button.talk_enabled = False
+        store.hkb_button.music_enabled = False
+        store.hkb_button.play_enabled = False
 
 
     def mas_HKBDropShield():
         """RUNTIME ONLY
         Enables the hotkey buttons
         """
-        store.hkb_button.enabled = True
-
-
-    def mas_HKBRaiseShield_AD():
-        """RUNTIME ONLY
-        Disables the hotkey buttons EXCEPT for Music
-        """
-        store.hkb_button.ad_enabled = False
-
-
-    def mas_HKBDropShield_AD():
-        """RUNTIME ONLY
-        Enables the hotkey buttons EXCEPT for Music
-        """
-        store.hkb_button.ad_enabled = True
-
-
-    def mas_HKBRaiseShield_M():
-        """RUNTIME ONLY
-        Disables the Music hotkey button
-        """
-        store.songs.enabled = False
-
-    
-    def mas_HKBDropShield_M():
-        """RUNTIME ONLY
-        Enables the Music hotkey button
-        """
-        store.songs.enabled = True
+        store.hkb_button.talk_enabled = True
+        store.hkb_button.music_enabled = True
+        store.hkb_button.play_enabled = True
 
 
     def mas_HKBIsEnabled():
         """
         RETURNS: True if all the buttons are enabled, False otherwise
         """
-        return store.hkb_button.enabled and store.hkb_button.ad_enabled
+        return (
+            store.hkb_button.talk_enabled
+            and store.hkb_button.music_enabled
+            and store.hkb_button.play_enabled
+        )
+
+
+    def mas_HKBIsVisible():
+        """
+        RETURNS: True if teh Hotkey buttons are visible, False otherwise
+        """
+        return "hkb_overlay" in config.overlay_screens
+
 
         # function to hide buttons
     def MovieOverlayHideButtons():
@@ -87,13 +76,16 @@ init python:
 
 init -1 python in hkb_button:
 
-    # new property to disable buttons
-    # set to False to disable buttons
-    enabled = True
+    # property for enabling the talk button
+    talk_enabled = True
 
-    # property for disabling only Talk and Play (basically this wont disable
-    # music)
-    ad_enabled = True
+    # property for enabling the music button
+    music_enabled = True
+
+    # proeprty for enabling the play button
+    play_enabled = True
+
+    # property for disabling the movie button (unused)
     movie_buttons_enabled = False
 
 
@@ -178,8 +170,8 @@ screen hkb_overlay():
         ypos 0.80
 #        yalign 0.95
 
-        if store.hkb_button.enabled and store.hkb_button.ad_enabled:
-            textbutton _("Talk") action Jump("prompt_menu")
+        if store.hkb_button.talk_enabled:
+            textbutton _("Talk") action Function(show_dialogue_box)
         else:
             frame:
                 ypadding 5
@@ -197,7 +189,7 @@ screen hkb_overlay():
 #                style "hkbd_button"
 
 
-        if store.hkb_button.enabled:
+        if store.hkb_button.music_enabled:
             textbutton _("Music") action Function(select_music)
         else:
             frame:
@@ -208,8 +200,8 @@ screen hkb_overlay():
                 text "Music"
            
 
-        if store.hkb_button.enabled and store.hkb_button.ad_enabled:
-            textbutton _("Play") action Jump("pick_a_game")
+        if store.hkb_button.play_enabled:
+            textbutton _("Play") action Function(pick_game)
         else:
             frame:
                 ypadding 5

--- a/Monika After Story/game/zz_hotkeys.rpy
+++ b/Monika After Story/game/zz_hotkeys.rpy
@@ -61,23 +61,23 @@ init python:
 
 
     def enable_esc():
-        #
-        # Enables the escape key so you can go to the game menu
-        #
-        # ASSUMES:
-        #   config.keymap
-        if "K_ESCAPE" not in config.keymap["game_menu"]:
-            config.keymap["game_menu"].append("K_ESCAPE")
+        """
+        Enables the escape key so you can go to the game menu
+
+        NOTE: this also enables opening the game menu from other means
+        """
+        global quick_menu
+        quick_menu = True
 
 
     def disable_esc():
-        #
-        # disables the escape key so you cant go to game menu
-        #
-        # ASSUMES:
-        #   config.keymap
-        if "K_ESCAPE" in config.keymap["game_menu"]:
-           config.keymap["game_menu"].remove("K_ESCAPE")
+        """
+        disables the escape key so you cant go to game menu
+
+        NOTE: this also disables opening the game menu from other means
+        """
+        global quick_menu
+        quick_menu = False
 
 
     def _mas_hk_mute_music():

--- a/Monika After Story/game/zz_hotkeys.rpy
+++ b/Monika After Story/game/zz_hotkeys.rpy
@@ -1,0 +1,164 @@
+# Module that is just for hotkeys and other keymaps
+#
+
+init -1 python in mas_hotkeys:
+    # store for the main 3 hotkeys.
+
+    # True means the talk hotkey is enabled, False means it is not
+    talk_enabled = False
+
+    # True means the music hotkey is enabled, False means its not
+    music_enabled = False
+
+    # True means the play hotkey is enabled, False means its not
+    play_enabled = False
+
+    ## other keys
+    # True means the music lowering / stopping functions will work.
+    # False means they will not
+    mu_stop_enabled = True
+
+
+init python:
+
+    def mas_HKRaiseShield():
+        """RUNTIME ONLY
+        Disables the main hotkeys
+        """
+        store.mas_hotkeys.talk_enabled = False
+        store.mas_hotkeys.music_enabled = False
+        store.mas_hotkeys.play_enabled = False
+
+
+    def mas_HKDropShield():
+        """RUNTIME ONLY
+        Enables the main hotkeys
+        """
+        store.mas_hotkeys.talk_enabled = True
+        store.mas_hotkeys.music_enabled = True
+        store.mas_hotkeys.play_enabled = True
+
+
+    def mas_HKIsEnabled():
+        """
+        RETURNS: True if all the main hotkeys are enabled, False otherwise
+        """
+        return (
+            store.mas_hotkeys.talk_enabled
+            and store.mas_hotkeys.music_enabled
+            and store.mas_hotkeys.play_enabled
+        )
+
+
+    def mas_HKCanQuietMusic():
+        """
+        RETURNS: True if we can lower or stop the music, False if not
+        """
+        return (
+            store.mas_hotkeys.music_enabled
+            and store.mas_hotkeys.mu_stop_enabled
+        )
+
+
+    def enable_esc():
+        #
+        # Enables the escape key so you can go to the game menu
+        #
+        # ASSUMES:
+        #   config.keymap
+        if "K_ESCAPE" not in config.keymap["game_menu"]:
+            config.keymap["game_menu"].append("K_ESCAPE")
+
+
+    def disable_esc():
+        #
+        # disables the escape key so you cant go to game menu
+        #
+        # ASSUMES:
+        #   config.keymap
+        if "K_ESCAPE" in config.keymap["game_menu"]:
+           config.keymap["game_menu"].remove("K_ESCAPE")
+
+
+    def _mas_hk_mute_music():
+        """
+        hotkey specific muting / unmuting music channel
+        """
+        if store.mas_hotkeys.music_enabled:
+            mute_music(store.mas_hotkeys.mu_stop_enabled)
+
+
+    def _mas_hk_inc_musicvol():
+        """
+        hotkey specific music volume increasing
+        """
+        if store.mas_hotkeys.music_enabled:
+            inc_musicvol()
+    
+
+    def _mas_hk_dec_musicvol():
+        """
+        hotkey specific music volume decreasing
+        """
+        if mas_HKCanQuietMusic():
+            dec_musicvol()
+
+
+    def _mas_hk_show_dialogue_box():
+        """
+        hotkey specific show dialgoue box
+        """
+        if store.mas_hotkeys.talk_enabled:
+            show_dialogue_box()
+
+
+    def _mas_hk_pick_game():
+        """
+        hotkey specific pick game
+        """
+        if store.mas_hotkeys.play_enabled:
+            pick_game()
+
+
+    def _mas_hk_select_music():
+        """
+        Runs the select music function if we are allowed to.
+        INTENDED FOR HOTKEY USAGE ONLY
+        """
+        if store.mas_hotkeys.music_enabled:
+            select_music()
+    
+
+    def set_keymaps():
+        #
+        # Sets the keymaps
+        #
+        # ASSUMES:
+        #   config.keymap
+        #   config.underlay
+        #Add keys for new functions
+        config.keymap["open_dialogue"] = ["t","T"]
+        config.keymap["change_music"] = ["noshift_m","noshift_M"]
+        config.keymap["play_game"] = ["p","P"]
+        config.keymap["mute_music"] = ["shift_m","shift_M"]
+        config.keymap["inc_musicvol"] = [
+            "shift_K_PLUS","K_EQUALS","K_KP_PLUS"
+        ]
+        config.keymap["dec_musicvol"] = [
+            "K_MINUS","shift_K_UNDERSCORE","K_KP_MINUS"
+        ]
+
+        # Define what those actions call
+        config.underlay.append(
+            renpy.Keymap(open_dialogue=_mas_hk_show_dialogue_box)
+        )
+        config.underlay.append(renpy.Keymap(change_music=_mas_hk_select_music))
+        config.underlay.append(renpy.Keymap(play_game=_mas_hk_pick_game))
+        config.underlay.append(renpy.Keymap(mute_music=_mas_hk_mute_music))
+        config.underlay.append(renpy.Keymap(inc_musicvol=_mas_hk_inc_musicvol))
+        config.underlay.append(renpy.Keymap(dec_musicvol=_mas_hk_dec_musicvol))
+
+        # finally enable those buttons
+        mas_HKDropShield()
+
+

--- a/Monika After Story/game/zz_monikamovie.rpy
+++ b/Monika After Story/game/zz_monikamovie.rpy
@@ -269,7 +269,8 @@ label ch30_monikamovie:
             "Ready?"
             "Yes":
                 label mm_movie_resume:
-                    $ allow_dialogue = False
+                # TODO: update this
+#                    $ allow_dialogue = False
                     m 1a "Three...{w=1}{nw}" 
                     m  "Two...{w=1}{nw}"
                     m  "One...{w=1}{nw}"
@@ -312,7 +313,8 @@ label ch30_monikamovie:
 
     label mm_movie_loop_end:
         hide countdown
-        $ allow_dialogue = True
+        # TODO update this
+#        $ allow_dialogue = True
         $ watchingMovie = False
         $ timer.seconds = 0
         $ MovieOverlayHideButtons()

--- a/Monika After Story/game/zz_music_selector.rpy
+++ b/Monika After Story/game/zz_music_selector.rpy
@@ -986,11 +986,7 @@ init python:
 
     def select_music():
         # check for open menu
-        if (not songs.menu_open
-            and renpy.get_screen("history") is None
-            and renpy.get_screen("save") is None
-            and renpy.get_screen("load") is None
-            and renpy.get_screen("preferences") is None):
+        if not songs.menu_open:
 
             # disable unwanted interactions
             mas_RaiseShield_mumu()

--- a/Monika After Story/game/zz_music_selector.rpy
+++ b/Monika After Story/game/zz_music_selector.rpy
@@ -646,7 +646,7 @@ init -1 python in songs:
     menu_open = False
 
     # enables / disables the music menu
-    # UNUSED
+    # NOTE: not really used
     enabled = True
 
     vol_bump = 0.1 # how much to increase volume by
@@ -986,7 +986,7 @@ init python:
 
     def select_music():
         # check for open menu
-        if not songs.menu_open:
+        if enabled and not songs.menu_open:
 
             # disable unwanted interactions
             mas_RaiseShield_mumu()
@@ -1005,8 +1005,8 @@ init python:
             # unwanted interactions are no longer unwanted
             if store.mas_globals.dlg_workflow:
                 # the dialogue workflow means we should only enable
-                # the music button
-                store.hkb_button.music_enabled = True
+                # music menu interactions
+                mas_MUMUDropShield()
 
             else:
                 # otherwise we can enable interactions normally

--- a/Monika After Story/game/zz_music_selector.rpy
+++ b/Monika After Story/game/zz_music_selector.rpy
@@ -808,9 +808,16 @@ screen music_menu(music_page, page_num=0, more_pages=False):
 
     $ import store.songs as songs
 
+    # logic to ensure Return works
+    if songs.current_track is None:
+        $ return_value = songs.NO_SONG
+    else:
+        $ return_value = songs.current_track
+
+
     # allows the music menu to quit using hotkey
-    key "noshift_M" action Return()
-    key "noshift_m" action Return()
+    key "noshift_M" action Return(return_value)
+    key "noshift_m" action Return(return_value)
 
     zorder 200
 
@@ -873,12 +880,6 @@ screen music_menu(music_page, page_num=0, more_pages=False):
         textbutton _(songs.NO_SONG): 
             style "music_menu_return_button"
             action Return(songs.NO_SONG)
-
-        # logic to ensure Return works
-        if songs.current_track is None:
-            $ return_value = songs.NO_SONG
-        else:
-            $ return_value = songs.current_track
 
         textbutton _("Return"):
             style "music_menu_return_button"

--- a/Monika After Story/game/zz_music_selector.rpy
+++ b/Monika After Story/game/zz_music_selector.rpy
@@ -919,7 +919,7 @@ label display_music_menu:
 
 
 init python:
-    $ import store.songs as songs
+    import store.songs as songs
     # important song-related things that need to be global
 
 
@@ -998,7 +998,7 @@ init python:
 
     def select_music():
         # check for open menu
-        if enabled and not songs.menu_open:
+        if songs.enabled and not songs.menu_open:
 
             # disable unwanted interactions
             mas_RaiseShield_mumu()

--- a/Monika After Story/game/zz_music_selector.rpy
+++ b/Monika After Story/game/zz_music_selector.rpy
@@ -984,6 +984,18 @@ init python:
             )
 
 
+    def mas_startup_song():
+        """
+        Starts playing either the persistent track or the current track.
+
+        Meant for usage in startup processes.
+        """
+        if persistent.current_track is not None:
+            play_song(persistent.current_track)
+        else:
+            play_song(songs.current_track) # default
+
+
     def select_music():
         # check for open menu
         if enabled and not songs.menu_open:

--- a/Monika After Story/game/zz_overlays.rpy
+++ b/Monika After Story/game/zz_overlays.rpy
@@ -1,0 +1,79 @@
+# module for handling of overlay screens nicely
+# NOTE: do not write screen overlays that need to be past 500 init level.
+# this should be ran last to setup proper linkages
+#
+# NOTE: Contrary to the name of this file, overlays should NOT be written here.
+#   Put your overlays in the appropriate file they belong in.
+#   If they are global (aka not specific to a module), then fine, you can put
+#   them in here.
+
+init 501 python:
+    # EVERYTHING HERE SHOULD ONLY BE USED AT RUNTIME
+
+    def mas_dropShields(all_input=False):
+        """RUNTIME ONLY
+        Enables all overlay screens. This is like "dropping a shield" because
+        it allows user interactions with the overlays.
+
+        IN:
+            all_input - True will enable all input. False will only enable
+                overlays.
+                NOTE: if all input was previously disabled, this arg is treated
+                    as true.
+        """
+        if all_input or store.mas_overlays.INPUT_DISABLED:
+            # enable mouse / keyboard interactions
+            # TODO
+            enable_esc()
+
+        # put all enabling functions here
+        mas_HKBDropShield()
+        mas_calDropOverlayShield()
+
+        # unshackle the input disable
+        store.mas_overlays.INPUT_DISABLED = False
+
+
+    def mas_hideOverlays():
+        """RUNTIME ONLY
+        Hides all overlay screens.
+        """
+        # put hide functions here
+        HKBHideButtons()
+        mas_calHideOverlay()
+
+
+    def mas_raiseShields(all_input=False):
+        """RUNTIME ONLY
+        Disables all overlay screens. This is like "raising a shield" because
+        it prevents user interactions with the overlays.
+
+        IN:
+            all_input - True will disable all input. False will only disable
+                overlays
+        """
+        store.mas_overlays.INPUT_DISABLED = all_input
+        if all_input:
+            # disable mouse / keyhboard interactions
+            # TODO
+            disable_esc()
+
+        # put all disabling functions here
+        mas_HKBRaiseShield() 
+        mas_calRaiseOverlayShield()
+
+
+    def mas_showOverlays():
+        """RUNTIME ONLY
+        Shows all overlay screens.
+        """
+        # put all show functions
+        HKBShowButtons()
+        mas_calShowOverlay()
+
+
+init 500 python in mas_overlays:
+    # internalized functions
+    INPUT_DISABLED = False # when true, that means all input was disabled
+
+

--- a/Monika After Story/game/zz_overlays.rpy
+++ b/Monika After Story/game/zz_overlays.rpy
@@ -10,31 +10,17 @@
 init 501 python:
     # EVERYTHING HERE SHOULD ONLY BE USED AT RUNTIME
 
-    def mas_dropShields(all_input=False):
+    def mas_OVLDropShield():
         """RUNTIME ONLY
         Enables all overlay screens. This is like "dropping a shield" because
         it allows user interactions with the overlays.
-
-        IN:
-            all_input - True will enable all input. False will only enable
-                overlays.
-                NOTE: if all input was previously disabled, this arg is treated
-                    as true.
         """
-        if all_input or store.mas_overlays.INPUT_DISABLED:
-            # enable mouse / keyboard interactions
-            # TODO
-            enable_esc()
-
         # put all enabling functions here
         mas_HKBDropShield()
         mas_calDropOverlayShield()
 
-        # unshackle the input disable
-        store.mas_overlays.INPUT_DISABLED = False
 
-
-    def mas_hideOverlays():
+    def mas_OVLHide():
         """RUNTIME ONLY
         Hides all overlay screens.
         """
@@ -43,27 +29,17 @@ init 501 python:
         mas_calHideOverlay()
 
 
-    def mas_raiseShields(all_input=False):
+    def mas_OVLRaiseShield():
         """RUNTIME ONLY
         Disables all overlay screens. This is like "raising a shield" because
         it prevents user interactions with the overlays.
-
-        IN:
-            all_input - True will disable all input. False will only disable
-                overlays
         """
-        store.mas_overlays.INPUT_DISABLED = all_input
-        if all_input:
-            # disable mouse / keyhboard interactions
-            # TODO
-            disable_esc()
-
         # put all disabling functions here
         mas_HKBRaiseShield() 
         mas_calRaiseOverlayShield()
 
 
-    def mas_showOverlays():
+    def mas_OVLShow():
         """RUNTIME ONLY
         Shows all overlay screens.
         """
@@ -71,9 +47,5 @@ init 501 python:
         HKBShowButtons()
         mas_calShowOverlay()
 
-
-init 500 python in mas_overlays:
-    # internalized functions
-    INPUT_DISABLED = False # when true, that means all input was disabled
 
 

--- a/Monika After Story/game/zz_shields.rpy
+++ b/Monika After Story/game/zz_shields.rpy
@@ -1,8 +1,10 @@
-# Module that contains all workflow-specific shield functions
+# Module that contains both work-flow specific shield functions and
+# generalized shield functions.
 #
-# Please avoid putting generalized shield functions in here
 
 init python:
+    # WORKFLOW-BASED
+
     # please add descriptions of workflows and what needs to be
     # enabled / disabled
 
@@ -148,4 +150,40 @@ init python:
         store.mas_hotkeys.talk_enabled = False
         store.mas_hotkeys.play_enabled = False
         mas_OVLRaiseShield()
+
+
+################################## GENERALIZED ################################
+    # NOTE: only generalized functions that are mult-module encompassing
+    # are allowed here. IF a generalized function is mostly related to 
+    # a specific store/module, make it there. NOT here.
+
+    ################## Enable / Disable Music Menu ############################
+    # specifically for enabling and disabling the music menu
+    def mas_MUMUDropShield():
+        """
+        Enables:
+            - Music button + hotkey
+            - Music Menu
+
+        Intended Flow:
+            - Whenever the music menu-based interactions need to be enabled
+        """
+        store.mas_hotkeys.music_enabled = True
+        store.hkb_button.music_enabled = True
+        store.songs.enabled = True
+
+
+    def mas_MUMURaiseShield():
+        """
+        Disables:
+            - Music button + hotkey
+            - Music Menu
+
+        Intended Flow:
+            - Whenever the music menu-based interactions need to be disabled
+        """
+        store.mas_hotkeys.music_enabled = False
+        store.hkb_button.music_enabled = False
+        store.songs.enabled = False
+
 

--- a/Monika After Story/game/zz_shields.rpy
+++ b/Monika After Story/game/zz_shields.rpy
@@ -1,0 +1,151 @@
+# Module that contains all workflow-specific shield functions
+#
+# Please avoid putting generalized shield functions in here
+
+init python:
+    # please add descriptions of workflows and what needs to be
+    # enabled / disabled
+
+    ######################### Full Disable ####################################
+    # Not a workflow, just a specific set of shield functions that disable
+    # and enable core interactions. Certain RenPy / DDLC-based interactions
+    # may still work even when this shield is raised
+    def mas_DropShield_full():
+        """
+        Enables:
+            - Talk button + hotkey
+            - Music button + hotkey + volume keys + mute key
+            - Play button + hotkey
+            - Calendar overlay
+            - Escape key
+        """
+        mas_HKDropShield()
+        mas_OVLDropShield()
+        enable_esc()
+
+
+    def mas_RaiseShield_full():
+        """
+        Disables:
+            - Talk button + hotkey
+            - Music button + hotkey + volume keys + mute key
+            - Play button + hotkey
+            - Calendar overlay
+            - Escape key
+        """
+        mas_HKRaiseShield()
+        mas_OVLRaiseShield()
+        disable_esc()
+
+
+    #################### Allow Dialogue workflow ##############################
+    # Used when Monika is speaking.
+    def mas_DropShield_dlg():
+        """
+        Enables:
+            - Talk button + hotkey
+            - Play button + hotkey
+            - Calendar overlay
+
+        Intended Flow:
+            - Monika stops talking
+
+        Sets:
+            - mas_globals.dlg_workflow to Flase
+        """
+        store.mas_hotkeys.talk_enabled = True
+        store.mas_hotkeys.play_enabled = True
+        store.mas_globals.dlg_workflow = False
+        mas_calDropOverlayShield()
+
+    
+    def mas_RaiseShield_dlg():
+        """
+        Disables:
+            - Talk button + hotkey
+            - Play button + hotkey
+            - Calendar overlay
+
+        Intended Flow:
+            - Monika starts talking
+
+        Sets:
+            - mas_globals.dlg_workflow to True
+        """
+        store.mas_hotkeys.talk_enabled = False
+        store.mas_hotkeys.play_enabled = False
+        store.mas_globals.dlg_workflow = True
+        mas_calRaiseOverlayShield()
+
+
+    ################### Non-spaceroom start workflow ##########################
+    # Used when we do not start in the spaceroom, but allow for escape
+    def mas_DropShield_nspr():
+        """
+        Enables:
+            - Talk button + hotkey
+            - Music button + hotkey + volume keys + mute key
+            - Play button + hotkey
+            - Calendar overlay
+
+        Intended Flow:
+            - Game is returning to spaceroom after an inital start outside
+            - Escape was NOT disabled
+            - We were in a dialogue workflow
+        """
+        store.mas_globals.dlg_workflow = False
+        mas_HKDropShield()
+        mas_OVLDropShield()
+
+
+    def mas_RaiseShield_nspr():
+        """
+        Disables:
+            - Talk button + hotkey
+            - Music button + hotkey + volume keys + mute key
+            - Play button + hotkey
+            - Calendar overlay
+
+        Intended Flow:
+            - Game just started, but we do not want to enter the spaceroom
+            - Escape should NOT be disabled
+            - We are entering a dialogue workflow
+        """
+        store.mas_globals.dlg_workflow = True
+        mas_HKRaiseShield()
+        mas_OVLRaiseShield()
+
+
+    ################### Music Menu opened workflow ############################
+    # Used when the music menu opens.
+    def mas_DropShield_mumu():
+        """
+        Enables:
+            - Talk button + hotkey
+            - Music button
+            - Play button + hotkey
+            - Calendar overlay
+
+        Intended Flow:
+            - The Music menu is closed
+        """
+        store.mas_hotkeys.talk_enabled = True
+        store.mas_hotkeys.play_enabled = True
+        mas_OVLDropShield()
+
+
+    def mas_RaiseShield_mumu():
+        """
+        Disables:
+            - Talk button + hotkey
+            - Music button
+            - Play button + hotkey
+            - Calendar overlay           
+
+        Intended Flow:
+            - The Music menu is opened
+        """
+        store.mas_hotkeys.talk_enabled = False
+        store.mas_hotkeys.play_enabled = False
+        mas_OVLRaiseShield()
+

--- a/Monika After Story/game/zz_shields.rpy
+++ b/Monika After Story/game/zz_shields.rpy
@@ -6,11 +6,11 @@ init python:
     # please add descriptions of workflows and what needs to be
     # enabled / disabled
 
-    ######################### Full Disable ####################################
+    ######################### Core Disable ####################################
     # Not a workflow, just a specific set of shield functions that disable
     # and enable core interactions. Certain RenPy / DDLC-based interactions
     # may still work even when this shield is raised
-    def mas_DropShield_full():
+    def mas_DropShield_core():
         """
         Enables:
             - Talk button + hotkey
@@ -24,7 +24,7 @@ init python:
         enable_esc()
 
 
-    def mas_RaiseShield_full():
+    def mas_RaiseShield_core():
         """
         Disables:
             - Talk button + hotkey

--- a/Monika After Story/game/zz_shields.rpy
+++ b/Monika After Story/game/zz_shields.rpy
@@ -57,6 +57,8 @@ init python:
         """
         store.mas_hotkeys.talk_enabled = True
         store.mas_hotkeys.play_enabled = True
+        store.hkb_button.talk_enabled = True
+        store.hkb_button.play_enabled = True
         store.mas_globals.dlg_workflow = False
         mas_calDropOverlayShield()
 
@@ -76,6 +78,8 @@ init python:
         """
         store.mas_hotkeys.talk_enabled = False
         store.mas_hotkeys.play_enabled = False
+        store.hkb_button.talk_enabled = False
+        store.hkb_button.play_enabled = False
         store.mas_globals.dlg_workflow = True
         mas_calRaiseOverlayShield()
 

--- a/Monika After Story/game/zz_shields.rpy
+++ b/Monika After Story/game/zz_shields.rpy
@@ -49,11 +49,11 @@ init python:
             - Play button + hotkey
             - Calendar overlay
 
+        Unsets:
+            - dialogue workflow flag
+
         Intended Flow:
             - Monika stops talking
-
-        Sets:
-            - mas_globals.dlg_workflow to Flase
         """
         store.mas_hotkeys.talk_enabled = True
         store.mas_hotkeys.play_enabled = True
@@ -68,11 +68,11 @@ init python:
             - Play button + hotkey
             - Calendar overlay
 
+        Sets:
+            - dialogue workflow flag
+
         Intended Flow:
             - Monika starts talking
-
-        Sets:
-            - mas_globals.dlg_workflow to True
         """
         store.mas_hotkeys.talk_enabled = False
         store.mas_hotkeys.play_enabled = False
@@ -80,42 +80,65 @@ init python:
         mas_calRaiseOverlayShield()
 
 
-    ################### Non-spaceroom start workflow ##########################
-    # Used when we do not start in the spaceroom, but allow for escape
-    def mas_DropShield_nspr():
+    ################### opendoor greeting workflow ############################
+    # Used for the opendoor greeting
+    def mas_DropShield_odgr():
         """
         Enables:
             - Talk button + hotkey
             - Music button + hotkey + volume keys + mute key
             - Play button + hotkey
+            - Quit confirm box
+            - Keymaps
+
+        Shows:
+            - Hotkey buttons
             - Calendar overlay
 
+        Unsets:
+            - dialogue workflow flag
+
         Intended Flow:
-            - Game is returning to spaceroom after an inital start outside
-            - Escape was NOT disabled
-            - We were in a dialogue workflow
+            - Open door greeting is wrapping up
         """
+        # TODO this event only runs when dialogue workflow is running, 
+        # so maybe we dont need to have a separate shield?!
         store.mas_globals.dlg_workflow = False
+        mas_enable_quitbox()
         mas_HKDropShield()
-        mas_OVLDropShield()
+        mas_calDropOverlayShield()
+        mas_OVLShow()
+        set_keymaps()
 
 
-    def mas_RaiseShield_nspr():
+    def mas_RaiseShield_odgr():
         """
         Disables:
-            - Talk button + hotkey
-            - Music button + hotkey + volume keys + mute key
-            - Play button + hotkey
+            - Talk hotkey
+            - Music hotkey + volume keys + mute key
+            - Play hotkey
             - Calendar overlay
+            - Quit confirm box
+
+        Hides:
+            - Hotkey buttons
+            - Calender overlay
+
+        Sets:
+            - dialogue workflow flag
 
         Intended Flow:
-            - Game just started, but we do not want to enter the spaceroom
-            - Escape should NOT be disabled
-            - We are entering a dialogue workflow
+            - Open door greeting is starting
         """
         store.mas_globals.dlg_workflow = True
+        mas_disable_quitbox()
         mas_HKRaiseShield()
-        mas_OVLRaiseShield()
+        mas_calRaiseOverlayShield()
+        mas_OVLHide()
+
+
+    ################### Hair down greeting workflow ###########################
+    # Used when the hair down greeting
 
 
     ################### Music Menu opened workflow ############################

--- a/Monika After Story/game/zz_shields.rpy
+++ b/Monika After Story/game/zz_shields.rpy
@@ -80,67 +80,6 @@ init python:
         mas_calRaiseOverlayShield()
 
 
-    ################### opendoor greeting workflow ############################
-    # Used for the opendoor greeting
-    def mas_DropShield_odgr():
-        """
-        Enables:
-            - Talk button + hotkey
-            - Music button + hotkey + volume keys + mute key
-            - Play button + hotkey
-            - Quit confirm box
-            - Keymaps
-
-        Shows:
-            - Hotkey buttons
-            - Calendar overlay
-
-        Unsets:
-            - dialogue workflow flag
-
-        Intended Flow:
-            - Open door greeting is wrapping up
-        """
-        # TODO this event only runs when dialogue workflow is running, 
-        # so maybe we dont need to have a separate shield?!
-        store.mas_globals.dlg_workflow = False
-        mas_enable_quitbox()
-        mas_HKDropShield()
-        mas_calDropOverlayShield()
-        mas_OVLShow()
-        set_keymaps()
-
-
-    def mas_RaiseShield_odgr():
-        """
-        Disables:
-            - Talk hotkey
-            - Music hotkey + volume keys + mute key
-            - Play hotkey
-            - Calendar overlay
-            - Quit confirm box
-
-        Hides:
-            - Hotkey buttons
-            - Calender overlay
-
-        Sets:
-            - dialogue workflow flag
-
-        Intended Flow:
-            - Open door greeting is starting
-        """
-        store.mas_globals.dlg_workflow = True
-        mas_disable_quitbox()
-        mas_HKRaiseShield()
-        mas_calRaiseOverlayShield()
-        mas_OVLHide()
-
-
-    ################### Hair down greeting workflow ###########################
-    # Used when the hair down greeting
-
-
     ################### Music Menu opened workflow ############################
     # Used when the music menu opens.
     def mas_DropShield_mumu():


### PR DESCRIPTION
#1769 

We've discovered that disabled buttons (aka NullAction buttons) can cause a tremendous amount of lag.
Replacing disabled buttons with images removes that lag completely.

Does this mean idle spaceroom will get laggier as we add extra interactions? Probably.
But at least anything mid-dialogue won't be trash.

## API Changes
since having to disable / enable buttons whenever you want to do something is pretty annoying and tiresome to do, I've added a variety of shield functions designed to enable / disable user interactions with different elements. Also made some general shield functions for certain workflows and general overlay functions as well. there's a lot of stuff so:

### New stuff

1. `zz_hotkeys` - new module that contains hotkey enable states, shield functions, callbacks, and the `set_keymaps` function
   1. Each hotkey (T, M, P) has an enabled state:
      1. `talk_enabled`
      2. `music_enabled`
      3. `play_enabled`
   2. there is also an enable state for music volume adjustment / muting. Ideally would be used with sayori, but currently not being used that way.
2. `zz_overlays` - new module that contains general shield raising / dropping and overlay hiding / showing functions. Use this to do a hide_all / disable_all / enable_all / show_all kind of thing for **overlays only**.
3. `zz_shields` - new module that contains workflow-based shield raising / dropping. These functions are designed to simplify certain reptitive actions that `allow_dialogue` controlled.

### Changed stuff

1. `zz_calendar` - made show / hide / raise / drop functions for the calendar overlay
2. `zz_hotkey_buttons` - made raise / drop functions for the hotkey buttons. Also made each button separately controllable and made them launch a function instead of jump
3. `zz_music_selector` - moved all music-related functions (including hotkey callbacks) to this module. Also fixed a bug here with `M` not closing an already open music menu.
4. `script-ch30` - basically a majority of the music-related / hotkey-related functions have been moved from here to their respective modules. Also added special functions to enable / disable the quit dialogue box and closed_self settings.

### Other stuff

1. The `enable_esc` and `disable_esc` now properly work in all contexts. (except for dev console)
2. Add dev labels for primitive overlay / shield testing
3. when the game menu is open, T, M and P should **not** do anything anymore.

## Testing

There is a ton of testing to do here. 

### Workflow regression testing:

The following workflows need to be retested as a result of changes:
1. First-time introduction.
    - All buttons should be visible but disabled until end of introduction.
    - All hotkeys should be disabled until end of introduction.
    - Escape button should not work until end of introduction.
    - Calendar overlay visible but disabled until end of introduction.
2. Import DDLC save data.
    - All hotkeys should be disabled.
    - Escape button should not work until end of interaction.
    - If this workflow was started in the middle of dialogue, only the music related functions should be enabled after this interaction is finished.
3. General dialogue / Talk menu / play menu
    - Talk and play buttons should be disabled until end of dialogue
    - Talk and play hotkeys should be disabled until end of dialogue
    - Calendar overlay disabled until end of dialogue
4. Hairdown greeting
    - All buttons hidden until end of greeting.
    - All hotkeys disabled. Only music button reenabled at end of greeting, unless idle mode is next.
    - Calendar overlay disabled until end of greeting.
5. opendoor greeting
    - All buttons hidden until end of greeting.
    - All hotkeys disabled until end of greeting. Only music button renabled at end of greeting, unless idle mode is next.
    - Calendar overlay hidden at start, may appear during greeting depending on workflow, will be disabled until end of greeting.
    - Quitting during certain parts of the workflow is possible without monika knowing. However as soon as Monika is aware you are there, quitting will prompt the box. (This is new, previously we just never cared until you reached the end of the greeting).

Verifying that these workflows work correctly effectively tests the new functions as well. I added 2 dev labels to do primitive testing of the overlay functions, but you can add additional ones if you want. **do not test the shield / overlay functions using the dev console.** The different context will most likely break those functions.