### PR TITLE
Popping the history list when appropriate

### DIFF
--- a/Monika After Story/game/chess.rpy
+++ b/Monika After Story/game/chess.rpy
@@ -2241,6 +2241,7 @@ label mas_chess_dlg_qf_edit_n_3:
     m 2dfc "[player]..."
     m 2dftdc "I kept a backup of our game.{w} I know you edited the save file."
     m 2dftsc "I just-"
+    $ _history_list.pop()
     m 6ektsc "I just{fast} can't believe you would cheat and {i}lie{/i} to me."
     m 6rktsc "..."
     

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -449,6 +449,7 @@ label greeting_glitch:
      hide monika
      show yuri glitch zorder MAS_BACKGROUND_Z
      y "{cps=500}[player]?!{nw}{/cps}"
+     $ _history_list.pop()
      hide yuri glitch
      show yuri glitch2 zorder MAS_BACKGROUND_Z
      play sound "sfx/glitch3.ogg"
@@ -697,6 +698,7 @@ label monikaroom_greeting_opendoor_locked:
             m "Aww, sorry."
         "No":
             m "{cps=*2}Hmph, I'll get you next time.{/cps}{nw}"
+            $ _history_list.pop()
             m "I figured. It's a basic glitch after all."
     m "Since you keep opening my door,{w} I couldn't help but add a little surprise for you~"
     m "Knock next time, okay?"

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -314,6 +314,7 @@ label mas_random_ask:
             m "If you get tired of watching me talk about the same things over and over,{w} just open up the settings and uncheck 'Repeat Topics'."
             # TODO: this really should be a smug or wink face
             m "That tells me when {cps=*2}you're bored of me{/cps}{nw}"
+            $ _history_list.pop()
             m "That tells me when {fast}you just want to quietly spend time with me."
             $ persistent._mas_enable_random_repeats = True
             return True
@@ -343,6 +344,7 @@ init 5 python:
 label mas_monikai_detected:
     m 2wud "What's this?"
     m "Is that-"
+    $ _history_list.pop()
     m 1wuo "Is that{fast} a tiny version of me?"
     m 1hua "How cute!"
     show monika 1eua

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -6802,6 +6802,7 @@ label monika_dating_startdate:
         # its today?!
         # this should NEVER HAPPEN
         m 1lsc "We started dating..."
+        $ _history_list.pop()
         m 1wud "We started dating{fast} today?!"
         m 2wfw "You couldn't have possibly triggered this event today, [player]."
         menu:
@@ -6821,6 +6822,7 @@ label monika_dating_startdate:
     if not persistent._mas_changed_start_date:
         m 1lsc "Hmmm..."
         m 1dsc "I think it was..."
+        $ _history_list.pop()
         m 1eua "I think it was{fast} [first_sesh]."
         m 1rksdlb "But my memory might be off."
 
@@ -6986,6 +6988,7 @@ label monika_dating_startdate_confirm(first_sesh_raw):
                 m 6dftdc "..."
                 m 1eka "In that case..."
                 m 1tku "{cps=*4}I've got some work to do.{/cps}{nw}"
+                $ _history_list.pop()
 
                 menu:
                     "What?":

--- a/Monika After Story/game/zz_hangman.rpy
+++ b/Monika After Story/game/zz_hangman.rpy
@@ -386,6 +386,7 @@ label mas_hangman_game_loop:
 
                 # display weird text
                 m "{cps=*2}[hm_glitch_word]{/cps}{w=0.2}{nw}"
+                $ _history_list.pop()
 
                 # tear screen and glitch sound
                 show screen tear(20, 0.1, 0.1, 0, 40)


### PR DESCRIPTION
This is to hide certain bits of text from history that kind of break the immersion.

Particular places with `{fast}` or `{nw}` tags