### PR TITLE
Pool Progression adjustments

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -659,6 +659,10 @@ label ch30_autoload:
             #Set unlock flag for stories
             mas_can_unlock_story = True
 
+            # unlock extra pool topics if we can
+            while persistent._mas_pool_unlocks > 0 and mas_unlockPrompt():
+                persistent._mas_pool_unlocks -= 1
+
 
     #Run actions for any events that need to be changed based on a condition
     $ evhand.event_database=Event.checkConditionals(evhand.event_database)

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -258,6 +258,11 @@ label v0_8_3(version="v0_8_3"):
         ex_ev.random = False
         ex_ev.pool = True
 
+        # give players pool unlocks if they've been here for some time
+        curr_level = get_level()
+        if curr_level > 25:
+            persistent._mas_pool_unlocks = int(curr_level / 2)
+
     return
 
 # 0.8.2


### PR DESCRIPTION
Pool topics are currently unlocked via progression whenever the user reaches the next level. This is great for people who are new, but bad for long-time players because reaching the next level might take forever. 

this adds a counter that increments whenever `unlock_prompt` is reached but no prompt was unlocked. When the game starts, this counter is checked and pool topics are attempted to be unlocked. When we add new content, this should act as retro-actively unlocking pool topics based on user level.

Also, all current users will start will a number of pool unlocks based on their level. If their level is over 25, they will get half their level in pool unlocks.

### Testing

I just set `persistent._mas_pool_unlocks` to a value and then locked value+1 pool topics and checked to make sure that one of the pool topics was not unlocked on a restart.
