### PR TITLE
Init level adjustments

### DIFF
--- a/Monika After Story/game/chess.rpy
+++ b/Monika After Story/game/chess.rpy
@@ -388,7 +388,7 @@ init 1 python in mas_chess:
         return _checkInProgressGame(pgn_game, mth)
 
 
-init 999 python:
+init 899 python:
     # run init function
     store.mas_chess._initMASChess(MASQuipList)
 

--- a/Monika After Story/game/chess.rpy
+++ b/Monika After Story/game/chess.rpy
@@ -388,7 +388,7 @@ init 1 python in mas_chess:
         return _checkInProgressGame(pgn_game, mth)
 
 
-init 2018 python:
+init 999 python:
     # run init function
     store.mas_chess._initMASChess(MASQuipList)
 

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -1776,7 +1776,7 @@ init -1 python in _mas_root:
         persistent._mas_affection["affection"] = 0
 
 
-init -9900 python in mas_utils:
+init -990 python in mas_utils:
     import shutil
     mas_log = renpy.renpy.log.open("mas_log")
     mas_log_open = mas_log.open()

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -78,7 +78,7 @@ init -500 python:
     Event.INIT_LOCKDB = persistent._mas_event_init_lockdb
 
 
-init 1000 python:
+init 991 python:
     # mainly to create centralized database for calendar lookup
     # (and possible general db lookups)
     mas_all_ev_db = dict()

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -105,7 +105,7 @@ init python in mas_layout:
         store.layout.QUIT_NO = quit_no
 
 
-init 3000 python:
+init 900 python:
     import store.mas_layout
     store.mas_layout.setupQuits()
 

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -813,7 +813,7 @@ label mas_lupd_v0_8_3:
     return
 
 
-init 5000 python:
+init 999 python:
     for __temp_version in persistent._mas_zz_lupd_ex_v:
         __lupd_v = "mas_lupd_" + __temp_version
         if renpy.has_label(__lupd_v):

--- a/Monika After Story/game/zz_backup.rpy
+++ b/Monika After Story/game/zz_backup.rpy
@@ -1,6 +1,6 @@
 # module that does some file backup work
 
-init -9001 python:
+init -900 python:
     import os
     import store.mas_utils as mas_utils
 

--- a/Monika After Story/game/zz_pianokeys.rpy
+++ b/Monika After Story/game/zz_pianokeys.rpy
@@ -1381,7 +1381,7 @@ init -3 python in mas_piano_keys:
 
 
 # all songs are done in jsons now
-init 1000 python in mas_piano_keys:
+init 790 python in mas_piano_keys:
     import json
 
     # functions used for pnmls.
@@ -1532,7 +1532,7 @@ label mas_piano_dpco_prac:
     return
 
 
-init 1000 python in mas_piano_keys:
+init 800 python in mas_piano_keys:
     # d, piano note setup
     # verse 1
     # also checkpoint 1
@@ -1899,7 +1899,7 @@ init 1000 python in mas_piano_keys:
         return song_list, ("Nevermind", "None", False, False, 10)
 
 # make this later than mas_piano_keys
-init 1001 python:
+init 810 python:
     import store.mas_piano_keys as mas_piano_keys
 
     # setup named tuple dicts


### PR DESCRIPTION
Renpy suggests using init levels between -999 and 999. 

Probably should have read that.

Don't know if init levels could have caused missing stores, but this should scratch the possibility of these things being the cause of that

### Testing
* make sure everything still loads fine and works