### PR TITLE
Affection fixes/changes pt.1

### DIFF
--- a/Monika After Story/game/chess.rpy
+++ b/Monika After Story/game/chess.rpy
@@ -114,17 +114,17 @@ init 1 python in mas_chess:
     #   (Monika's fault)
     QS_LOST = 0
 
-    # Quick File LOST (OF Course Not): the external quick save got removed, 
-    #   player denied removal 
+    # Quick File LOST (OF Course Not): the external quick save got removed,
+    #   player denied removal
     #   (Player's fault)
     QF_LOST_OFCN = 1
 
-    # Quick File LOST MAYBE: the external quick save got removed, player 
+    # Quick File LOST MAYBE: the external quick save got removed, player
     #   admitted to it
     #   (Player's fault)
     QF_LOST_MAYBE = 2
 
-    # Quick File LOST ACciDeNT: the external quick save got removed, player 
+    # Quick File LOST ACciDeNT: the external quick save got removed, player
     #   said it was an accident.
     #   (Could be player's fault, or not)
     QF_LOST_ACDNT = 3
@@ -158,7 +158,7 @@ init 1 python in mas_chess:
     # base part of label for variable chess strength when monika wins
     DLG_MONIKA_WIN_BASE = "mas_chess_dlg_game_monika_win_{0}"
 
-    # base part of label for variable chess strength when monika wins by 
+    # base part of label for variable chess strength when monika wins by
     # early surrender
     DLG_MONIKA_WIN_SURR_BASE = "mas_chess_dlg_game_monika_win_surr_{0}"
 
@@ -223,20 +223,20 @@ init 1 python in mas_chess:
         "mas_chess_dlg_game_monika_win_surr_trying"
     )
 
-    
+
 ## functions ==================================================================
 
     def __initDLGActions():
         """
-        Initailizes the DLG actions dict and updates the persistent 
+        Initailizes the DLG actions dict and updates the persistent
         appriorpately
 
         ASSUMES:
             renpy.game.persistent._mas_chess_dlg_actions
         """
         # dlg actions dict
-        # NOTE: this is a way of allowing for dict expansion without fancy 
-        # update scripts. 
+        # NOTE: this is a way of allowing for dict expansion without fancy
+        # update scripts.
         dlg_actions = {
             QS_LOST: 0,
             QF_LOST_OFCN: 0,
@@ -245,7 +245,7 @@ init 1 python in mas_chess:
             QF_EDIT_YES: 0,
             QF_EDIT_NO: 0
         }
-        
+
         # check to ensure persistent is updated
         if len(dlg_actions) != len(renpy.game.persistent._mas_chess_dlg_actions):
             dlg_actions.update(renpy.game.persistent._mas_chess_dlg_actions)
@@ -310,7 +310,7 @@ init 1 python in mas_chess:
                 even though we arent global
         """
         __initDLGActions()
-        
+
         if renpy.game.persistent._mas_chess_3_edit_sorry:
             _initQuipLists(MASQL_class)
 
@@ -329,7 +329,7 @@ init 1 python in mas_chess:
         """
         if pgn_game is None:
             return None
-        
+
         if pgn_game.headers["Result"] != "*":
             return None
 
@@ -357,7 +357,7 @@ init 1 python in mas_chess:
             ),
             pgn_game
         )
