### PR TITLE
Fixes De-random event issue

### DIFF
--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -745,9 +745,13 @@ label call_next_event:
             $ ev.shown_count += 1
             $ ev.last_seen = datetime.datetime.now()
 
-        if _return == 'quit':
-            $persistent.closed_self = True #Monika happily closes herself
-            jump _quit
+        if _return is not None:
+            if "derandom" in _return:
+                $ ev.random = False
+
+            if "quit" in _return:
+                $persistent.closed_self = True #Monika happily closes herself
+                jump _quit
 
         show monika 1 at t11 zorder MAS_MONIKA_Z with dissolve #Return monika to normal pose
 

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -392,8 +392,7 @@ label monika_selfesteem:
             m 1e "I can't promise it will be easy, but it'll be worth it."
             m 3k "I'll always root for you, [player]!"
 
-    $ hideEventLabel("monika_selfesteem", derandom=True)
-    return
+    return "derandom"
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_sayori",category=['club members'],prompt="Sayori regrets.",random=True))
@@ -1365,10 +1364,7 @@ label monika_rain:
             $ persistent._mas_likes_rain = False
 
     # unrandom this event if its currently random topic
-    if evhand.event_database["monika_rain"].random:
-        $ hideEventLabel("monika_rain", derandom=True)
-
-    return
+    return "derandom"
 
 
 init 5 python:
@@ -2583,8 +2579,7 @@ label monika_images:
     m 2h "Anything lewd you've seen has definitely never taken place."
     m 2j "I'm a super pure and innocent high school girl who's dreaming of a fateful romance!"
     m "You better be saving yourself for me, [player]~"
-    $ hideEventLabel("monika_images", derandom=True)
-    return
+    return "derandom"
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_herself",category=['monika','ddlc'],prompt="Tell me about yourself.",pool=True))
@@ -3064,8 +3059,7 @@ label monika_cities:
         "No":
             $ persistent._mas_pm_live_in_city = False
             m 1hua "Being away from the city sounds relaxing. Somewhere quiet and peaceful, without much noise, would be a wonderful place to live."
-    $ hideEventLabel("monika_cities", derandom=True)
-    return
+    return "derandom"
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_chloroform",category=['trivia'],prompt="Chloroform",random=True))
@@ -3493,8 +3487,7 @@ label monika_haterReaction:
             m 1ekbfa "Now that you've said it, I have to do my best to keep you from developing hate towards me."
             m "I trust you, [player]. I love you for believing in me."
 
-    $ hideEventLabel("monika_haterReaction", derandom=True)
-    return
+    return "derandom"
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_swordsmanship",category=['monika','misc'],prompt="Swordsmanship",random=True))
@@ -3766,8 +3759,7 @@ label monika_japanese:
             m 1eua "Maybe if I take the time to learn more Japanese, I'll know more languages than you!"
             m 1ekbfa "Ahaha! It's okay [player]. It just means that I can say 'I love you' in more ways than one!"
 
-    $ hideEventLabel("monika_japanese", derandom=True)
-    return
+    return "derandom"
 
 default persistent._mas_penname = ""
 init 5 python:
@@ -4044,8 +4036,7 @@ label monika_icecream:
             m 3eua "Ah, I could go on and on about this stuff, you know?"
             m 4eua "But I feel like it would be easier for me to show you what I mean, once I figure out a way to get out of here of course, and besides, actions speak louder than words, anyway!"
 
-    $ hideEventLabel("monika_icecream", derandom=True)
-    return
+    return "derandom"
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_sayhappybirthday",category=['misc'],prompt="Can you tell someone Happy Birthday for me?",pool=True))
@@ -4746,8 +4737,7 @@ label monika_weddingring:
             m 1ekc "Aww. That's a shame."
             m 1eka "Well, at least think about it, okay?"
 
-    $ hideEventLabel("monika_weddingring", derandom=True)
-    return
+    return "derandom"
 
 # do you like playing sports
 default persistent._mas_pm_like_playing_sports = None
@@ -4775,8 +4765,7 @@ label monika_sports:
             m 1eka "Oh... Well, that’s okay, but I hope you’re still getting enough exercise!"
             m 1ekc "I would hate to see you get sick because of something like that..."
 
-    $ hideEventLabel("monika_sports", derandom=True)
-    return
+    return "derandom"
 
 # do you meditate
 default persistent._mas_pm_meditates = None
