### PR TITLE
Disabled renpy's updater for steam

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -2,6 +2,9 @@ define persistent.demo = False
 define persistent.steam = False
 define config.developer = False #This is the flag for Developer tools
 
+init 1 python:
+    persistent.steam = "steamapps" in config.basedir.lower()
+
 python early:
     import singleton
     me = singleton.SingleInstance()

--- a/Monika After Story/game/splash.rpy
+++ b/Monika After Story/game/splash.rpy
@@ -209,7 +209,6 @@ label splashscreen:
 
 
     #Check for game updates before loading the game or the splash screen
-#    call update_now from _call_update_now
 
     #autoload handling
     #Use persistent.autoload if you want to bypass the splashscreen on startup for some reason

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -1981,6 +1981,19 @@ image monika 1eksdlb = DynamicDisplayable(
     sweat="def"
 )
 
+image monika 1eksdla = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="normal",
+    nose="def",
+    mouth="smile",
+    head="m",
+    left="1l",
+    right="1r",
+    arms="steepling",
+    sweat="def"
+)
 
 image monika 1lksdlc = DynamicDisplayable(
     mas_drawmonika,
@@ -2164,6 +2177,19 @@ image monika 1efo = DynamicDisplayable(
     nose="def",
     mouth="gasp",
     head="i",
+    left="1l",
+    right="1r",
+    arms="steepling"
+)
+
+image monika 1efp = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="furrowed",
+    eyes="normal",
+    nose="def",
+    mouth="pout",
+    head="h",
     left="1l",
     right="1r",
     arms="steepling"

--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -671,8 +671,8 @@ init python in mas_updater:
 
             try:
                 os.rename(
-                    renpy.config.basedir + "/game/update",
-                    renpy.config.basedir + "/update"
+                    os.path.normcase(renpy.config.basedir + "/game/update"),
+                    os.path.normcase(renpy.config.basedir + "/update")
                 )
                 can_update = renpy.store.updater.can_update()
 
@@ -748,12 +748,45 @@ init 10 python:
         the_thread.start()
 
 
+label mas_updater_steam_issue:
+#    show monika at t11
+    m 1eub "[player]!{w} I see you're using Steam."
+    m 1eksdlb "Unfortunately..."
+    m 1efp "I can't run the updater because Steam is a meanie!"
+    m 1eksdla "You'll have to manually install the update from the releases page on Github.{w} {a=https://github.com/Monika-After-Story/MonikaModDev/releases}Click here to go to releases page{/a}."
+    m 1hua "Make sure to say goodbye to me first before installing the update."
+    return
+
+
 label forced_update_now:
     $ mas_updater.force = True
+
+    # steam check
+    if persistent.steam:
+
+        $ mas_RaiseShield_core()
+
+        call mas_updater_steam_issue
+
+        if store.mas_globals.dlg_workflow:
+            # current in dialogue workflow, we should only enable the escape
+            # and music stuff
+            $ enable_esc()
+            $ mas_MUMUDropShield()
+
+        else:
+            # otherwise, reenable core interactions
+            $ mas_DropShield_core()
+
+        return
 
 #This file goes through the actions for updating Monika After story
 label update_now:
     $import time #this instance of time can stay
+
+    # steam check
+    if persistent.steam:
+        return
 
     # screen check
     if renpy.showing("masupdateroverlay", layer="overlay"):


### PR DESCRIPTION
#1984 (and any mas_layout errors with steam versions)

I feel that PyTom envisioned the RenPy updater for usage with VNs that **aren't** on steam. 

Since perm errors are abundant with the built in updater and steam installs, this just disables in-game updating for steam builds. The game will still let you know if there's a newer version, but clicking "Update Now" will have monika tell you about how she cant update the game from here and ask you to manually update with a link.

### Testing
Best way to do this is to test in this order:
1. Launch game using renpy sdk.
2. Have Unstable checked so you it can find an update. (assuming that you are not running unstable already)
3. Click Update Now and check that it finds an update as it should. **Dont update**
4. Close game.
5. Copy rpycs from `game/` into steam version of DDLC's game folder.
6. Launch game using steam
7. You should still get the update slider.
8. Clicking update Now starts some dialogue
9. Clicking the link monika says to click opens the releases page.
10. When monika stops talking, context isn't broken.

### NOTES:
* this is in `content` because of 2 new expressions here (pouting and a smile sweat-drop version)
* I do have some dialogue, so getting that proofread would be nice
* `persistent.steam` is how we can check for steam now.