-   
+
 
     def isInProgressGame(filename, mth):
         """
@@ -464,14 +464,14 @@ init:
         # only add chess folder if we can even do chess
         if is_platform_good_for_chess():
             # first create the folder for this
-            try: 
+            try:
                 file_path = os.path.normcase(
                     config.basedir + mas_chess.CHESS_SAVE_PATH
                 )
                 if not os.access(file_path, os.F_OK):
                     os.mkdir(file_path)
                 mas_chess.CHESS_SAVE_PATH = file_path
-            except: 
+            except:
                 raise ChessException(
                     "Chess game folder could not be created '{0}'".format(
                         file_path
@@ -511,7 +511,7 @@ init:
                 self.move_indicator_monika = Image("mod_assets/move_indicator_monika.png")
                 self.player_move_prompt = Text(_("It's your turn, [player]!"), size=36)
                 self.num_turns = 0
-                self.surrendered = False           
+                self.surrendered = False
 
                 # The sizes of some of the images.
                 self.VECTOR_PIECE_POS = {
@@ -595,7 +595,7 @@ init:
                 )
                 drawn_button_y_top = (
                     720 - (
-                        (self.BUTTON_HEIGHT * 2) + 
+                        (self.BUTTON_HEIGHT * 2) +
                         self.BUTTON_Y_SPACING +
                         self.drawn_board_y
                     )
@@ -737,7 +737,7 @@ init:
                     # last move
                     last_move = self.board.peek().uci()
                     self.last_move_src = (
-                        ord(last_move[0]) - ord('a'), 
+                        ord(last_move[0]) - ord('a'),
                         ord(last_move[1]) - ord('1')
                     )
                     self.last_move_dst = (
@@ -752,10 +752,10 @@ init:
                     # start off with traditional board
                     self.board = chess.Board()
 
-                    # stuff we need to save to the board 
+                    # stuff we need to save to the board
                     self.today_date = datetime.date.today().strftime("%Y.%m.%d")
                     self.start_fen = self.board.fen()
-                    
+
                     # other game setup
                     self.current_turn = self.COLOR_WHITE
 
@@ -849,7 +849,7 @@ init:
                     new_pgn.headers["Date"] = self.pgn_game.headers["Date"]
                     new_pgn.headers["White"] = self.pgn_game.headers["White"]
                     new_pgn.headers["Black"] = self.pgn_game.headers["Black"]
-                    
+
                     old_fen = self.pgn_game.headers.get("FEN", None)
                     if old_fen:
                         new_pgn.headers["FEN"] = old_fen
@@ -867,7 +867,7 @@ init:
 
                     # date, site, and fen
                     # MAS is malaysia but who cares
-                    new_pgn.headers["Site"] = "MAS" 
+                    new_pgn.headers["Site"] = "MAS"
                     new_pgn.headers["Date"] = self.today_date
                     new_pgn.headers["FEN"] = self.start_fen
                     new_pgn.headers["SetUp"] = "1"
@@ -947,10 +947,10 @@ init:
                 highlight_yellow = renpy.render(self.piece_highlight_yellow_image, 1280, 720, st, at)
                 highlight_magenta = renpy.render(self.piece_highlight_magenta_image, 1280, 720, st, at)
 
-                # get the mouse pos 
+                # get the mouse pos
                 mx, my = get_mouse_pos()
 
-                
+
                 # if the mouse is over a button, render that button
                 # differently
                 # winner?
@@ -1067,7 +1067,7 @@ init:
                             # white won
                             elif str(piece) == "k" and result == "1-0":
                                 r.blit(highlight_red, (x, y))
-                               
+
                         r.blit(get_piece_render_for_letter(str(piece)), (x, y))
 
 
@@ -1096,21 +1096,21 @@ init:
 
             # Handles events.
             def event(self, ev, x, y, st):
- 
+
                 # check muouse position
                 if ev.type in self.MOUSE_EVENTS:
                     # are we in mouse button things
 
                      # inital check for winner
                     if self.winner:
-                        
+
                         if self._button_done.event(ev, x, y, st):
                             # user clicks Done
                             return self._quitPGN(False)
 
                     # inital check for buttons
                     elif self.current_turn == self.player_color:
-                        
+
                         if self._button_save.event(ev, x, y, st):
                             # user wants to save this game
                             return self._quitPGN(False)
@@ -1120,7 +1120,7 @@ init:
                             if mas_chess.quit_game:
                                 # user wishes to surrender (noob)
                                 return self._quitPGN(True)
-                   
+
                 def get_piece_pos():
                     mx, my = get_mouse_pos()
                     mx -= (1280 - (self.BOARD_WIDTH - self.BOARD_BORDER_WIDTH * 2)) / 2
@@ -1148,11 +1148,11 @@ init:
                     # continue
                     px, py = get_piece_pos()
                     if (
-                            px is not None 
-                            and py is not None 
-                            and self.board.piece_at(py * 8 + px) is not None 
-                            and bool(str(self.board.piece_at(py * 8 + px)).isupper()) 
-                                == (self.player_color == self.COLOR_WHITE) 
+                            px is not None
+                            and py is not None
+                            and self.board.piece_at(py * 8 + px) is not None
+                            and bool(str(self.board.piece_at(py * 8 + px)).isupper())
+                                == (self.player_color == self.COLOR_WHITE)
                             and self.current_turn == self.player_color
                         ):
 
@@ -1295,7 +1295,7 @@ label demo_minigame_chess:
     elif len(persistent._mas_chess_quicksave) > 0:
         # quicksave holds the pgn game in plaintext
         python:
-            import StringIO # python 2 
+            import StringIO # python 2
             import chess.pgn
             import os
 
@@ -1433,7 +1433,7 @@ label demo_minigame_chess:
                 jump mas_chess_new_game_start
 
         python:
-           
+
             # because quicksaved_file is different form isInProgress
             quicksaved_file = quicksaved_file[1]
 
@@ -1458,7 +1458,7 @@ label demo_minigame_chess:
 
             # kill the quicksaves
             python:
-                persistent._mas_chess_quicksave = ""   
+                persistent._mas_chess_quicksave = ""
                 try:
                     os.remove(quicksaved_filename_clean)
                 except:
@@ -1561,7 +1561,7 @@ label mas_chess_game_start:
     elif is_monika_winner:
         $ persistent._mas_chess_stats["losses"] += 1
         if is_surrender and num_turns <= 4:
-           
+
             # main dialogue
             call mas_chess_dlg_game_monika_win_surr from _mas_chess_dlggmws
 
@@ -1612,6 +1612,7 @@ label mas_chess_playagain:
             pass
 
 label mas_chess_end:
+    #TODO minor affection gain for playing with her
 
     # monika wins
     if is_monika_winner:
@@ -1633,12 +1634,12 @@ label mas_chess_end:
             call mas_chess_dlg_game_monika_lose_end_quick from _mas_chess_dgmlequick
         else:
             call mas_chess_dlg_game_monika_lose_end from _mas_chess_dgmlelong
-        
+
     return
 
 # label for new context for confirm screen
 label mas_chess_confirm_context:
-    call screen mas_chess_confirm 
+    call screen mas_chess_confirm
     $ store.mas_chess.quit_game = _return
     return
 
@@ -1648,7 +1649,7 @@ label mas_chess_save_migration:
         import chess.pgn
         import os
         import store.mas_chess as mas_chess
-    
+
         pgn_files = os.listdir(mas_chess.CHESS_SAVE_PATH)
         sel_game = (mas_chess.CHESS_NO_GAMES_FOUND,)
 
@@ -1692,7 +1693,7 @@ label mas_chess_save_migration:
                     $ pick_text = "Pick a game you'd like to keep."
             show monika 1e at t21
             $ renpy.say(m, pick_text, interact=False)
-            
+
             call screen mas_gen_scrollable_menu(pgn_games, mas_chess.CHESS_MENU_AREA, mas_chess.CHESS_MENU_XALIGN, mas_chess.CHESS_MENU_WAIT_ITEM)
 
             show monika at t11
@@ -1704,7 +1705,7 @@ label mas_chess_save_migration:
                 return False
             else:
                 # user selected a game
-                m 1eua "Alright." 
+                m 1eua "Alright."
                 python:
                     sel_game = actual_pgn_games.pop(_return)
                     for pgn_game in actual_pgn_games:
@@ -1720,7 +1721,7 @@ label mas_chess_save_migration:
             $ sel_game = actual_pgn_games[0]
 
 # FALL THROUGH
-label mas_chess_save_selected: 
+label mas_chess_save_selected:
     return sel_game[0]
 
 label mas_chess_savegame:
@@ -1730,9 +1731,9 @@ label mas_chess_savegame:
                 loaded_game.headers["Event"]
             )
 
-            # filename 
+            # filename
             save_filename = (
-                new_pgn_game.headers["Event"] + 
+                new_pgn_game.headers["Event"] +
                 mas_chess.CHESS_SAVE_EXT
             )
 
@@ -1741,7 +1742,7 @@ label mas_chess_savegame:
 
             # the loaded game needs to be reset if it exists
             loaded_game = None
-        
+
     # otherwise ask for name
     else:
         python:
@@ -1777,7 +1778,7 @@ label mas_chess_savegame:
                     jump mas_chess_savegame
 
     python:
-       
+
         with open(file_path, "w") as pgn_file:
             pgn_file.write(str(new_pgn_game))
 
@@ -1816,13 +1817,13 @@ label mas_chess_savegame:
 
 ### Quicksave lost:
 label mas_chess_dlg_qs_lost:
-    python: 
+    python:
         import store.mas_chess as mas_chess
         persistent._mas_chess_dlg_actions[mas_chess.QS_LOST] += 1
         qs_gone_count = persistent._mas_chess_dlg_actions[mas_chess.QS_LOST]
-        
+
     call mas_chess_dlg_qs_lost_start from _mas_chess_dqsls
-    
+
     if qs_gone_count == 2:
         call mas_chess_dlg_qs_lost_2 from _mas_chess_dlgqslost2
 
@@ -1872,7 +1873,7 @@ label mas_chess_dlg_qs_lost_3:
 label mas_chess_dlg_qs_lost_5r:
     m 2esc "This has happened [qs_gone_count] times now..."
     m "I wonder if this is a side effect of {cps=*0.75}{i}someone{/i}{/cps} trying to edit the saves.{w=1}.{w=1}.{w=1}"
-    m 1esd "Anyway..."   
+    m 1esd "Anyway..."
     m "Let's start a new game."
     show monika 1esc
     return
@@ -1886,7 +1887,7 @@ label mas_chess_dlg_qs_lost_7r:
 label mas_chess_dlg_qf_lost:
     python:
         import store.mas_chess as mas_chess
-    
+
     call mas_chess_dlg_qf_lost_start from _mas_chess_dqfls
 
     menu:
@@ -1910,7 +1911,7 @@ label mas_chess_dlg_qf_lost_start:
 
 ## of course not flow
 label mas_chess_dlg_qf_lost_ofcn_start:
-    python: 
+    python:
         import store.mas_chess as mas_chess
         persistent._mas_chess_dlg_actions[mas_chess.QF_LOST_OFCN] += 1
         qf_gone_count = persistent._mas_chess_dlg_actions[mas_chess.QF_LOST_OFCN]
@@ -1955,6 +1956,7 @@ label mas_chess_dlg_qf_lost_ofcn_4:
 
 # 5th time you ofcn monika
 label mas_chess_dlg_qf_lost_ofcn_5:
+    # TODO decrease affection
     m 2esc "..."
     m "[player],{w} this is happening way too much."
     m 2dsc "I really don't believe you this time."
@@ -1962,11 +1964,12 @@ label mas_chess_dlg_qf_lost_ofcn_5:
     m 2esc "I hope you're not messing with me."
     m "..."
     m 1esc "Whatever.{w} Let's just play a new game."
-    return 
+    return
 
 # 6th time you ofcn monika
 label mas_chess_dlg_qf_lost_ofcn_6:
     # disable chess forever!
+    # TODO: heavy affection decrease
     m 2dfc "..."
     m 2efc "[player],{w} I don't believe you."
     # TODO: we need an angry monika
@@ -1979,7 +1982,7 @@ label mas_chess_dlg_qf_lost_ofcn_6:
 
 ## maybe monika flow
 label mas_chess_dlg_qf_lost_may_start:
-    python: 
+    python:
         import store.mas_chess as mas_chess
         persistent._mas_chess_dlg_actions[mas_chess.QF_LOST_MAYBE] += 1
         qf_gone_count = persistent._mas_chess_dlg_actions[mas_chess.QF_LOST_MAYBE]
@@ -2019,7 +2022,7 @@ label mas_chess_dlg_qf_lost_may_2_found:
 
 # maybe monika file checking parts
 label mas_chess_dlg_qf_lost_may_filechecker:
-    $ import os 
+    $ import os
     $ import store.mas_chess as mas_chess
     $ game_file = mas_chess.loaded_game_filename
 
@@ -2069,6 +2072,7 @@ label mas_chess_dlg_qf_lost_may_3:
 
 # maybe monika, but player removed the file again!
 label mas_chess_dlg_qf_lost_may_removed:
+    # TODO: decrease affection
     # TODO; angery monika here
     m 2wfw "[player]!"
     m 2wfx "You removed the save again."
@@ -2080,7 +2084,7 @@ label mas_chess_dlg_qf_lost_may_removed:
 
 ## Accident monika flow
 label mas_chess_dlg_qf_lost_acdnt_start:
-    python: 
+    python:
         import store.mas_chess as mas_chess
         persistent._mas_chess_dlg_actions[mas_chess.QF_LOST_ACDNT] += 1
         qf_gone_count = persistent._mas_chess_dlg_actions[mas_chess.QF_LOST_ACDNT]
@@ -2144,7 +2148,7 @@ label mas_chess_dlg_qf_edit_start:
 
 ## Yes Edit flow
 label mas_chess_dlg_qf_edit_y_start:
-    python: 
+    python:
         import store.mas_chess as mas_chess
         persistent._mas_chess_dlg_actions[mas_chess.QF_EDIT_YES] += 1
         qf_edit_count = persistent._mas_chess_dlg_actions[mas_chess.QF_EDIT_YES]
@@ -2182,6 +2186,7 @@ label mas_chess_dlg_qf_edit_y_1:
 
 # 2nd time yes edit
 label mas_chess_dlg_qf_edit_y_2:
+    # TODO: decrease affection
     m 2dfc "I am incredibly disappointed in you."
     m 2rfc "I don't want to play chess right now."
     python:
@@ -2191,6 +2196,7 @@ label mas_chess_dlg_qf_edit_y_2:
 
 # 3rd time yes edit
 label mas_chess_dlg_qf_edit_y_3:
+    # TODO decrease affection
     m 2dsc "I'm not surprised..."
     m 2esc "But I am prepared."
     m "I kept a backup of our game just in case you did this again."
@@ -2202,7 +2208,7 @@ label mas_chess_dlg_qf_edit_y_3:
 
 ## No Edit flow
 label mas_chess_dlg_qf_edit_n_start:
-    python: 
+    python:
         import store.mas_chess as mas_chess
         persistent._mas_chess_dlg_actions[mas_chess.QF_EDIT_NO] += 1
         qf_edit_count = persistent._mas_chess_dlg_actions[mas_chess.QF_EDIT_NO]
@@ -2220,6 +2226,7 @@ label mas_chess_dlg_qf_edit_n_start:
 
 # 1st time no edit
 label mas_chess_dlg_qf_edit_n_1:
+    # TODO: decrease affection
     m 1ekc "I see."
     m "The save file looks different than how I last remembered it, but maybe that's just my memory failing me."
     m 1eua "Let's continue this game."
@@ -2229,6 +2236,7 @@ label mas_chess_dlg_qf_edit_n_1:
 
 # 2nd time no edit
 label mas_chess_dlg_qf_edit_n_2:
+    # TODO: decrease affection even more
     m 1ekc "I see."
     m "..."
     m "Let's just continue this game."
@@ -2238,13 +2246,14 @@ label mas_chess_dlg_qf_edit_n_2:
 
 # 3rd time no edit
 label mas_chess_dlg_qf_edit_n_3:
+    # TODO: decrease affection a lot more
     m 2dfc "[player]..."
     m 2dftdc "I kept a backup of our game.{w} I know you edited the save file."
     m 2dftsc "I just-"
     $ _history_list.pop()
     m 6ektsc "I just{fast} can't believe you would cheat and {i}lie{/i} to me."
     m 6rktsc "..."
-    
+
     # THE ULTIMATE CHOICE
     show screen mas_background_timed_jump(3, "mas_chess_dlg_qf_edit_n_3n")
     menu:
@@ -2268,7 +2277,7 @@ label mas_chess_dlg_qf_edit_n_3_s:
     m "I forgive you, [player], but please don't do this to me again."
     m 2lktsc "..."
     $ store.mas_chess.chess_strength = (True, persistent.chess_strength)
-    $ persistent.chess_strength = 20   
+    $ persistent.chess_strength = 20
     $ persistent._mas_chess_3_edit_sorry = True
     $ persistent._mas_chess_skip_file_checks = True
     $ store.mas_chess._initQuipLists(MASQuipList)
@@ -2276,6 +2285,7 @@ label mas_chess_dlg_qf_edit_n_3_s:
 
 # 3rd time no edit, sorry, edit qs
 label mas_chess_dlg_qf_edit_n_3_n_qs:
+    # TODO: heavy affection decrease
     m 2dfc "[player]..."
     m 2efc "I see you've edited my backup saves."
     m 2lfc "If you want to be like that right now, then we'll play chess some other time."
@@ -2288,7 +2298,7 @@ label mas_chess_dlg_qf_edit_n_3_n_qs:
 label mas_chess_dlg_qf_edit_n_3_n:
     m 6ektsc "I can't trust you anymore."
     m "Goodbye, [player].{nw}"
-   
+
     # do some permanent stuff
 label mas_chess_go_ham_and_delete_everything:
     python:
@@ -2325,12 +2335,13 @@ label mas_chess_go_ham_and_delete_everything:
         # forever remember
         persistent._mas_chess_mangle_all = True
         persistent.autoload = "mas_chess_go_ham_and_delete_everything"
-        
+
     jump _quit
 
 ## general dialogue
 # if chess is locked
 label mas_chess_dlg_chess_locked:
+    # TODO: maybe decrease affection a bit?
     m 1efc "..."
     m 2lfc "I don't feel like playing chess right now."
     return
@@ -2375,7 +2386,7 @@ label mas_chess_dlg_game_monika_win:
 
     # bad players get rekt by monika
     if persistent._mas_chess_3_edit_sorry:
-        
+
         # pull a quip and say it
         $ t_quip, v_quip = mas_chess.monika_wins_mean_quips.quip()
 
@@ -2495,7 +2506,7 @@ label mas_chess_dlg_game_monika_win_19:
 # winning, chess strength 20
 label mas_chess_dlg_game_monika_win_20:
     m 1tfu "I'll go a little easier on you next time."
-    return      
+    return
 
 ## monika wins by early surrender
 # monika win by early surrender dialogue start
@@ -2510,7 +2521,7 @@ label mas_chess_dlg_game_monika_win_surr:
 
     # bad players get rekt by monika
     if persistent._mas_chess_3_edit_sorry:
-        
+
         # pull a quip and say it
         $ t_quip, v_quip = mas_chess.monika_wins_surr_mean_quips.quip()
 
@@ -2638,7 +2649,7 @@ label mas_chess_dlg_game_monika_win_surr_19:
 # winning by surrender, chess strength 20
 label mas_chess_dlg_game_monika_win_surr_20:
     # nothint for now
-    return      
+    return
 
 ## monika loses
 # monika lose label start dialogue
@@ -2653,7 +2664,7 @@ label mas_chess_dlg_game_monika_lose:
 
     # bad players get rekt by monika
     if persistent._mas_chess_3_edit_sorry:
-        
+
         # pull a quip and say it
         $ t_quip, v_quip = mas_chess.monika_loses_mean_quips.quip()
 
@@ -2729,7 +2740,7 @@ label mas_chess_dlg_game_monika_lose_6:
 # losing, chess strength 7
 label mas_chess_dlg_game_monika_lose_7:
     m 3hua "Excellently played, [player]!"
-    return      
+    return
 
 # losing, chess strength 8
 label mas_chess_dlg_game_monika_lose_8:
@@ -2742,7 +2753,7 @@ label mas_chess_dlg_game_monika_lose_9:
 # losing, chess strength 10
 label mas_chess_dlg_game_monika_lose_10:
     m 1wuo "You're quite a strong chess player!"
-    return      
+    return
 
 # losing, chess strength 11
 label mas_chess_dlg_game_monika_lose_11:
@@ -2751,7 +2762,7 @@ label mas_chess_dlg_game_monika_lose_11:
 # losing, chess strength 12
 label mas_chess_dlg_game_monika_lose_12:
     m 1wuo "You're a very challenging opponent, [player]!"
-    return      
+    return
 
 # losing, chess strength 13
 label mas_chess_dlg_game_monika_lose_13:
@@ -2769,7 +2780,7 @@ label mas_chess_dlg_game_monika_lose_15:
 label mas_chess_dlg_game_monika_lose_16:
     # ee for good chess players
     m 2lfx "I-{w=1}It's not like I let you win or anything, b-{w=1}baka!"
-    return      
+    return
 
 # losing, chess strength 17
 label mas_chess_dlg_game_monika_lose_17:
@@ -2783,13 +2794,13 @@ label mas_chess_dlg_game_monika_lose_18:
 label mas_chess_dlg_game_monika_lose_19:
     m 1wuo "Wow! You're amazing at chess."
     m 1sub "You could be a professional chess player!"
-    return      
+    return
 
 # losing, chess strength 20
 label mas_chess_dlg_game_monika_lose_20:
     m 1wuo "Wow!"
     m 1tku "Are you sure you're not cheating?"
-    return      
+    return
 
 ### chess has ended dialogue
 # monika won

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -3279,6 +3279,9 @@ default persistent._mas_first_calendar_check = False
 default persistent._mas_likes_rain = False
 define mas_is_raining = False
 
+# music
+default persistent.current_track = renpy.store.songs.FP_JUST_MONIKA
+
 # clothes
 default persistent._mas_monika_clothes = "def"
 default persistent._mas_monika_hair = "def"

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -1753,6 +1753,7 @@ init -1 python in _mas_root:
         renpy.game.persistent._mas_you_chr = False
         renpy.game.persistent.opendoor_opencount = 0
         renpy.game.persistent.opendoor_knockyes = False
+        persistent._mas_greeting_type = None
 
         # hangman
         renpy.game.persistent._mas_hangman_playername = False
@@ -1760,6 +1761,9 @@ init -1 python in _mas_root:
         # piano
         renpy.game.persistent._mas_pnml_data = list()
         renpy.game.persistent._mas_piano_keymaps = dict()
+
+        # affection
+        persistent._mas_affection["affection"] = 0
 
 
 init -100 python in mas_utils:

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -432,7 +432,8 @@ python early:
                 pool=None,
                 action=None,
                 seen=None,
-                excl_cat=None):
+                excl_cat=None,
+                moni_wants=None):
             #
             # Filters the given event object accoridng to the given filters
             # NOTE: NO SANITY CHECKS
@@ -481,6 +482,10 @@ python early:
                 if event.category and len(set(excl_cat).intersection(set(event.category))) > 0:
                     return False
 
+            # check if event contains the monika wants this rule
+            if moni_wants is not None and event.monikaWantsThisFirst() != moni_wants:
+                return False
+
             # we've passed all the filtering rules somehow
             return True
 
@@ -494,7 +499,8 @@ python early:
                 pool=None,
                 action=None,
                 seen=None,
-                excl_cat=None):
+                excl_cat=None,
+                moni_wants=None):
             #
             # Filters the given events dict according to the given filters.
             # HOW TO USE: Use ** to pass in a dict of filters. they must match
@@ -529,6 +535,9 @@ python early:
             #   excl_cat - list of categories to exclude, if given an empty
             #       list it filters out events that have a non-None category
             #       (Default: None)
+            #   moni_wants - boolean value to match if the event has the monika
+            #       wants this first.
+            #       (Default: None )
             #
             # RETURNS:
             #   if full_copy is True, we return a completely separate copy of
@@ -546,7 +555,8 @@ python early:
                     and pool is None
                     and action is None
                     and seen is None
-                    and excl_cat is None)):
+                    and excl_cat is None
+                    and moni_wants is None)):
                 return events
 
             # copy check
@@ -570,7 +580,7 @@ python early:
                 # time to apply filtering rules
                 if Event._filterEvent(v,category=category, unlocked=unlocked,
                         random=random, pool=pool, action=action, seen=seen,
-                        excl_cat=excl_cat):
+                        excl_cat=excl_cat,moni_wants=moni_wants):
 
                     filt_ev_dict[k] = v
 

--- a/Monika After Story/game/dev/dev_affection-test.rpy
+++ b/Monika After Story/game/dev/dev_affection-test.rpy
@@ -1,13 +1,26 @@
-#Testing purposes!   
-label monika_affection_check:
+# Affection related checks
+
+init 5 python:
+    addEvent(
+        Event(
+            persistent.event_database,
+            eventlabel="dev_monika_affection_check",
+            category=["dev"],
+            prompt="AFFECTION CHECK",
+            pool=True,
+            random=True,
+            unlocked=True
+        )
+    )
+
+label dev_monika_affection_check:
     m 1c "How do I feel? That came out of nowhere, [player]..."
-    m 3h "In a single word I would say I am [monika_current_affection]."
-    m 3a "As a number it would be...[persistent._mas_affection[affection]]."
+    m 3a "My affection as a number it would be...[persistent._mas_affection[affection]]."
     m 3c "But if I were pressed further I would say I'm feeling..."
     if mas_curr_affection == mas_affection.BROKEN:
         m 1q "Like you shattered my heart..."
         m 1f "Did I do something wrong?"
-  
+
     elif mas_curr_affection == mas_affection.DISTRESSED:
         m 1r "Like my situation is hopeless..."
         m 1f "I really thought we could make it work..."
@@ -32,49 +45,52 @@ label monika_affection_check:
         m 1k "I want nothing more than you, forever and ever!"
     return
 
-label force_affection_heartbroken:
+
+# Should these be added to the dev category? I don't want to make cheating easy
+
+label dev_force_affection_heartbroken:
     m 1h "..."
     $ persistent._mas_affection["affection"] = -100
     $ mas_updateAffectionExp()
     m 1q "You're so cruel [player]..."
     return
 
-label force_affection_distressed:
+label dev_force_affection_distressed:
     m 1h "..."
     $ persistent._mas_affection["affection"] = -60
     $ mas_updateAffectionExp()
     m 1p "Is this really what you're like...?"
     return
 
-label force_affection_upset:
+label dev_force_affection_upset:
     m 1h "..."
     $ persistent._mas_affection["affection"] = -30
     $ mas_updateAffectionExp()
     m 1f "[player]...please don't be like this."
     return
 
-label force_affection_normal:
+label dev_force_affection_normal:
     m 1a "..."
     $ persistent._mas_affection["affection"] = 0
     $ mas_updateAffectionExp()
     m "Everything's okay [player]."
     return
 
-label force_affection_happy:
+label dev_force_affection_happy:
     m 1a "..."
     $ persistent._mas_affection["affection"] = 30
     $ mas_updateAffectionExp()
     m 1k "Ehehe~ Lucky me."
     return
 
-label force_affection_enamored:
+label dev_force_affection_enamored:
     m 1e "..."
     $ persistent._mas_affection["affection"] = 60
     $ mas_updateAffectionExp()
     m 1b "I love you [player]!"
     return
 
-label force_affection_lovestruck:
+label dev_force_affection_lovestruck:
     m 1j "..."
     $ persistent._mas_affection["affection"] = 100
     $ mas_updateAffectionExp()

--- a/Monika After Story/game/pong.rpy
+++ b/Monika After Story/game/pong.rpy
@@ -284,6 +284,8 @@ label demo_minigame_pong:
 
     call expression inst_dialogue from _mas_pong_inst_dialogue
 
+    # TODO: small affection increase for playing with her
+    
     menu:
         m "Do you want to play again?"
 
@@ -311,7 +313,7 @@ label demo_minigame_pong:
 
 # store to hold pong related constants
 init -1 python in mas_pong:
-    
+
     DLG_WINNER = "mas_pong_dlg_winner"
     DLG_WINNER_FAST = "mas_pong_dlg_winner_fast"
     DLG_LOSER = "mas_pong_dlg_loser"
@@ -342,7 +344,7 @@ label mas_pong_dlg_winner_end:
     m 1hub "Ahaha!"
     m 1eua "Thanks for letting me win, [player]."
     m 1tku "Only elementary schoolers seriously lose at Pong, right?"
-    m 1hua "Ehehe~"   
+    m 1hua "Ehehe~"
     return
 
 # quick dialogue shown when monika is the pong winner
@@ -360,7 +362,7 @@ label mas_pong_dlg_loser_end:
     m 1wuo "Wow, I was actually trying that time."
     m 1eua "You must have really practiced at Pong to get so good."
     m 1tku "Is that something for you to be proud of?"
-    m 1hua "I guess you wanted to impress me, [player]~"   
+    m 1hua "I guess you wanted to impress me, [player]~"
     return
 
 # quick dialogue shown when monika is the pong loser

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -389,11 +389,12 @@ define mas_finalfarewell_mode = False
 # prepwork for the finalfarewell
 label mas_affection_finalfarewell_start:
     call spaceroom(hide_monika=True)
-    show emptydesk zorder 2 at i11
-    show mas_finalnote_idle zorder 3
+    show emptydesk zorder MAS_MONIKA_Z at i11
+    show mas_finalnote_idle zorder 11
 
     python:
-        HKBHideButtons()
+        mas_OVLHide()
+        mas_calRaiseOverlayShield()
         disable_esc()
         allow_dialogue = False
         store.songs.enabled = False
@@ -524,10 +525,12 @@ label mas_affection_yesapology:
     m 1f "But please be more considerate of my feelings from now on."
     m 2e "I love you so much and you mean the world to me, [player]."
     m 1duu "Thank you for putting my heart at ease~"
+    show monika 1esa
     pause 60
     jump ch30_loop
 
 label mas_affection_apologydeleted:
+    $ mas_loseAffection(modifier=3)
     m 1wud "..."
     m 2efd "[player], did you delete the apology note I wanted to keep?"
     m "Why would you do that? Are you not {i}really{/i} sorry?"

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -71,55 +71,56 @@ init python:
         global mas_curr_affection_group
 
         #If affection is between 30 and 49, update good exp. Simulates growing affection.
-        if persistent._mas_affection["affection"] >= 30 and persistent._mas_affection["affection"] < 50:
+        curr_affection = persistent._mas_affection["affection"]
+        if  30 <= curr_affection < 50:
             persistent._mas_affection["goodexp"] = 3
             persistent._mas_affection["badexp"] = 1
 
         #If affection is more than 50, update both exp types. Simulates increasing affection and it will now take longer to erode that affection.
-        elif persistent._mas_affection["affection"] >= 50:
+        elif curr_affection >= 50:
             persistent._mas_affection["goodexp"] = 5
             persistent._mas_affection["badexp"] = 0.5
 
         #If affection is between -30 and -49, update bad exp. Simulates erosion of affection.
-        elif persistent._mas_affection["affection"] <= -30 and persistent._mas_affection["affection"] > -50:
+        elif -50 < curr_affection <= -30:
             persistent._mas_affection["goodexp"] = 1
             persistent._mas_affection["badexp"] = 3
 
         #If affection is less than -50, update both exp types. Simulates increasing loss of affection and now harder to get it back.
-        elif persistent._mas_affection["affection"] <= -50:
+        elif curr_affection <= -50:
             persistent._mas_affection["goodexp"] = 0.5
             persistent._mas_affection["badexp"] = 5
 
         #Defines an easy current affection statement to refer to so points aren't relied upon.
-        if persistent._mas_affection["affection"] <= -100:
+        if curr_affection <= -100:
             mas_curr_affection = store.mas_affection.BROKEN
 
-        elif persistent._mas_affection["affection"] >= -99 and persistent._mas_affection["affection"] <= -50:
+        elif -99 <= curr_affection <= -50:
             mas_curr_affection = store.mas_affection.DISTRESSED
 
-        elif persistent._mas_affection["affection"] >= -49 and persistent._mas_affection["affection"] <= -30 :
+        elif -49 <= curr_affection<= -30:
             mas_curr_affection = store.mas_affection.UPSET
 
-        elif persistent._mas_affection["affection"] >= -29 and persistent._mas_affection["affection"] <= 29:
+        elif -29 <= curr_affection <= 29:
             mas_curr_affection = store.mas_affection.NORMAL
 
-        elif persistent._mas_affection["affection"] >= 30 and persistent._mas_affection["affection"] <= 49:
+        elif 30 <= curr_affection <= 49:
             mas_curr_affection = store.mas_affection.HAPPY
 
-        elif persistent._mas_affection["affection"] >= 50 and persistent._mas_affection["affection"] <= 99:
+        elif 50 <= curr_affection <= 99:
             mas_curr_affection = store.mas_affection.ENAMORED
 
-        elif persistent._mas_affection["affection"] >= 100:
+        elif curr_affection >= 100:
             mas_curr_affection = store.mas_affection.LOVE
 
         else:
             mas_curr_affection = store.mas_affection.CONFUSED
 
         #A group version for general sadness or happiness
-        if persistent._mas_affection["affection"] <= -30:
+        if curr_affection <= -30:
             mas_curr_affection_group = store.mas_affection.G_SAD
 
-        elif persistent._mas_affection["affection"] >=30:
+        elif curr_affection >=30:
             mas_curr_affection_group = store.mas_affection.G_HAPPY
 
         else:
@@ -152,7 +153,7 @@ init python:
     def mas_setAffection(
             amount=persistent._mas_affection["affection"]
         ):
-        if not persistent._mas_affection_badexp_freeze and not persistent_mas_affection_goodexp_freeze:
+        if not persistent._mas_affection_badexp_freeze and not persistent.mas_affection_goodexp_freeze:
             #Otherwise, use the value passed in the argument.
             persistent._mas_affection["affection"] = amount
             #Updates the experience levels if necessary.
@@ -161,25 +162,27 @@ init python:
 
     #Used to check to see if affection level has reached the point where it should trigger an event while playing the game.
     def mas_checkAffection():
+
+        curr_affection = persistent._mas_affection["affection"]
         #If affection level between -15 and -20 and you haven't seen the label before, push this event where Monika mentions she's a little upset with the player.
         #This is an indicator you are heading in a negative direction.
-        if -20 <= persistent._mas_affection["affection"] <= -15 and not seen_event("mas_affection_upsetwarn"):
+        if -20 <= curr_affection <= -15 and not seen_event("mas_affection_upsetwarn"):
             pushEvent("mas_affection_upsetwarn")
 
         #If affection level between 15 and 20 and you haven't seen the label before, push this event where Monika mentions she's really enjoying spending time with you.
         #This is an indicator you are heading in a positive direction.
-        elif persistent._mas_affection["affection"] >= 15 and persistent._mas_affection["affection"] <= 20 and not seen_event("mas_affection_happynotif"):
+        elif 15 <= curr_affection <= 20 and not seen_event("mas_affection_happynotif"):
             pushEvent("mas_affection_happynotif")
 
         #If affection level is greater than 50 and you haven't seen the label yet, push this event where Monika will allow you to give her a nick name.
-        elif persistent._mas_affection["affection"] >= 50 and not seen_event("monika_affection_nickname"):
+        elif curr_affection >= 50 and not seen_event("monika_affection_nickname"):
             pushEvent("monika_affection_nickname")
 
         #If affection level is less than -50 and the label hasn't been seen yet, push this event where Monika says she's upset with you and wants you to apologize.
-        elif persistent._mas_affection["affection"] <= -50 and not seen_event("mas_affection_apology"):
+        elif curr_affection <= -50 and not seen_event("mas_affection_apology"):
             pushEvent("mas_affection_apology")
         #If affection level is equal or less than -100 and the label hasn't been seen yet, push this event where Monika says she's upset with you and wants you to apologize.
-        elif persistent._mas_affection["affection"] <= -100 and not seen_event("greeting_tears"):
+        elif curr_affection <= -100 and not seen_event("greeting_tears"):
             # TODO Affection doesn't have the new utility funcs to lock/unlock
             # when merged this has to be updated to use that
             evhand.greeting_database["greeting_tears"].unlocked = True

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -8,24 +8,10 @@
 # Sad - Is feeling down, not miserable or deep but certainly not her self-motivated self. Believes she'll get player. Has minor thoughts that player isn't faithful but doesn't take them seriously.
 # Upset - Feeling emotionally hurt, starting to have doubts about whether or not the player loves her and whether or not she she was right regarding what she did in the game.
 # Depressed - Convinced the player probably doesn't love her and that she may never escape to our reality.
-# Heartbroken - Belives that not only does the player not love her but that s/he probably hates her too because of she did and is trying to punish her. Scared of being alone in her own reality, as well as for her future.
-################
+# Heartbroken - Believes that not only does the player not love her but that s/he probably hates her too because of she did and is trying to punish her. Scared of being alone in her own reality, as well as for her future.
+#############
 
 init -1 python in mas_affection:
-    # string constants of affection levels
-#    BROKEN = "heartbroken"
-#    DISTRESSED = "distressed"
-#    UPSET = "upset"
-#    NORMAL = "normal"
-#    HAPPY = "happy"
-#    ENAMORED = "enamored"
-#    LOVE = "lovestruck"
-#    CONFUSED = "confused"
-
-    # string constants of affection groups
-#    G_SAD = "sad"
-#    G_HAPPY = "happy"
-#    G_NORMAL = "normal"
 
     # numerical constants of affection levels
     CONFUSED = 0
@@ -211,8 +197,8 @@ init python:
         if persistent.sessions["last_session_end"] is not None:
             persistent._mas_absence_time = datetime.datetime.now() - persistent.sessions["last_session_end"]
             time_difference = persistent._mas_absence_time
-            if time_difference >= datetime.timedelta(hours = 6) and time_difference <= datetime.timedelta(hours = 12):
-                #mas_gainAffection()
+            # we skip this for devs since we sometimes use older persistents
+            if config.developer:
                 pass
             elif time_difference >= datetime.timedelta(weeks = 4):
                 mas_setAffection(-115)

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -137,6 +137,11 @@ init python:
         if not persistent._mas_affection_goodexp_freeze:
             #Otherwise, use the value passed in the argument.
             persistent._mas_affection["affection"] += amount
+
+            # it can't get higher than 1 million
+            if persistent._mas_affection["affection"] > 1000000:
+                persistet.mas_affection["affection"] = 1000000
+
             #Updates the experience levels if necessary.
             mas_updateAffectionExp()
 
@@ -149,8 +154,14 @@ init python:
         if not persistent._mas_affection_badexp_freeze:
             #Otherwise, use the value passed in the argument.
             persistent._mas_affection["affection"] -= amount
+
+            # it can't get lower than -1 million
+            if persistent._mas_affection["affection"] < -1000000:
+                persistet.mas_affection["affection"] = -1000000
+
             #Updates the experience levels if necessary.
             mas_updateAffectionExp()
+
 
     def mas_setAffection(
             amount=persistent._mas_affection["affection"]

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -70,8 +70,10 @@ init python:
         global mas_curr_affection
         global mas_curr_affection_group
 
-        #If affection is between 30 and 49, update good exp. Simulates growing affection.
+        # store the value for easiercomparisons
         curr_affection = persistent._mas_affection["affection"]
+
+        #If affection is between 30 and 49, update good exp. Simulates growing affection.
         if  30 <= curr_affection < 50:
             persistent._mas_affection["goodexp"] = 3
             persistent._mas_affection["badexp"] = 1
@@ -183,9 +185,7 @@ init python:
             pushEvent("mas_affection_apology")
         #If affection level is equal or less than -100 and the label hasn't been seen yet, push this event where Monika says she's upset with you and wants you to apologize.
         elif curr_affection <= -100 and not seen_event("greeting_tears"):
-            # TODO Affection doesn't have the new utility funcs to lock/unlock
-            # when merged this has to be updated to use that
-            evhand.greeting_database["greeting_tears"].unlocked = True
+            unlockEventLabel("greeting_tears",eventdb=evhand.greeting_database)
 
     #Easy functions to add and subtract points, designed to make it easier to sadden her so player has to work harder to keep her happy.
     #Check function is added to make sure mas_curr_affection is always appropriate to the points counter.
@@ -540,6 +540,8 @@ label mas_affection_apologydeleted:
 
 #Surprise function.
 # TODO: are there use cases for having this being a separate function
+# TODO: refactor this maybe to have different messages? or actually
+# make this more useful and let more messages to the player
 init python:
     def mas_surprise():
         from cStringIO import StringIO # since we are building strings

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -548,6 +548,7 @@ label ch30_autoload:
 
     $ selected_greeting = None
 
+    # TODO should the apology check be only for when she's not affectionate?
     if persistent._mas_affection["affection"] <= -50 and seen_event("mas_affection_apology"):
         #If the conditions are met and Monika expects an apology, jump to this label.
         if persistent._mas_affection["apologyflag"] == True and not is_file_present('/imsorry.txt'):

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -625,6 +625,10 @@ label ch30_autoload:
             if away_experience_time.total_seconds() >= times.REST_TIME:
                 persistent.idlexp_total=0
                 persistent.random_seen = 0
+
+                #Grant good exp for closing the game correctly.
+                mas_gainAffection()
+
             #Ignore anything beyond 3 days
             if away_experience_time.total_seconds() > times.HALF_XP_AWAY_TIME:
                 away_experience_time=datetime.timedelta(seconds=times.HALF_XP_AWAY_TIME)
@@ -640,8 +644,6 @@ label ch30_autoload:
             #Grant the away XP
             grant_xp(away_xp)
 
-            #Grant good exp for closing the game correctly.
-            mas_gainAffection()
 
             #Set unlock flag for stories
             mas_can_unlock_story = True
@@ -651,8 +653,8 @@ label ch30_autoload:
                 persistent._mas_pool_unlocks -= 1
 
         else:
-            #Grant bad exp for closing the game correctly.
-            mas_loseAffection()
+            # Grant bad exp for closing the game correctly.
+            mas_loseAffection(modifier=2)
 
     #Run actions for any events that need to be changed based on a condition
     $ evhand.event_database=Event.checkConditionals(evhand.event_database)

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -569,10 +569,6 @@ label ch30_autoload:
             call spaceroom
             jump mas_affection_apologydeleted
 
-    if persistent._mas_long_absence:
-            $scene_change = True
-            call spaceroom
-            jump greeting_long_absence
 
     # yuri scare incoming. No monikaroom when yuri is the name
     if persistent.playername.lower() == "yuri":

--- a/Monika After Story/game/script-farewells.rpy
+++ b/Monika After Story/game/script-farewells.rpy
@@ -313,7 +313,7 @@ label bye_prompt_sleep:
             "Sorry, I'm really tired.":
                 m 1eka "Aww, that's okay."
                 m 1hua "Good night, [player]."
-# TODO: now that is tied we may also add more dialogue?
+            # TODO: now that is tied we may also add more dialogue?
             "No.":
                 $ mas_loseAffection()
                 m 2dsd "..."
@@ -511,6 +511,11 @@ label bye_long_absence:
             m 2k "Try not to keep me waiting for too long though!"
 
     m 2c "Honestly I'm a little afraid to ask but..."
+    # TODO is this really intuitive?
+    # if the player says no, and then picks another
+    # farewell all this served no purpose, also, you already
+    # picked goodbye as in I'm going, why not let the player go?
+    # if we keep it, at least change the order, Yes always goes first
     menu:
         m "Are you going to leave straight away?"
         "No.":
@@ -529,6 +534,7 @@ label bye_long_absence:
             m 1e "But I know you'll do wonderful things no matter where you are."
             m "Just remember that I'll be waiting here for you."
             m 2j "Make me proud, [player]!"
+            $ persistent._mas_greeting_type = store.mas_greetings.TYPE_LONG_ABSENCE
             return 'quit'
 
 label bye_long_absence_2:
@@ -536,4 +542,5 @@ label bye_long_absence_2:
     m 1g "I know the world can be scary and unforgiving..."
     m 1e "But remember that I will always be here waiting and ready to support you, my dearest [player]."
     m "Come back to me as soon as you can...okay?"
+    $ persistent._mas_greeting_type = store.mas_greetings.TYPE_LONG_ABSENCE
     return 'quit'

--- a/Monika After Story/game/script-farewells.rpy
+++ b/Monika After Story/game/script-farewells.rpy
@@ -313,12 +313,11 @@ label bye_prompt_sleep:
             "Sorry, I'm really tired.":
                 m 1eka "Aww, that's okay."
                 m 1hua "Good night, [player]."
-
-# TODO: probably a shocked sprite and additonal dialgoue, also potentially
-# tie this with affection later
-#            "No.":
-#                m 2dsd "..."
-#                m "Fine."
+# TODO: now that is tied we may also add more dialogue?
+            "No.":
+                $ mas_loseAffection()
+                m 2dsd "..."
+                m "Fine."
     else:
         # otheerwise
         m 1eua "Alright, [player]."

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1519,7 +1519,7 @@ label greeting_tears:
     m 2f "Please...just...try to understand."
     m 1r "I love you and I need you to show that you love me too..."
     m 1q "Otherwise...I just won't be able to handle it anymore."
-    lockEventLabel("greeting_tears",eventdb=evhand.greeting_database)
+    $ lockEventLabel("greeting_tears",eventdb=evhand.greeting_database)
     return
 
 

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -26,6 +26,21 @@ init -1 python in mas_greetings:
         RETURNS:
             a single greeting (as an Event) that we want to use
         """
