### PR TITLE
Changed Anniversary Start dates

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -1798,10 +1798,45 @@ init -100 python in mas_utils:
     #at 3 AM
     # START-OF-DAY
     def sod(starting_date):
-        new_date = starting_date.replace(hour=3,minute=0,second=0,microsecond=0)
+        return am3(starting_date)
 
-        return new_date
 
+    def mdnt(starting_date):
+        """
+        Takes a datetime object and returns a new datetime with the same date
+        at midnight
+
+        IN:
+            starting_date - date to change
+
+        RETURNS:
+            starting_date but at midnight
+        """
+        return starting_date.replace(
+            hour=0,
+            minute=0,
+            second=0,
+            microsecond=0
+        )
+
+
+    def am3(_datetime):
+        """
+        Takes a datetime object and returns a new datetime with the same date
+        at 3 am.
+
+        IN:
+            _datetime - datetime to change
+
+        RETURNS:
+            _datetime but at 3am
+        """
+        return _datetime.replace(
+            hour=3,
+            minute=0,
+            second=0,
+            microsecond=0
+        )
 
 
 

--- a/Monika After Story/game/script-anniversary.rpy
+++ b/Monika After Story/game/script-anniversary.rpy
@@ -110,7 +110,7 @@ init 10 python in mas_anni:
             mas_utils.mdnt(new_start_date),
             months
         )
-        ev.end_date = ev.start_date + span
+        ev.end_date = mas_utils.mdnt(ev.start_date + span)
 
     def _day_adjuster(ev, new_start_date, days, span):
         """
@@ -124,8 +124,10 @@ init 10 python in mas_anni:
             days - number of months to advance
             span - the time from the event's new start_date to end_date
         """
-        ev.start_date = new_start_date + datetime.timedelta(days=days)
-        ev.end_date = ev.start_date + span
+        ev.start_date = mas_utils.mdnt(
+            new_start_date + datetime.timedelta(days=days)
+        )
+        ev.end_date = mas_utils.mdnt(ev.start_date + span)
 
 
     def add_cal_annis():

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -714,9 +714,9 @@ label mas_lupd_v0_8_3:
 
 
 init 5000 python:
-    while len(persistent._mas_zz_lupd_ex_v) > 0:
-        lupd_v = "mas_lupd_" + persistent._mas_zz_lupd_ex_v.pop()
-        if renpy.has_label(lupd_v):
-            renpy.call_in_new_context(lupd_v)
+    for __temp_version in persistent._mas_zz_lupd_ex_v:
+        __lupd_v = "mas_lupd_" + __temp_version
+        if renpy.has_label(__lupd_v):
+            renpy.call_in_new_context(__lupd_v)
 
     persistent._mas_zz_lupd_ex_v = list()

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -5,6 +5,8 @@
 #   persistent._seen_ever
 #   persistent.version_number
 
+define persistent._mas_zz_lupd_ex_v = []
+
 # preeverything stuff
 init -10 python:
     found_monika_ani = persistent.monika_anniversary is not None
@@ -302,6 +304,10 @@ label v0_8_3(version="v0_8_3"):
             if renpy.seen_label(topic) and ev:
                 ev.unlocked = True
                 ev.unlock_date = datetime.datetime.now()
+
+        # anniversaries need to be readjusted again!
+        # but we will use late update script this time
+        persistent._mas_zz_lupd_ex_v.append(version)
 
     return
 
@@ -668,3 +674,49 @@ label v0_3_0(version="v0_3_0"):
 #
 #        del _mas_events_unlocked_v073
 #        del ev_key
+
+
+###############################################################################
+### SUPER LATE scripts
+# these scripts are for doing python things really LATE in the pipeline
+#
+# USAGE:
+# 1. define a label called mas_lupd_v#_#_#
+# 2. Put your update code into there.
+# 3. Push the version number into `persistent._mas_zz_lupd_ex_v` to run it
+#
+# NOTE: none of this code will ever run more than once.
+# NOTE: this code will respect version update chaining, but these are chained
+#   post-version. This means that if a multipel version chain occurs,
+#   the regular labels are executed first, then this (the late-chain) executes.
+#   For example, lets say we have 3 versions: A, B, C
+#   and 2 of these versions have late scripts, B' and C'
+#   
+#   Update order:
+#   1. A
+#   2. B
+#   3. C
+#   4. B'
+#   5. C'
+#
+#   Please make sure your late update scripts are not required before a next
+#   version regular update script.
+
+label mas_lupd_v0_8_3:
+    python:
+        # readjust anniversaries
+        if persistent.sessions:
+            first_sesh = persistent.sessions.get("first_session", None)
+            if first_sesh:
+                store.mas_anni.reset_annis(first_sesh)
+
+    return
+
+
+init 5000 python:
+    while len(persistent._mas_zz_lupd_ex_v) > 0:
+        lupd_v = "mas_lupd_" + persistent._mas_zz_lupd_ex_v.pop()
+        if renpy.has_label(lupd_v):
+            renpy.call_in_new_context(lupd_v)
+
+    persistent._mas_zz_lupd_ex_v = list()


### PR DESCRIPTION
#1818 

Anniversaries start at 3am. This makes no sense lol.

Changed anniversaries to start at midnight.

Ending dates will continue to be midnight next day.

### Testing
1. Check if the annivesaries have correct start/end dates on a fresh persistent
2. Check if version update scripts properly adjust anniversari start/end dates

### other
This also adds something called SUPER LATE update scripts, which are run at python level 5k.
These can be used by pushing the version number to `_mas_zz_lupd_ex_v` persistent var.