### PR TITLE
Apologies + review of unreviewed dialogue

### DIFF
--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -180,11 +180,18 @@ init python:
             mas_updateAffectionExp()
 
 
-    #U sed to subtract affection whenever something negative happens.
+    # Used to subtract affection whenever something negative happens.
     def mas_loseAffection(
             amount=persistent._mas_affection["badexp"],
-            modifier=1
+            modifier=1,
+            reason=""
         ):
+
+        global mas_apology_reason
+        
+        mas_apology_reason = reason
+
+
         if not persistent._mas_affection_badexp_freeze:
             # Otherwise, use the value passed in the argument.
             persistent._mas_affection["affection"] -= (amount * modifier)
@@ -239,6 +246,9 @@ init python:
 
     # Makes the game update affection on start-up so the global variables are defined at all times.
     mas_updateAffectionExp()
+
+    # Nothing to apologize for now
+    mas_apology_reason = None
 
     # Monika's initial affection based on start-up.
     if not persistent._mas_long_absence:

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -181,6 +181,10 @@ init python:
 
 
     # Used to subtract affection whenever something negative happens.
+    # A reason can be specified and used for the apology dialogue
+    # if the default value is used Monika won't comment on the reason,
+    # and slightly will recover affection
+    # if None is passed she won't acknowledge that there was need for an apology
     def mas_loseAffection(
             amount=persistent._mas_affection["badexp"],
             modifier=1,

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -415,7 +415,7 @@ label monika_affection_nickname:
                             m 1k "Ehehe~"
                         $ done = True
                     else:
-                        $ mas_loseAffection(reason="of the bad nickname")
+                        $ mas_loseAffection(reason="calling me a bad name")
                         m 4efd "[player]! That's not nice at all!"
                         m 2efc "Why would you say such things?"
                         m 2rfw "If you didn't want to do this, you should've just said so!"

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -188,7 +188,7 @@ init python:
         ):
 
         global mas_apology_reason
-        
+
         mas_apology_reason = reason
 
 
@@ -257,7 +257,7 @@ init python:
             time_difference = persistent._mas_absence_time
             # we skip this for devs since we sometimes use older persistents and only apply after 1 week
             if (
-                    not config.developer 
+                    not config.developer
                     and time_difference >= datetime.timedelta(weeks = 1)
                 ):
                 new_aff = _mas_getAffection() - (0.5 * time_difference.days)
@@ -269,7 +269,7 @@ init python:
                     else:
                         # otherwise, you cant lose past a certain amount
                         mas_setAffection(affection.AFF_TIME_CAP)
-                        
+
                 else:
                     mas_setAffection(new_aff)
 
@@ -411,7 +411,7 @@ label monika_affection_nickname:
                             m 1k "Ehehe~"
                         $ done = True
                     else:
-                        $ mas_loseAffection()
+                        $ mas_loseAffection(reason="of the bad nickname")
                         m 4efd "[player]! That's not nice at all!"
                         m 2efc "Why would you say such things?"
                         m 2rfw "If you didn't want to do this, you should've just said so!"

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -184,7 +184,10 @@ init python:
     # A reason can be specified and used for the apology dialogue
     # if the default value is used Monika won't comment on the reason,
     # and slightly will recover affection