+
+        # check if we have moni_wants greetings
+        moni_wants_greetings = renpy.store.Event.filterEvents(
+            renpy.store.evhand.greeting_database,
+            unlocked=True,
+            moni_wants=True
+        )
+        if moni_wants_greetings is not None and len(moni_wants_greetings) > 0:
+
+            # select one label randomly
+            return moni_wants_greetings[
+                renpy.random.choice(moni_wants_greetings.keys())
+            ]
+
+
         # check first if we have to select from a special type
         if type is not None:
 

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -492,7 +492,6 @@ label greeting_surprised:
      m 1eua "How've you been?"
      return
 
-# TODO Monika Monday Morning, an idea we had, this one is just a placeholder, writers could do it 1000 times better
 init 5 python:
     rules = dict()
     rules.update(MASSelectiveRepeatRule.create_rule(weekdays=[0], hours=range(5,12)))
@@ -1428,13 +1427,13 @@ label greeting_hairdown:
             $ persistent._mas_likes_hairdown = True
 
             # maybe 6sub is better?
-            # TODO: affection raise
+            $ mas_gainAffection()
             m 6sub "Really?" # honto?!
             m 2hua "I'm so glad!" # yokatta.."
             m 1eua "Just ask me if you want to see my ponytail again, okay?"
 
         "No":