@@ -4818,8 +4807,7 @@ label monika_meditation:
     show monika 1hubfa at t11 zorder MAS_MONIKA_Z with dissolve
     m 1hubfa "Don't you ever forget that, [player]~"
 
-    $ hideEventLabel("monika_meditation", derandom=True)
-    return
+    return "derandom"
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_orchestra",category=['media','you'],prompt="Classical music",random=True))
@@ -4867,8 +4855,7 @@ label monika_orchestra:
             m 1eka "Anyhow, you should really see if anything catches your fancy."
             m 1hua "I would be very happy to hear you play."
 
-    $ hideEventLabel("monika_orchestra", derandom=True)
-    return
+    return "derandom"
 
 # do you like jazzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
 default persistent._mas_pm_like_jazz = None
@@ -4905,8 +4892,7 @@ label monika_jazz:
     m 1eua "It was about experimenting, about going beyond what already existed. To make something more wild and colorful."
     m 1hua "Like poetry! It used to be structured and rhyming, but it's changed. It gives greater freedom now."
     m 1eua "Maybe that's what I like about jazz, if anything."
-    $ hideEventLabel("monika_jazz", derandom=True)
-    return
+    return "derandom"
 
 # do you watch animemes
 default persistent._mas_pm_watch_mangime = None
@@ -4949,8 +4935,7 @@ label monika_otaku:
     m 1lfu "I wouldn't want to be replaced by some two-dimensional cutout."
     m 1eua "Besides, if you ever want to escape from reality..."
     m 1hubfa "I can be your real-life fantasy instead~"
-    $ hideEventLabel("monika_otaku", derandom=True)
-    return
+    return "derandom"
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_writingtip3",category=['writing tips'],prompt="Writing tip #3",conditional="seen_event('monika_writingtip2')",action=EV_ACT_POOL))
@@ -5477,8 +5462,7 @@ label monika_smoking:
             m 1hua "I'll be here to support you every step of the way."
             m 1hub "I believe in you [player], I know you can do it!"
 
-    $ hideEventLabel("monika_smoking", derandom=True)
-    return
+    return "derandom"
 
 init 5 python:
      addEvent(Event(persistent.event_database,eventlabel="monika_cartravel",category=['romance'],prompt="Road Trip",random=True))
@@ -5670,8 +5654,7 @@ label monika_asks_family:
             m 1eka "You can tell me about your family when you're ready, [player]."
             m 1hubfa "I love you very much!"
 
