### PR TITLE
More gracious note matching in piano

### DIFF
--- a/Monika After Story/game/zz_pianokeys.rpy
+++ b/Monika After Story/game/zz_pianokeys.rpy
@@ -570,6 +570,11 @@ init -3 python in mas_piano_keys:
         "C6": C6
     }
 
+    # match notes to strings for displaying
+    KEYMAP_TO_STR = dict()
+    for k in JSON_KEYMAP:
+        KEYMAP_TO_STR[JSON_KEYMAP[k]] = k
+
 
 # FUNCTIONS ===================================================================
 
@@ -3754,7 +3759,10 @@ init 810 python:
                 if len(self.played) > 0:
                     played_text = renpy.render(
                         renpy.text.text.Text(
-                            "".join([chr(x) for x in self.played])
+                            "[[" + ", ".join([
+                                store.mas_piano_keys.KEYMAP_TO_STR.get(x,"")
+                                for x in self.played
+                            ]) + "]"
                         ),
                         1280,
                         720,

--- a/Monika After Story/game/zz_pianokeys.rpy
+++ b/Monika After Story/game/zz_pianokeys.rpy
@@ -1936,7 +1936,7 @@ init 810 python:
 
         # CONSTANTS
         # timeout
-        TIMEOUT = 1.0 # seconds
+        TIMEOUT = 1.5 # seconds
         SONG_TIMEOUT = 3.0 # seconds
         SONG_VIS_TIMEOUT = 4.0 # seconds
 #        FAIL_TIMEOUT = 4.0 # number of seconds to display awkward face on fail
@@ -3750,6 +3750,25 @@ init 810 python:
                         670
                     )
                 )
+
+                if len(self.played) > 0:
+                    played_text = renpy.render(
+                        renpy.text.text.Text(
+                            "".join([chr(x) for x in self.played])
+                        ),
+                        1280,
+                        720,
+                        st,
+                        at
+                    )
+                    rtw, rth = played_text.get_size()
+                    r.blit(
+                        played_text,
+                        (
+                            int((width - rtw) / 2),
+                            645
+                        )
+                    )
 
 
 


### PR DESCRIPTION
the default freestyle timeout of 1.0 second is brutal for adding custom songs.
Changing this to 1.5 worked nicer with @multimokia 's json.

Also added an additional bit of dev stuff with a visible string of the notes currently in the played queue. Should help people who are testing their songs.

### Testing
* Try multimokia's JSON available in discord. You should be able to match now pretty easily. You still have to play it somewhat quickly though.
* You should see a list of the notes you played at the bottom of the screen above the state. **only for dev mode**