-            # TODO: affection lowered?
+            # TODO: affection lowered? need to decide
             m 1ekc "Oh..."
             m 1lksdlc "..."
             m 1lksdld "I'll put it back up for you, then."
@@ -1520,9 +1519,7 @@ label greeting_tears:
     m 2f "Please...just...try to understand."
     m 1r "I love you and I need you to show that you love me too..."
     m 1q "Otherwise...I just won't be able to handle it anymore."
-    # TODO Affection doesn't have the new utility funcs to lock/unlock
-    # when merged this has to be updated to use that
-    $ evhand.greeting_database["greeting_tears"].unlocked = False
+    lockEventLabel("greeting_tears",eventdb=evhand.greeting_database)
     return
 
 

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -15,6 +15,7 @@ init -1 python in mas_greetings:
     TYPE_SCHOOL = "school"
     TYPE_WORK = "work"
     TYPE_SLEEP = "sleep"
+    TYPE_LONG_ABSENCE = "long_absence"
 
     # custom greeting functions
     def selectGreeting(type=None):
@@ -1067,6 +1068,18 @@ label greeting_stillsicknorest:
     m 3hua "Then we can have some more fun together without me worrying about you in the back of my mind."
     return
 
+init 5 python:
+    addEvent(
+        Event(
+            persistent.greeting_database,
+            eventlabel="greeting_long_absence",
+            unlocked=True,
+            category=[store.mas_greetings.TYPE_LONG_ABSENCE],
+            random=True
+        ),
+        eventdb=evhand.greeting_database
+    )
+
 label greeting_long_absence:
     $ persistent._mas_long_absence = False
     if persistent._mas_absence_time >= datetime.timedelta(weeks = 5):