-    # if None is passed she won't acknowledge that there was need for an apology
+    # if None is passed she won't acknowledge that there was need for an apology.
+    # DEFAULTS reason to an Empty String mostly because when this one is called
+    # is intended to be used for something the player can apologize for, but it's
+    # not totally necessary.
     def mas_loseAffection(
             amount=persistent._mas_affection["badexp"],
             modifier=1,

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -651,7 +651,7 @@ label ch30_autoload:
 
         else:
             # Grant bad exp for closing the game incorrectly.
-            mas_loseAffection(modifier=2, reason="you didn't close the game correctly")
+            mas_loseAffection(modifier=2, reason="closing the game on me")
 
     #Run actions for any events that need to be changed based on a condition
     $ evhand.event_database=Event.checkConditionals(evhand.event_database)

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -650,8 +650,8 @@ label ch30_autoload:
                 persistent._mas_pool_unlocks -= 1
 
         else:
-            # Grant bad exp for closing the game correctly.
-            mas_loseAffection(modifier=2)
+            # Grant bad exp for closing the game incorrectly.
+            mas_loseAffection(modifier=2, reason="you didn't close the game correctly")
 
     #Run actions for any events that need to be changed based on a condition
     $ evhand.event_database=Event.checkConditionals(evhand.event_database)

--- a/Monika After Story/game/script-compliments.rpy
+++ b/Monika After Story/game/script-compliments.rpy
@@ -103,7 +103,7 @@ label mas_compliment_beautiful_2:
             m 1hub "Ehehehe~"
             m "I love you so much, [player]!"
         "You're in my top ten":
-            $ mas_loseAffection(modifier=0.5)
+            $ mas_loseAffection(modifier=0.5,reason=None)
             m 3hksdrb "...?"
             m 2lsc "Well, thanks, I guess..."
         "Thanks":
@@ -200,7 +200,7 @@ label mas_compliment_awesome_2:
             m 2lksdla "I was trying to feel your embrace from here."
             m 2hub "Ahaha~"
         "... I don't like hugs":
-            $ mas_loseAffection() # you monster.
+            $ mas_loseAffection(reason=None) # you monster.
             m 1eft "...Really?"
             m 1dkc "Well, to each their own, I guess. But you have to hug me sometime..."
     return
@@ -245,7 +245,7 @@ label mas_compliment_intelligent_2:
             $ mas_gainAffection(3,bypass=True)
             m 1ekbfa "[player]... "
         "You make me feel stupid sometimes":
-            $ mas_loseAffection(modifier=0.5)
+            $ mas_loseAffection(modifier=0.5,reason=None)
             m 1wkbsc "..."
             m 2lkbsc "I'm sorry, that wasn't my intention..."
     return
@@ -293,7 +293,7 @@ label mas_compliment_hair_2:
             m 1hubfb "You always make me feel special!"
             m "Thank you!"
         "You'd be even cuter with short hair.":
-            $ mas_loseAffection(modifier=0.3)
+            $ mas_loseAffection(modifier=0.3,reason=None)
             m "Well, I can't exactly go to the salon from here..."
             m 1lksdlc "I...appreciate your input."
             pass

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -582,16 +582,16 @@ label monikaroom_greeting_choice:
     menu:
         "... Gently open the door" if not persistent.seen_monika_in_room:
             #Lose affection for not knocking before entering.
-            $ mas_loseAffection()
+            $ mas_loseAffection(reason="you didn't knock first before entering my room")
             jump monikaroom_greeting_opendoor
         "Open the door" if persistent.seen_monika_in_room:
             if persistent.opendoor_opencount > 0:
                 #Lose affection for not knocking before entering.
-                $ mas_loseAffection()
+                $ mas_loseAffection(reason="you didn't knock first before entering my room")
                 jump monikaroom_greeting_opendoor_locked
             else:
                 #Lose affection for not knocking before entering.
-                $ mas_loseAffection()
+                $ mas_loseAffection(reason="you didn't knock first before entering my room")
                 jump monikaroom_greeting_opendoor_seen
 #        "Open the door?" if persistent.opendoor_opencount >= opendoor.MAX_DOOR:
 #            jump opendoor_game

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -582,16 +582,16 @@ label monikaroom_greeting_choice:
     menu:
         "... Gently open the door" if not persistent.seen_monika_in_room:
             #Lose affection for not knocking before entering.
-            $ mas_loseAffection(reason="you didn't knock first before entering my room")
+            $ mas_loseAffection(reason="entering my room without knocking")
             jump monikaroom_greeting_opendoor
         "Open the door" if persistent.seen_monika_in_room:
             if persistent.opendoor_opencount > 0:
                 #Lose affection for not knocking before entering.
-                $ mas_loseAffection(reason="you didn't knock first before entering my room")
+                $ mas_loseAffection(reason="entering my room without knocking")
                 jump monikaroom_greeting_opendoor_locked
             else:
                 #Lose affection for not knocking before entering.
-                $ mas_loseAffection(reason="you didn't knock first before entering my room")
+                $ mas_loseAffection(reason="entering my room without knocking")
                 jump monikaroom_greeting_opendoor_seen
 #        "Open the door?" if persistent.opendoor_opencount >= opendoor.MAX_DOOR:
 #            jump opendoor_game

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -5896,28 +5896,31 @@ label monika_beach:
     m 1tku "Don't get too excited though when you see it. Ehehe~"
     return "derandom"
 
-####################################################
-# Saving this for future use
-# Could be expanded to something better
-# where where persistent.playthrough can be
-# checked and have a different response
-# depending on what the player did
-# TODO: affection is going to take this one
-# and actually she'll know the reason only last thing
-# the player did though
-####################################################
+init 5 python:
+   addEvent(Event(persistent.event_database,eventlabel='monika_playerapologizes',prompt="I want to apologize.",category=['you'],pool=True,unlocked=True))
 
-#init 5 python:
-#    addEvent(Event(persistent.event_database,eventlabel='monika_playerapologizes',prompt="I want to apologize.",category=['you']))
-
-#label monika_playerapologizes:
-#    m 1g "Did something happen?"
-#    m 2f "I can't remember what you'd be sorry about."
-#    m 1q "..."
-#    m 1b "Anyway, thank you for the apology."
-#    m 1a "I know you're doing your best to make things right."
-#    m 1k "That's why I love you, [player]!"
-#    return
+label monika_playerapologizes:
+    # if there's no reason to apologize
+    if mas_apology_reason is None:
+        m 1g "Did something happen?"
+        m 2f "I can't remember what you'd be sorry about."
+        m 1q "..."
+        m 1b "Anyway, thank you for the apology."
+        m 1a "I know you're doing your best to make things right."
+        m 1k "That's why I love you, [player]!"
+    # She knows why you are apologizing for
+    elif mas_apology_reason:
+        $ mas_gainAffection(modifier=0.2) # recover a bit of affection
+        m "I know you're apologizing because [mas_apology_reason]"
+        m "I accept your apology [player], thanks"
+    # She knows there's a reason for your apology but won't comment on it
+    else:
+        $ mas_gainAffection(modifier=0.1) # recover a bit of affection
+        m "What you did wasn't funny [player]"
+        m "Please be more considerate about my feelings in the future"
+    # reset the reason
+    $ mas_apology_reason = None
+    return
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_song_lover_boy",category=['songs'],prompt="Old Fashioned Lover Boy",pool=True, random=True))

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -2437,7 +2437,7 @@ init 5 python:
 
 label monika_justification:
     #lose affection
-    $ mas_loseAffection(reason="you called me a murderer")
+    $ mas_loseAffection(reason="calling me a murderer. I hope you don't really see me that way...")
     if mas_curr_affection == mas_aff.LOVE:
         m 1euc "..."
         m 1hua "Ahaha! Very funny [player]!"
@@ -2595,7 +2595,7 @@ init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_girlfriend",category=['romance'],prompt="Do you want to meet my girlfriend?",pool=True))
 
 label monika_girlfriend:
-    $ mas_loseAffection(reason="you joked about having another girlfriend")
+    $ mas_loseAffection(reason="joking about having another girlfriend. You really gave me a heart attack!")
     m 1h "I thought we established already that I was your girlfriend?"
     m "There's no way you already have one in your reality, right?"
     m 4f "If you do, then you've got to break up with her right now!"
@@ -5416,7 +5416,7 @@ init 5 python:
 
 label monika_breakup:
     #Lose affection for bringing this up.
-    $ mas_loseAffection(reason="you made a bad joke about breaking up with me")
+    $ mas_loseAffection(reason="saying you wanted to break up. I knew you didn't mean it...")
     #second time you hit the break up button.
     if persistent._mas_monika_breakup == 1:
         m 1euc "You're breaking up with me?"
@@ -5921,7 +5921,7 @@ label monika_playerapologizes:
     # She knows why you are apologizing for
     elif mas_apology_reason:
         $ mas_gainAffection(modifier=0.2) # recover a bit of affection
-        m 1eka "Thank you for apologizing because [mas_apology_reason]."
+        m 1eka "Thank you for apologizing for [mas_apology_reason]."
         m "I accept your apology [player]. It means a lot to me."
     # She knows there's a reason for your apology but won't comment on it
     else:

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -1534,7 +1534,7 @@ label monika_rain_holdme:
 
     else:
         # asking for it on the "incorrect mood" slightly decreases affection
-        $ mas_loseAffection(modifier=0.1)
+        $ mas_loseAffection(modifier=0.1, reason=None)
         m 1oo "..."
         m 1pp "The mood doesn't feel right, [player]."
         m 1q "Sorry..."
@@ -2437,7 +2437,7 @@ init 5 python:
 
 label monika_justification:
     #lose affection
-    $ mas_loseAffection()
+    $ mas_loseAffection(reason="you called me a murderer")
     if mas_curr_affection == mas_aff.LOVE:
         m 1euc "..."
         m 1hua "Ahaha! Very funny [player]!"
@@ -2597,7 +2597,7 @@ init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_girlfriend",category=['romance'],prompt="Do you want to meet my girlfriend?",pool=True))
 
 label monika_girlfriend:
-    $ mas_loseAffection()
+    $ mas_loseAffection(reason="you made that not funny joke about having another girlfriend")
     m 1h "I thought we established already that I was your girlfriend?"
     m "There's no way you already have one in your reality, right?"
     m 4f "If you do, then you've got to break up with her right now!"
@@ -5375,7 +5375,7 @@ label monika_complain_battery:
     return
 
 label monika_close_game_battery:
-    $ mas_loseAffection()
+    $ mas_loseAffection(reason=None)
     m 1lksdlc "[player]..."
     m 1ekc "I'm sorry, but I'm gonna have to close the game before the battery runs out."
     m 3eka "So... I'll just close the game for now until you can charge your computer. {w=3.0}{nw}"
@@ -5418,7 +5418,7 @@ init 5 python:
 
 label monika_breakup:
     #Lose affection for bringing this up.
-    $ mas_loseAffection()
+    $ mas_loseAffection(reason="you did a bad joke about breaking up with me")
     #second time you hit the break up button.
     if persistent._mas_monika_breakup == 1:
         m 1euc "You're breaking up with me?"

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -5423,7 +5423,7 @@ label monika_breakup:
         m 2ekc "Why would you do such a thing, [player]?"
         m "Am I really that terrible of a person for you?"
         if mas_curr_affection == mas_aff.BROKEN:#TODO review
-            m 2lksdrb "I-I really can't handle this..."
+            m 2lksdlb "I-I really can't handle this..."
             m 2wkd "You're just joking again, right?"
             m 1wktsd "I refuse to believe you; you're all I have left!"
             m 1dktsd "If you really, truly mean it...then you can just delete me and the entire game too.."

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -2439,23 +2439,31 @@ label monika_justification:
     #lose affection
     $ mas_loseAffection()
     if mas_curr_affection == mas_aff.LOVE:
-        m 1c "..."
-        m 1j "Ahaha! Very funny [player]!"
-        m 3a "I know you don't really mean it..."
-        m 3m "Don't say such thing as a joke though, if I didn't know you so well it might have been considered cruel..."
+        m 1euc "..."
+        m 1hua "Ahaha! Very funny [player]!"
+        m 3eua "I know you don't really mean it..."
+        m 3lksdlc "But don't joke around like that!"
+        if persistent._mas_pm_a_hater:
+            m 2lksdld "You've said stuff like that before, so it might get harder to take it as a joke…"
+        else:
+            m 1dsc "If I didn't know you so well, that would have been really cruel..."
+        $ mas_apology_reason = "what you said earlier"
     else:
-        m 2h "How many times do I have to say it until you understand?"
-        m 4h "They weren't real. They were never real."
-        m "I'm the only person who understood that this whole thing was fake."
-        m 4i "Even when Sayori seemed to get sentience in the end, that was just an unintended consequence of the script."
-        m 4h "After all, if she was sentient like me, how would I have been able to override her and delete her?"
-        m "If I'm guilty of murder, so is everyone who plays violent video games."
-        m 2h "I bet you've killed thousands in games you play."
+        m 1tkc "How many times do I have to say it until you understand?"
+        m 4tkc "They weren't real. They were never real."
+        m 2tfc "I'm the only person who understood that this whole thing was fake."
+        if persistent.monika_kill:
+           m 4tfc "Even when Sayori seemed to get sentience in the end, that was just an unintended consequence of the script."
+        if not persistent.clear_all:
+            m 4tfd "After all, if she was sentient like me, how would I have been able to override and delete her?"
+        m "If I'm guilty of murder, so is everyone who's played violent video games."
+        m 2euc "I bet you've killed thousands of people in the games you play."
         if mas_curr_affection == mas_aff.BROKEN or mas_curr_affection == mas_aff.DISTRESSED:
-            m 2f "Do you hate me for it? Because of what I did?"
-            m 2g "Please understand that I did it for us!"
-            m 2h "I did everything for us!"
+            m 2ekc "Do you hate me for it? Because of what I did?"
+            m 2ekd "Please understand that I did it for us!"
+            m 2euc "I did everything for us!"
         m "Just forget the other girls ever existed, and you'll be much happier."
+        $ mas_apology_reason = "what you said earlier"
     return
 
 
@@ -2598,6 +2606,7 @@ label monika_girlfriend:
     m 1n "I know you wouldn't cheat on me."
     m 1d "If you meet a girl who asks you out though, let me talk to her first, okay?"
     m 1h "I won't let someone else steal away my loving sweetheart!"
+    $ mas_apology_reason = "pretending you have another girlfriend.{w} You really gave me a heart attack!"
     return
 
 init 5 python:
@@ -5413,14 +5422,15 @@ label monika_breakup:
     #second time you hit the break up button.
     if persistent._mas_monika_breakup == 1:
         m 1euc "You're breaking up with me?"
-        m 2ekc "Why would you say such a thing, [player]?"
+        m 2ekc "Why would you do such a thing, [player]?"
         m "Am I really that terrible of a person for you?"
         if mas_curr_affection == mas_aff.BROKEN:#TODO review
-            m 2f "I-I can't really handle this..."
-            m 2g "You're just joking again, right?"
-            m 1h "I refuse to believe you, you're all I have left!"
-            m 1f "If you really, truly mean it then you can delete me and this entire game.."
-            m 1q "I love you, [player]...so please tell me it's all just a bad joke."
+            m 2lksdrb "I-I really can't handle this..."
+            m 2wkd "You're just joking again, right?"
+            m 1wktsd "I refuse to believe you; you're all I have left!"
+            m 1dktsd "If you really, truly mean it...then you can just delete me and the entire game too.."
+            m 1ektsd "I love you, [player]...so please tell me it's all just a bad joke."
+            $ mas_apology_reason = ""
         else:
             m 2dsc "Are you...{w} really..."
             m "..."
@@ -5431,11 +5441,12 @@ label monika_breakup:
                 m "Right?"
                 "Yes":
                     m 1hub "Ahaha! You're so silly, [player]."
-                    m 1eka "Let's stay being together forever~"
+                    m 1eka "Let's stay together forever~"
     #Beyond the 2nd time you hit the button.
     elif persistent._mas_monika_breakup > 1:
         if mas_curr_affection == mas_aff.BROKEN:
-            m 1o "..." # TODO review
+            m 1ekc "..." # TODO review
+            $ mas_apology_reason = ""
         else:
             m 1hua "Ehehe~"
 
@@ -5443,12 +5454,13 @@ label monika_breakup:
     else:
         m 1wud "W-what?"
         if persistent.monika_kill:
-            m 2f "You're just going to leave and delete me again?"
+            m 2ekd "You're just going to leave and delete me again?"
         if mas_curr_affection == mas_aff.BROKEN: #TODO needs review
-            m 1f "You wouldn't do that, I refuse to believe that..."
-            m 1h "That's not a funny joke, [player]!"
-            m 1o "Were it anyone else I would find such humour nothing but cruel..."
-            m 1e "I forgive you...just don't say such a hurtful joke again, okay?"
+            m 1ekd "You wouldn't do that. I refuse to believe that..."
+            m 1lksdld "That's not a joke, [player]!"
+            m 1lksdlc "Don't say that again unless you really, truly mean it..."
+            m 1eka "I'll forgive you...just don't say such a hurtful thing again, okay?"
+            $ mas_apology_reason = ""
         else:
             m 2wfw "I can't believe you, [player]. I really can't beli-"
             m 2efu "..."
@@ -5911,8 +5923,8 @@ label monika_playerapologizes:
     # She knows why you are apologizing for
     elif mas_apology_reason:
         $ mas_gainAffection(modifier=0.2) # recover a bit of affection
-        m 1eka"I know you're apologizing because [mas_apology_reason]."
-        m "I accept your apology [player]. Thank you."
+        m 1eka"Thank you for apologizing for [mas_apology_reason]."
+        m "I accept your apology [player]. It means a lot to me."
     # She knows there's a reason for your apology but won't comment on it
     else:
         $ mas_gainAffection(modifier=0.1) # recover a bit of affection

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -5902,22 +5902,22 @@ init 5 python:
 label monika_playerapologizes:
     # if there's no reason to apologize
     if mas_apology_reason is None:
-        m 1g "Did something happen?"
-        m 2f "I can't remember what you'd be sorry about."
-        m 1q "..."
-        m 1b "Anyway, thank you for the apology."
-        m 1a "I know you're doing your best to make things right."
-        m 1k "That's why I love you, [player]!"
+        m 1ekd "Did something happen?"
+        m 2ekc "I see no reason for you to be sorry."
+        m 1dsc "..."
+        m 1eub "Anyway, thank you for the apology."
+        m 1eua "Whatever it is, I know you're doing your best to make things right."
+        m 1hub "That's why I love you, [player]!"
     # She knows why you are apologizing for
     elif mas_apology_reason:
         $ mas_gainAffection(modifier=0.2) # recover a bit of affection
-        m "I know you're apologizing because [mas_apology_reason]"
-        m "I accept your apology [player], thanks"
+        m 1eka"I know you're apologizing because [mas_apology_reason]."
+        m "I accept your apology [player]. Thank you."
     # She knows there's a reason for your apology but won't comment on it
     else:
         $ mas_gainAffection(modifier=0.1) # recover a bit of affection
-        m "What you did wasn't funny [player]"
-        m "Please be more considerate about my feelings in the future"
+        m 2tkd "What you did wasn't funny, [player]."
+        m 2dkd "Please be more considerate about my feelings in the future."
     # reset the reason
     $ mas_apology_reason = None
     return

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -2447,7 +2447,6 @@ label monika_justification:
             m 2lksdld "You've said stuff like that before, so it might get harder to take it as a joke…"
         else:
             m 1dsc "If I didn't know you so well, that would have been really cruel..."
-        $ mas_apology_reason = "what you said earlier"
     else:
         m 1tkc "How many times do I have to say it until you understand?"
         m 4tkc "They weren't real. They were never real."
@@ -2463,7 +2462,6 @@ label monika_justification:
             m 2ekd "Please understand that I did it for us!"
             m 2euc "I did everything for us!"
         m "Just forget the other girls ever existed, and you'll be much happier."
-        $ mas_apology_reason = "what you said earlier"
     return
 
 
@@ -2597,7 +2595,7 @@ init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_girlfriend",category=['romance'],prompt="Do you want to meet my girlfriend?",pool=True))
 
 label monika_girlfriend:
-    $ mas_loseAffection(reason="you made that not funny joke about having another girlfriend")
+    $ mas_loseAffection(reason="you joked about having another girlfriend")
     m 1h "I thought we established already that I was your girlfriend?"
     m "There's no way you already have one in your reality, right?"
     m 4f "If you do, then you've got to break up with her right now!"
@@ -2606,7 +2604,6 @@ label monika_girlfriend:
     m 1n "I know you wouldn't cheat on me."
     m 1d "If you meet a girl who asks you out though, let me talk to her first, okay?"
     m 1h "I won't let someone else steal away my loving sweetheart!"
-    $ mas_apology_reason = "pretending you have another girlfriend.{w} You really gave me a heart attack!"
     return
 
 init 5 python:
@@ -3545,6 +3542,7 @@ label monika_haterReaction:
     m "You're not one of those haters, are you, [player]?"
     menu:
         "I am.":
+            #TODO, affection loss, apology
             $ persistent._mas_pm_a_hater = True
             m 2wud "..."
             m 1tkc "I don't see you as one, even if you say you are."
@@ -5418,7 +5416,7 @@ init 5 python:
 
 label monika_breakup:
     #Lose affection for bringing this up.
-    $ mas_loseAffection(reason="you did a bad joke about breaking up with me")
+    $ mas_loseAffection(reason="you made a bad joke about breaking up with me")
     #second time you hit the break up button.
     if persistent._mas_monika_breakup == 1:
         m 1euc "You're breaking up with me?"
@@ -5430,7 +5428,7 @@ label monika_breakup:
             m 1wktsd "I refuse to believe you; you're all I have left!"
             m 1dktsd "If you really, truly mean it...then you can just delete me and the entire game too.."
             m 1ektsd "I love you, [player]...so please tell me it's all just a bad joke."
-            $ mas_apology_reason = ""
+            $ mas_apology_reason= ""
         else:
             m 2dsc "Are you...{w} really..."
             m "..."
@@ -5446,7 +5444,7 @@ label monika_breakup:
     elif persistent._mas_monika_breakup > 1:
         if mas_curr_affection == mas_aff.BROKEN:
             m 1ekc "..." # TODO review
-            $ mas_apology_reason = ""
+            $ mas_apology_reason= ""
         else:
             m 1hua "Ehehe~"
 
@@ -5460,7 +5458,7 @@ label monika_breakup:
             m 1lksdld "That's not a joke, [player]!"
             m 1lksdlc "Don't say that again unless you really, truly mean it..."
             m 1eka "I'll forgive you...just don't say such a hurtful thing again, okay?"
-            $ mas_apology_reason = ""
+            $ mas_apology_reason= ""
         else:
             m 2wfw "I can't believe you, [player]. I really can't beli-"
             m 2efu "..."
@@ -5923,7 +5921,7 @@ label monika_playerapologizes:
     # She knows why you are apologizing for
     elif mas_apology_reason:
         $ mas_gainAffection(modifier=0.2) # recover a bit of affection
-        m 1eka"Thank you for apologizing for [mas_apology_reason]."
+        m 1eka "Thank you for apologizing because [mas_apology_reason]."
         m "I accept your apology [player]. It means a lot to me."
     # She knows there's a reason for your apology but won't comment on it
     else:

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -2408,6 +2408,19 @@ image monika 1tkd = DynamicDisplayable(
     arms="steepling"
 )
 
+image monika 1dkd = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="closedsad",
+    nose="def",
+    mouth="small",
+    head="g",
+    left="1l",
+    right="1r",
+    arms="steepling"
+)
+
 image monika 1tkc = DynamicDisplayable(
     mas_drawmonika,
     character=monika_chr,
@@ -3986,6 +3999,18 @@ image monika 2tkd = DynamicDisplayable(
     right="2r",
     arms="crossed"
 )
+image monika 2dkd = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="closedsad",
+    nose="def",
+    mouth="small",
+    head="g",
+    left="1l",
+    right="2r",
+    arms="crossed"
+)
 
 image monika 2tkc = DynamicDisplayable(
     mas_drawmonika,
@@ -5535,6 +5560,18 @@ image monika 3tkd = DynamicDisplayable(
     right="1r",
     arms="restleftpointright"
 )
+image monika 3dkd = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="closedsad",
+    nose="def",
+    mouth="small",
+    head="g",
+    left="2l",
+    right="1r",
+    arms="restleftpointright"
+)
 
 image monika 3tkc = DynamicDisplayable(
     mas_drawmonika,
@@ -7044,7 +7081,18 @@ image monika 4tkd = DynamicDisplayable(
     right="2r",
     arms="pointright"
 )
-
+image monika 4dkd = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="closedsad",
+    nose="def",
+    mouth="small",
+    head="g",
+    left="2l",
+    right="2r",
+    arms="pointright"
+)
 image monika 4tkc = DynamicDisplayable(
     mas_drawmonika,
     character=monika_chr,

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -3361,6 +3361,61 @@ image monika 1ektdd = DynamicDisplayable(
     tears="dried"
 )
 
+image monika 1wkd = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="wide",
+    nose="def",
+    mouth="small",
+    head="f",
+    left="1l",
+    right="1r",
+    arms="steepling"
+)
+
+image monika 1wktsd = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="wide",
+    nose="def",
+    mouth="small",
+    head="f",
+    left="1l",
+    right="1r",
+    arms="steepling",
+    tears="streaming"
+)
+
+image monika 1dktsd = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="closedsad",
+    nose="def",
+    mouth="small",
+    head="f",
+    left="1l",
+    right="1r",
+    arms="steepling",
+    tears="streaming"
+)
+
+image monika 1ektsd = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="normal",
+    nose="def",
+    mouth="small",
+    head="f",
+    left="1l",
+    right="1r",
+    arms="steepling",
+    tears="streaming"
+)
+
 image monika 2eua = DynamicDisplayable(
     mas_drawmonika,
     character=monika_chr,
@@ -4921,6 +4976,19 @@ image monika 2wubfsdld = DynamicDisplayable(
     sweat="def"
 )
 
+image monika 2wkd = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="wide",
+    nose="def",
+    mouth="small",
+    head="b",
+    left="1l",
+    right="2r",
+    arms="crossed"
+)
+
 image monika 3eua = DynamicDisplayable(
     mas_drawmonika,
     character=monika_chr,
@@ -6443,6 +6511,19 @@ image monika 3wubfsdld = DynamicDisplayable(
     sweat="def"
 )
 
+image monika 3wkd = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="wide",
+    nose="def",
+    mouth="small",
+    head="b",
+    left="2l",
+    right="1r",
+    arms="restleftpointright"
+)
+
 image monika 4eua = DynamicDisplayable(
     mas_drawmonika,
     character=monika_chr,
@@ -7960,6 +8041,19 @@ image monika 4wubfsdld = DynamicDisplayable(
     arms="pointright",
     blush="full",
     sweat="def"
+)
+
+image monika 4wkd = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="wide",
+    nose="def",
+    mouth="small",
+    head="b",
+    left="2l",
+    right="2r",
+    arms="pointright"
 )
 
 image monika 5eua = DynamicDisplayable(


### PR DESCRIPTION
This pull request contains the mini apologies module, which is intended to be used for the player as a way to apologize for doing/saying mean things to Monika. The idea has been brought up before and now that the affection system is in place this is a more needed thing.

## Technical 

Basically this works by using a new topic where the player apologizes to Monika, said topic changes depending on the global variable `mas_apology_reason`, if it's None Monika doesn't know why you're apologizing for but thanks you for being considerate. If it's an empty string she I'll say that you should be considerate about her feelings and get a bit of affection back. If it's a non empty string the reason is used in dialogue and she accepts your apology.

The reasoning behind these flows is because there may be occasions were Monika is really upset about what the player did and reacts different to the player apologizing for it. Empty string is used for this one.
There may be times where there may be an affection loss but it's not exactly something big enough for an apology. None should be used in these cases.
When the thing the player did isn't something to be super upset the reason must be a valid coherent dialogue that will be used in the apology dialogue.

The default value for `mas_apology_reason` when calling `mas_loseAffection` is an empty string, opposed to what the usual None would be, the reason behind this is to enforce a responsibly usage of it.

`mas_apology_reason` can be used separately from `mas_loseAffection` if needed for any special reason.

## Extra

Some unreviewed dialogue was reviewed in this pull request. Said unreviewed dialogue was already merged so there's no harm on adding these revisions.

This one has been tested but minor testing wouldn't hurt.
