### PR TITLE
Fix python tip not unlocking

### DIFF
--- a/Monika After Story/game/script-python.rpy
+++ b/Monika After Story/game/script-python.rpy
@@ -156,7 +156,15 @@ init 5 python:
     )
 
 label monika_ptod_tip001:
-    # first enable this event
+    
+    # speical stuff for unstablers
+    $ tip_ev = mas_getEV("monika_ptod_tip001")
+    if tip_ev.unlock_date is None:
+        $ import datetime
+        $ tip_ev.unlock_date = datetime.datetime.now()
+
+    if tip_ev.shown_count == 0:
+        $ tip_ev.shown_count = 1
 
     m 1esa "Python was created by Guido Van Rossum in the early '90s."
     m "It is super versatile, so you can find it in web apps, embedded systems, Linux, and of course..."

--- a/Monika After Story/game/script-python.rpy
+++ b/Monika After Story/game/script-python.rpy
@@ -133,6 +133,15 @@ label monika_ptod_tip000:
     m 1esa "Let's start with what Python even is."
 
     $ hideEventLabel("monika_ptod_tip000", depool=True)
+
+    # enable tip 1
+    $ import datetime
+    $ tip_ev = mas_getEV("monika_ptod_tip001")
+    $ tip_ev.pool = True
+    $ tip_ev.unlocked = True
+    $ tip_ev.unlock_date = datetime.datetime.now()
+    $ tip_ev.shown_count = 1
+
     jump monika_ptod_tip001
 
 ###############################################################################
@@ -148,9 +157,6 @@ init 5 python:
 
 label monika_ptod_tip001:
     # first enable this event
-    $ tip_ev = mas_getEV("monika_ptod_tip001")
-    $ tip_ev.pool = True
-    $ tip_ev.unlocked = True
 
     m 1esa "Python was created by Guido Van Rossum in the early '90s."
     m "It is super versatile, so you can find it in web apps, embedded systems, Linux, and of course..."


### PR DESCRIPTION
Python tip 1 didn't get unlock_date or shown_count set, which stopped the rest of the tips from unlocking.

Oops

### Testing
2 things to test: unlocking for unstablers and proper unlocking in general

**Proper unlock**:
1. set `persistent._mas_dev_enable_ptods` to False
2. run `mas_reset_ptods()` (game will quit)
3. Ask question > Python tips > Can you teach me about python?
4. When dialogue is done, check if event `monika_ptod_tip001` has an `unlock_date` and a `shown_count`.
5. Set the `unlock_date` to yesterday.
6. restart game. Verify that `monika_ptod_tip003` has `pool` set to True
7. Restart game. Verify that `Ask question > pyton tips > An interpreted language` exists

**unstable unlock**:
unstablers currently have `unlock_date` and `shown_count` for `monika_ptod_tip001` set to None and 0.
1. setup tip 1 to have None for `unlock_date` and 0 for `shown_count`
2. Ask queston > python tips > what is python
3. When dialogue is done, check that `unlock_date` and `shown_count` are now set.
4. You can verify that the nxt tip unlocks by following the proper unlock steps 5-7.

I'll ask someone from unstable to upload their persistent as a comment here, if they do that, then you can just run their persistent and follow the unstbale unlock steps 2-4 instead of having to do setup, just make sure you remove `dev_python` before running.