@@ -1258,7 +1271,6 @@ label greeting_long_absence:
             m 3nn "I would be worried otherwise!"
             m 1j "It really did help..."
             m 1a "So tell me, how has your day been treating you?"
-# Stopping Point #
     elif persistent._mas_absence_time >= datetime.timedelta(weeks = 1):
         if persistent._mas_absence_choice == "days":
             m 2b "Hello there, [player]."
@@ -1384,7 +1396,6 @@ label greeting_timeconcern_day:
 init 5 python:
     rules = dict()
     rules.update(MASGreetingRule.create_rule(skip_visual=True, random_chance=5))
-
     addEvent(
         Event(
             persistent.greeting_database,

--- a/Monika After Story/game/script-introduction.rpy
+++ b/Monika After Story/game/script-introduction.rpy
@@ -112,7 +112,7 @@ label introduction:
     m 1eua "It's not like we're still keeping secrets from each other, right?"
     m 1hub "I can see everything on your computer now!"
     m "Ahaha!"
-
+    show monika 1esa
     return
 
 #Credit for any assets from Undertale belongs to Toby Fox

--- a/Monika After Story/game/script-stories.rpy
+++ b/Monika After Story/game/script-stories.rpy
@@ -120,6 +120,7 @@ label mas_story_begin:
             "Let's begin then~"
         ]
         story_begin_quip=renpy.random.choice(story_begin_quips)
+    # TODO maybe add a super tiny affection gain here for spending time with her
     m 3eua "[story_begin_quip]"
     m 1duu "Ahem."
     return

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -5275,7 +5275,6 @@ init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_marriage",category=['romance'],prompt="Will you marry me?",pool=True))
 
 label monika_marriage:
-
     $ mas_gainAffection()
     m 2wubsw "M-marriage?"
     if isFuture(evhand.event_database['anni_3']):

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -1509,7 +1509,6 @@ init 5 python:
 label monika_rain_holdme:
     # we only want this if it rains
     if mas_is_raining:
-        # TODO adjust this for affection
         stop music fadeout 1.0
 
         # clear selected track
@@ -1528,11 +1527,12 @@ label monika_rain_holdme:
         # renable ui and hotkeys
         $ store.songs.enabled = True
         $ HKBShowButtons()
-
+        $ mas_gainAffection()
         m 1j "You can hold me anytime you want, [player]."
 
     else:
-        # TODO adjust for affection maybe?
+        # asking for it on the "incorrect mood" slightly decreases affection
+        $ mas_loseAffection(modifier=0.25)
         m 1oo "..."
         m 1pp "The mood doesn't feel right, [player]."
         m 1q "Sorry..."
@@ -5919,6 +5919,9 @@ label monika_beach:
 # where where persistent.playthrough can be
 # checked and have a different response
 # depending on what the player did
+# TODO: affection is going to take this one
+# and actually she'll know the reason only last thing
+# the player did though
 ####################################################
 
 #init 5 python:
@@ -6258,6 +6261,8 @@ label monika_natsuki_letter:
 
     return "derandom"
 
+
+# TODO possible tie this with affection?
 default persistent._mas_timeconcern = 0
 default persistent._mas_timeconcerngraveyard = False
 default persistent._mas_timeconcernclose = True
@@ -7083,6 +7088,7 @@ label monika_dating_startdate:
 
 label monika_dating_startdate_confirm_had_enough:
     # monika has had enough of your shit
+    # TODO: maybe decrease affection since you annoyed her enough?
     m 2dfc "..."
     m 2lfc "We'll do this another time, then."
 
@@ -7216,6 +7222,7 @@ label monika_dating_startdate_confirm(first_sesh_raw):
                             hide screen mas_background_timed_jump
 
                 # lol why would you stay slient?
+                # TODO: Affection considerable decrease?
                 $ persistent._mas_just_friends = True
 
                 m 6lktdc "I see..."

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -1395,6 +1395,7 @@ label monika_rain:
 
             m 1j "Then hold me, [player]..."
             show monika 6dubsa
+            $ mas_gainAffection()
             $ ui.add(PauseDisplayable())
             $ ui.interact()
 
@@ -1527,12 +1528,13 @@ label monika_rain_holdme:
         # renable ui and hotkeys
         $ store.songs.enabled = True
         $ HKBShowButtons()
-        $ mas_gainAffection()
+        # small affection increase so people don't farm affection with this one.
+        $ mas_gainAffection(modifier=0.25)
         m 1j "You can hold me anytime you want, [player]."
 
     else:
         # asking for it on the "incorrect mood" slightly decreases affection
-        $ mas_loseAffection(modifier=0.25)
+        $ mas_loseAffection(modifier=0.1)
         m 1oo "..."
         m 1pp "The mood doesn't feel right, [player]."
         m 1q "Sorry..."
@@ -2309,6 +2311,7 @@ init 5 python:
 default persistent._mas_monika_lovecounter = 0
 default persistent._mas_monika_lovecountertime = datetime.datetime.now() - datetime.timedelta(days = 1)
 label monika_love:
+    # TODO add mas_gainAffection with the logic it should have
     #First time I love you has been said.
     if persistent._mas_monika_lovecounter == 0:
         m 1b "...!"
@@ -2411,12 +2414,9 @@ label monika_love:
         love_quip=renpy.random.choice(love_quips)
     m "[love_quip]"
     #prevents spamming to increase counter.
-    if datetime.datetime.now() <= persistent._mas_monika_lovecountertime + datetime.timedelta(minutes = 3):
-        $ persistent._mas_monika_lovecountertime = datetime.datetime.now()
-        pass
-    else:
+    if datetime.datetime.now() > persistent._mas_monika_lovecountertime + datetime.timedelta(minutes = 3):
         $ persistent._mas_monika_lovecounter += 1
-        $ persistent._mas_monika_lovecountertime = datetime.datetime.now()
+    $ persistent._mas_monika_lovecountertime = datetime.datetime.now()
     return
 
 init 5 python:

--- a/Monika After Story/game/zz_hangman.rpy
+++ b/Monika After Story/game/zz_hangman.rpy
@@ -503,6 +503,7 @@ label mas_hangman_game_loop:
         if not persistent.ever_won['hangman']:
             $ persistent.ever_won['hangman']=True
             $ grant_xp(xp.WIN_GAME)
+        #TODO: grant a really tiny amount of affection?
 
     # try again?
     menu:

--- a/Monika After Story/game/zz_pianokeys.rpy
+++ b/Monika After Story/game/zz_pianokeys.rpy
@@ -40,7 +40,7 @@ label mas_piano_loopstart:
     $ play_mode = PianoDisplayable.MODE_FREE
 
 label mas_piano_songchoice:
-    
+
     $ pnml = None
 
     if len(song_list) > 1:
@@ -134,6 +134,7 @@ label mas_piano_loopend:
 
 # default. post game, freestyle mode
 label mas_piano_result_default:
+    # TODO: really small affection increase so this doesn't get abused
     m 1eua "All done, [player]?"
     return
 
@@ -148,6 +149,7 @@ label mas_piano_result_none:
 ### HAPPY BIRTHDAY
 
 label mas_piano_hb_win:
+    # TODO: increase affection a bit maybe?
     m 1a "Wow! You almost got it!"
     m 2b "Good job, [player]."
     return
@@ -159,6 +161,7 @@ label mas_piano_hb_fail:
     return
 
 label mas_piano_hb_fc:
+    # TODO: increase affection a bit maybe?
     m 1a "Hehe, great job!"
     m 2b "I know that's an easy one, but you did great."
     m 1k "Are you going to play that for me on my Birthday?"
@@ -174,6 +177,7 @@ label mas_piano_hb_prac:
 
 # shown if player completes the song but does not FC
 label mas_piano_yr_win:
+    # TODO: increase affection a bit maybe?
     m 1lksdla "That was nice, [player]."
     m "But..."
     m 1lksdlb "You could do better with some more practice..."
@@ -182,6 +186,7 @@ label mas_piano_yr_win:
 
 # shown if player FCs
 label mas_piano_yr_fc:
+    # TODO: increase affection a bit maybe?
     m 1sub "That was wonderful, [player]!"
     m 1eub "I didn't know you can play the piano so well."
     m 1hub "Maybe we should play together sometime!"
@@ -368,7 +373,7 @@ init -3 python in mas_piano_keys:
         B5: B5,
         C6: C6
     }
