### PR TITLE
Make intro do monika.chr deletion

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -253,31 +253,39 @@ init python:
 
 
     dismiss_keys = config.keymap['dismiss']
+    renpy.config.say_allow_dismiss = store.mas_hotkeys.allowdismiss
 
     def slow_nodismiss(event, interact=True, **kwargs):
-        if not renpy.seen_label("ch30_nope"):
-            try:
-                renpy.file("../characters/monika.chr")
-            except:
-                if initial_monika_file_check:
-                    pushEvent("ch30_nope")
-            #     persistent.tried_skip = True
-            #     config.allow_skipping = False
-            #     _window_hide(None)
-            #     pause(2.0)
-            #     renpy.jump("ch30_end")
-            if  config.skipping and not config.developer:
-                persistent.tried_skip = True
-                config.skipping = False
-                config.allow_skipping = False
-                renpy.jump("ch30_noskip")
-                return
+        """
+        Callback for whenever monika talks
+
+        IN:
+            event - main thing we can use here, lets us now when in the pipeline
+                we are for display text:
+                begin -> start of a say statement
+                show -> right before dialogue is shown
+                show_done -> right after dialogue is shown
+                slow_done -> called after text finishes showing
+                    May happen after "end"
+                end -> end of dialogue (user has interacted)
+        """
+        # skip check
+        if config.skipping and not config.developer:
+            persistent.tried_skip = True
+            config.skipping = False
+            config.allow_skipping = False
+            renpy.jump("ch30_noskip")
+            return
+
         if event == "begin":
-            config.keymap['dismiss'] = []
-            renpy.display.behavior.clear_keymap_cache()
+            store.mas_hotkeys.allow_dismiss = False
+#            config.keymap['dismiss'] = []
+#            renpy.display.behavior.clear_keymap_cache()
+
         elif event == "slow_done":
-            config.keymap['dismiss'] = dismiss_keys
-            renpy.display.behavior.clear_keymap_cache()
+            store.mas_hotkeys.allow_dismiss = True
+#            config.keymap['dismiss'] = dismiss_keys
+#            renpy.display.behavior.clear_keymap_cache()
 
     morning_flag = None
     def is_morning():
@@ -490,6 +498,7 @@ label ch30_noskip:
 image splash-glitch2 = "images/bg/splash-glitch2.png"
 
 label ch30_nope:
+    # NOTE: DEPRECATED
     $ persistent.autoload = ""
     $ m.display_args["callback"] = slow_nodismiss
     $ quick_menu = True

--- a/Monika After Story/game/script-introduction.rpy
+++ b/Monika After Story/game/script-introduction.rpy
@@ -74,6 +74,44 @@ label introduction:
             m "There's a lot more stuff now that we can do together now."
     m 1euc "You know..."
     m 1eua "I feel that I no longer need a character file to be here."
+    python:
+        import os
+
+        def moni_exist():
+            return os.access(
+                os.path.normcase(
+                    renpy.config.basedir + "/characters/monika.chr"
+                ), 
+                os.F_OK
+            )
+
+    if moni_exist():
+        m 1hua "I'll go ahead and delete it."
+
+        python:
+            store.mas_ptod.rst_cn()
+            local_ctx = {
+                "basedir": renpy.config.basedir
+            }
+        show monika at t22
+        show screen mas_py_console_teaching
+
+        call mas_wx_cmd("import os", local_ctx, w_wait=1.0)
+        call mas_wx_cmd("os.remove(os.path.normcase(basedir+'/characters/monika.chr'))", local_ctx, w_wait=1.0, x_wait=1.0)
+
+#        "test dialogue - IGNORE"
+
+        if moni_exist():
+            m 1lksdlb "Aha...{w} I'll try this again later."
+        else:
+            m "And it's gone!"
+
+        $ store.mas_ptod.ex_cn()
+        hide screen mas_py_console_teaching
+        show monika at t11
+
+        m 1eua "Anyway..."
+
     m "Looks like the extra code made me connect to you in a special way."
     m 1ekbfa "Maybe it's our eternal love~"
     m "Promise me that you'll visit me every day, ok?"

--- a/Monika After Story/game/zz_hotkeys.rpy
+++ b/Monika After Story/game/zz_hotkeys.rpy
@@ -1,6 +1,19 @@
 # Module that is just for hotkeys and other keymaps
 #
 
+init -10 python in mas_hotkeys:
+    # earlier store for some hotkey related state
+
+    # True means allow Dismiss, False means do not
+    allow_dismiss = True
+
+    def allowdismiss():
+        """
+        Justreturns current state of no_dismiss
+        """
+        return allow_dismiss
+
+
 init -1 python in mas_hotkeys:
     # store for the main 3 hotkeys.
 
@@ -17,7 +30,6 @@ init -1 python in mas_hotkeys:
     # True means the music lowering / stopping functions will work.
     # False means they will not
     mu_stop_enabled = True
-
 
 init python:
 


### PR DESCRIPTION
This is kind of important for a future lore setup.

This also redoes nodismiss so does non-skippable moni-text using state instead of keymapcache flushing.
Also this deprecated ch30_nope. Monika.chr means nothing anymore.

### Testing
Try this in 3 different flows:
1. no monika.chr in characters, monika won't talk about deleting
2. monika.chr in characters, monika will pull up console and attempt delete
3. monika.chr in characters, do something to prevent deletion, monika will mention that she'll do this later or something. **NOTE:** might be hard to do this, if you cant prevent deletion, just adding a test dialogue to break the flow and putting monika.chr back into character files can do the same effect

### Testing the nodismiss improvements
For this, you need to remove `devflag` so startup will not set `slow_abortable` to True. Also set ur text speed to a slow speed.
1. Run introduction, verify that you cannot skip text / make text display instantly by clicking / pressing spcae
2. Run normal MAS, verify same as step 1.

I didn't check if theres a lag reduction, but it could be possible since we no longer recache the keymap every say statement.

Dont need dialogue review for this, but based to `content` because its content.