-    $ hideEventLabel("monika_asks_family", derandom=True)
-    return
+    return "derandom"
 
 init 5 python:
     addEvent(
@@ -5779,8 +5762,7 @@ label monika_beach:
     m 1tsbsa "Would you prefer a one piece or a two piece?"
     m 1eua "Actually, I think I'll make it a surprise."
     m 1tku "Don't get too excited though when you see it. Ehehe~"
-    $ hideEventLabel("monika_beach", derandom=True)
-    return
+    return "derandom"
 
 ####################################################
 # Saving this for future use
@@ -5963,8 +5945,7 @@ label monika_prom:
             m 1hua "Being with me is one of them, you know~"
             m 1hub "Ahaha!"
 
-    $ hideEventLabel("monika_prom", derandom=True)
-    return
+    return "derandom"
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_careful",category=['you'],prompt="Be Careful",random=True))
@@ -6034,8 +6015,7 @@ label monika_natsuki_letter:
             m 1eua "If that ever changes, don't be shy!"
             m 1hua "But maybe I really am all the support you need? Ahaha!"
 
-    $ hideEventLabel("monika_natsuki_letter", derandom=True)
-    return
+    return "derandom"
 
 default persistent._mas_timeconcern = 0
 default persistent._mas_timeconcerngraveyard = False
@@ -6509,8 +6489,7 @@ label monika_familygathering:
             m 1eua "If you want to keep me a secret, then that's fine."
             m 1hub "After all, it just means more alone time with you~"
 
-    $ hideEventLabel("monika_familygathering", derandom=True)
-    return
+    return "derandom"
 
 # do you eat fast food
 default persistent._mas_pm_eat_fast_food = None
@@ -6642,8 +6621,7 @@ label monika_yellowwp:
             m 1eka "It's a short story, so if you haven't, feel free to whenever you have the time."
             m 1hua "It'll definitely be an interesting read for you."
 
-    $ hideEventLabel("monika_yellowwp", derandom=True)
-    return
+    return "derandom"
 
 init 5 python:
     addEvent(

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -252,6 +252,7 @@ label v0_3_1(version=version): # 0.3.1
 # 0.8.3
 label v0_8_3(version="v0_8_3"):
     python:
+        import datetime
 
         # need to unrandom the explain topic
         ex_ev = mas_getEV("monika_explain")
@@ -271,6 +272,35 @@ label v0_8_3(version="v0_8_3"):
         curr_level = get_level()
         if curr_level > 25:
             persistent._mas_pool_unlocks = int(curr_level / 2)
+
+        # fix all derandom topics that were not unlocked
+        derandomable = [
+            "monika_natsuki_letter",
+            "monika_prom",
+            "monika_beach",
+            "monika_asks_family",
+            "monika_smoking",
+            "monika_otaku",
+            "monika_jazz",
+            "monika_orchestra",
+            "monika_meditation",
+            "monika_sports",
+            "monika_weddingring",
+            "monika_icecream",
+            "monika_japanese",
+            "monika_haterReaction",
+            "monika_cities",
+            "monika_images",
+            "monika_rain",
+            "monika_selfesteem",
+            "monika_yellowwp",
+            "monika_familygathering"
+        ]
+        for topic in derandomable:
+            ev = mas_getEV(topic)
+            if renpy.seen_label(topic) and ev:
+                ev.unlocked = True
+                ev.unlock_date = datetime.datetime.now()
 
     return
 

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -253,15 +253,16 @@ label v0_3_1(version=version): # 0.3.1
 label v0_8_3(version="v0_8_3"):
     python:
         import datetime
+        import store.evhand as evhand
 
         # need to unrandom the explain topic
-        ex_ev = mas_getEV("monika_explain")
+        ex_ev = evhand.event_database.get("monika_explain", None)
         if ex_ev is not None:
             ex_ev.random = False
             ex_ev.pool = True
 
         # update Kizuna's topic action
-        kiz_ev = mas_getEV("monika_kizuna")
+        kiz_ev = evhand.event_database.get("monika_kizuna", None)
         if kiz_ev is not None and not renpy.seen_label(kiz_ev.eventlabel):
             kiz_ev.action = EV_ACT_POOL
             kiz_ev.unlocked = False
@@ -297,7 +298,7 @@ label v0_8_3(version="v0_8_3"):
             "monika_familygathering"
         ]
         for topic in derandomable:
-            ev = mas_getEV(topic)
+            ev = evhand.event_database.get(topic, None)
             if renpy.seen_label(topic) and ev:
                 ev.unlocked = True
                 ev.unlock_date = datetime.datetime.now()

--- a/Monika After Story/game/updates_topics.rpy
+++ b/Monika After Story/game/updates_topics.rpy
@@ -40,6 +40,7 @@ label vv_updates_topics:
 
         # versions
         # use the v#_#_# notation so we can work with labels
+        vv0_8_3 = "v0_8_3"
         vv0_8_2 = "v0_8_2"
         vv0_8_1 = "v0_8_1"
         vv0_8_0 = "v0_8_0"
@@ -64,6 +65,7 @@ label vv_updates_topics:
         # update this dict accordingly to every new version
         # k:old version number -> v:new version number
         # some version changes skip some numbers because no major updates
+#        updates.version_updates[vv0_8_2] = vv0_8_3
         updates.version_updates[vv0_8_1] = vv0_8_2
         updates.version_updates[vv0_8_0] = vv0_8_1
         updates.version_updates[vv0_7_4] = vv0_8_0


### PR DESCRIPTION
#1866  (and possibly #1799)

This allows `call_next_event` to handle derandoming instead of having the topics do it. Should fix the issue of them not unlocking.

Also retroactively unlocking those events via version change update script. 
Here is list of affected events:
```python
            "monika_natsuki_letter",
            "monika_prom",
            "monika_beach",
            "monika_asks_family",
            "monika_smoking",
            "monika_otaku",
            "monika_jazz",
            "monika_orchestra",
            "monika_meditation",
            "monika_sports",
            "monika_weddingring",
            "monika_icecream",
            "monika_japanese",
            "monika_haterReaction",
            "monika_cities",
            "monika_images",
            "monika_rain",
            "monika_selfesteem",
            "monika_yellowwp",
            "monika_familygathering"
```