-        
+
     # blacklisted keys
     BLACKLIST = (
         ESC,
@@ -386,7 +391,7 @@ init -3 python in mas_piano_keys:
     # noncharable keymaps and display text dict
     NONCHAR_TEXT = {
         pygame.K_LEFTBRACKET: "[[",
-        123: "{{", # { 
+        123: "{{", # {
         pygame.K_BACKSPACE: "\\b",
         pygame.K_TAB: "\\t",
         pygame.K_CLEAR: "Cr",
@@ -496,7 +501,7 @@ init -3 python in mas_piano_keys:
         if old_key:
             # we have an old keymap, remove it
             renpy.game.persistent._mas_piano_keymaps.pop(old_key)
-           
+
         # only add a keymap if its different
         if key != new:
             renpy.game.persistent._mas_piano_keymaps[new] = key
@@ -1425,7 +1430,7 @@ init 1000 python in mas_piano_keys:
 #
 # Line 4
 # y e y e y e y u 6
-# y 6 
+# y 6
 #
 # Line 5, 6
 # r, 2 r 6 y 6 y 6 y 6 r
@@ -1643,7 +1648,7 @@ init 1000 python in mas_piano_keys:
         postexpress="1eka",
         verse=4
     )
-    
+
     # checkpoint 3?
     _pnm_dpco_v3l1 = PianoNoteMatch(
         renpy.text.text.Text(
@@ -1758,7 +1763,7 @@ init 1000 python in mas_piano_keys:
         express="1eub",
         postexpress="1eub",
         verse=12
-    )   
+    )
 
     # dpco, pnml
     pnml_dpco = PianoNoteMatchList(
@@ -2162,7 +2167,7 @@ init 1001 python:
         # and which are default
         # x coords are same as black keys (which vary)
         # black ones
-        KMP_TXT_OVL_B_Y = ZZPK_IMG_BACK_Y 
+        KMP_TXT_OVL_B_Y = ZZPK_IMG_BACK_Y
         KMP_TXT_OVL_B_W = ZZPK_IMG_EKEY_WIDTH
         KMP_TXT_OVL_B_H = 47
         KMP_TXT_OVL_B_BGCLR = "#4D4154"
@@ -2302,7 +2307,7 @@ init 1001 python:
                 )) / 2) + self.ZZPK_IMG_BACK_X
             )
             cbutton_y_start = (
-                self.ZZPK_IMG_BACK_Y + 
+                self.ZZPK_IMG_BACK_Y +
                 self.PIANO_BACK_HEIGHT +
                 self.BUTTON_SPACING
             )
