### PR TITLE
Attempt to lower chess difficulty

### DIFF
--- a/Monika After Story/game/chess.rpy
+++ b/Monika After Story/game/chess.rpy
@@ -481,7 +481,8 @@ init:
         class ChessDisplayable(renpy.Displayable):
             COLOR_WHITE = True
             COLOR_BLACK = False
-            MONIKA_WAITTIME = 1500
+#            MONIKA_WAITTIME = 1500
+            MONIKA_WAITTIME = 750
             MONIKA_OPTIMISM = 33
             MONIKA_THREADS = 1
 
@@ -685,6 +686,7 @@ init:
                 # Set Monika's parameters
                 self.stockfish.stdin.write("setoption name Skill Level value %d\n" % (persistent.chess_strength))
                 self.stockfish.stdin.write("setoption name Contempt value %d\n" % (self.MONIKA_OPTIMISM))
+                self.stockfish.stdin.write("setoption name Ponder value False\n") # dont let moni think during ur turn
 
                 # Set up facilities for asynchronous communication
                 self.queue = collections.deque()


### PR DESCRIPTION
#2016 #1969 

2 things:

1. disabled `Pondering` which makes Monika not think during player turn
2. cut monika's thinking time in half (from 1.5 seconds to 750 ms).

I have no idea if this will lower difficulty enough, so its more of a test.

### Testing
Make sure chess till works lol.