### PR TITLE
Changing the default frequency for random chatter

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -3633,8 +3633,8 @@ default him = "him"
 default himself = "himself"
 
 
-# default is NORMAL
-default persistent._mas_randchat_freq = 1
+# default is OFTEN
+default persistent._mas_randchat_freq = 0
 define mas_randchat_prev = persistent._mas_randchat_freq
 init 1 python in mas_randchat:
     ### random chatter frequencies


### PR DESCRIPTION
New users who dont know about the random chatter setting may think Monika has nothing random to say anymore.

This changes the default setting to be Often instead of Normal, which results in monika having something to say within 30 seconds of idle start.

### Testing
1. Run a fresh, new game
2. Verify that the default random chatter setting is Often
3. Verify that random chatter is indeed more frequent 