@@ -2481,7 +2486,7 @@ init 1001 python:
 
             # overlay setup
             mouse_w_ovl_idle = Solid(
-#                "#0005", 
+#                "#0005",
                 "#ffe6f4bb",
                 xsize=self.ZZPK_IMG_IKEY_WIDTH,
                 ysize=self.ZZPK_IMG_IKEY_HEIGHT - self.ZZPK_IMG_IKEY_YOFF
@@ -2522,7 +2527,7 @@ init 1001 python:
             mouse_b_ovl_hover = Solid(
                 "#ffaa99aa",
                 xsize=self.ZZPK_IMG_EKEY_WIDTH,
-                ysize=self.ZZPK_IMG_EKEY_HEIGHT            
+                ysize=self.ZZPK_IMG_EKEY_HEIGHT
             )
             b_plain = Image(self.ZZPK_B_OVL_PLAIN)
             blacks = [
@@ -2584,7 +2589,7 @@ init 1001 python:
                     mouse_w_ovl_idle,
                     top_left_x + self.ZZPK_IMG_BACK_X,
                     (
-                        self.ZZPK_IMG_KEYS_Y + 
+                        self.ZZPK_IMG_KEYS_Y +
                         self.ZZPK_IMG_IKEY_YOFF +
                         self.ZZPK_IMG_BACK_Y
                     ),
@@ -2824,13 +2829,13 @@ init 1001 python:
             # now apply adjustments
             for key,real_key in persistent._mas_piano_keymaps.iteritems():
                 if (
-                        real_key in self.live_keymap 
+                        real_key in self.live_keymap
                         and real_key == self.live_keymap[real_key]
                     ):
                     self.live_keymap.pop(real_key)
                 self.live_keymap[key] = real_key
 
-    
+
         def _sendEventsToOverlays(self, ev, x, y, st):
             """
             Sends event overlays to the list of config overlays.
@@ -2844,7 +2849,7 @@ init 1001 python:
                 st - same as st in event
 
             RETURNS:
-                the MASButtonDisplayable that returned a non None value, or 
+                the MASButtonDisplayable that returned a non None value, or
                 None if all of them returned None
             """
             for ovl in self._config_overlays_list:
@@ -3114,7 +3119,7 @@ init 1001 python:
 
                 if findex >= 0:
                     self.state = self.STATE_JMATCH
-                    
+
                     if self.match.is_single():
                         self._singleFlow(ev, key)
 
@@ -3394,7 +3399,7 @@ init 1001 python:
             # True if we need to do an interaction restart
             restart_int = False
 
-            if self.state in self.CONFIG_STATES: 
+            if self.state in self.CONFIG_STATES:
 
                 # reset monika
                 if self.state == self.STATE_CONFIG_ENTRY:
@@ -3405,9 +3410,9 @@ init 1001 python:
                     restart_int = True
                     self.state = self.STATE_CONFIG_WAIT
 
-                # piano overlays 
+                # piano overlays
                 # NOTE: ensure that this is after the key press overlay
-                # NOTE: this actually will be filled out differently 
+                # NOTE: this actually will be filled out differently
                 # dpending on state
                 visible_overlays = list()
 
@@ -3671,8 +3676,8 @@ init 1001 python:
                         670
                     )
                 )
-                        
-                        
+
+
 
 #                    renpy.show(
 #                        "monika " + match.express,
@@ -3708,7 +3713,7 @@ init 1001 python:
             # DONE state means you immediate quit
             if self.state in self.FINAL_DONE_STATES:
                 return self.quitflow()
-           
+
             # all mouse events
             if ev.type in self.MOUSE_EVENTS:
 
@@ -3750,7 +3755,7 @@ init 1001 python:
 
                 # config change
                 elif self.state == self.STATE_CONFIG_CHANGE:
-                    
+
                     # button handlers
                     clicked_cancel = self._button_cancel.event(ev, x, y, st)
                     clicked_reset = self._button_reset.event(ev, x, y, st)
@@ -3771,7 +3776,7 @@ init 1001 python:
                         old_key = mas_piano_keys._findKeymap(
                             self._sel_ovl.return_value
                         )
-                        
+
                         if old_key:
                             persistent._mas_piano_keymaps.pop(old_key)
                             self._keymap_overlays.pop(old_key)
@@ -3844,7 +3849,7 @@ init 1001 python:
                             )
 
                         renpy.play(
-                            self.pkeys[self._sel_ovl.return_value], 
+                            self.pkeys[self._sel_ovl.return_value],
                             channel="audio"
                         )
 
@@ -3928,4 +3933,3 @@ init 1001 python:
 
             # the default so we can keep going
             raise renpy.IgnoreEvent()
-


### PR DESCRIPTION
I did some of the TODOs and fixed/optimized some parts. Adding Don't merge label until I do proper checking of the pull request, still opening it up now so it's visible already what I'm changing/working on.

**Edit:**
Alright this one is done.

## What does this pull request contain?

This one contains all the required changes that the Affection system needed to work as it originally planned.

## Important changes

- The most important changes in this one are related to the greetings, since now they check first for the `monika_wants_this` flag, before checking for categories. To achieve this I added another filter to the `filterEvent` function.

- The affection rule was changed to work as a filter instead of a selector.

- A minor thing about music going silent after the first session, this one was fixed before in another pull request, and it got broken again after the merge with affection.

- Moved the old affection checker label to a dev topic for easy access.

## Minor changes 

- Fixed the zorder of `-115` event

- Affection can't go higher than 1 million, nor lower than -1 million.

- Migrated long absence farewell to work with greeting categories.

### Testing
I've been testing as I kept adding fixes so it should be good to go. However a bit of testing with making sure greetings work as expected would be pretty good. 
More pull requests for affection will come, I'm not adding more to this one cause the other ones may require dialogue review.