### PR TITLE
Adding affection logging and more

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -1797,10 +1797,24 @@ init -1 python in _mas_root:
         persistent._mas_affection["affection"] = 0
 
 
+init -999 python:
+    import os
+
+    # this is initially set to 60 seconds
+    renpy.not_infinite_loop(120)
+
+    # create the log folder if not exist
+    if not os.access(os.path.normcase(renpy.config.basedir + "/log"), os.F_OK):
+        try:
+            os.mkdir(os.path.normcase(renpy.config.basedir + "/log"))
+        except:
+            pass
+
+
 init -990 python in mas_utils:
     import os
     import shutil
-    mas_log = renpy.renpy.log.open("mas_log")
+    mas_log = renpy.renpy.log.open("log/mas_log")
     mas_log_open = mas_log.open()
     mas_log.raw_write = True
 
@@ -1894,6 +1908,66 @@ init -990 python in mas_utils:
         except Exception as e:
             if log:
                 writelog("[exp] {0}\n".format(str(e)))
+
+
+    def logrotate(logpath, filename):
+        """
+        Does a log rotation. Log rotations contstantly increase. We defualt
+        to about 2 decimal places, but let the limit go past that
+
+        NOTE: exceptions are logged
+
+        IN:
+            logpath - path to the folder containing logs
+                NOTE: this is assumed to have the trailing slash
+            filename - filename of the log to rotate
+        """
+        try:
+            filelist = os.listdir(logpath)
+        except Exception as e:
+            writelog("[ERROR] " + str(e) + "\n")
+            return
+
+        # log rotation constants
+        __numformat = "{:02d}"
+        __numdelim = "."
+
+        # parse filelist for valid filenames,
+        # also sort them so the largest number is last
+        filelist = sorted([
+            x
+            for x in filelist
+            if x.startswith(filename)
+        ])
+
+        # now extract only the largest number in this list.
+        # NOTE: this is only possible if we have more than one file in the list
+        if len(filelist) > 1:
+            fname, dot, largest_num = filelist.pop().rpartition(__numdelim)
+            largest_num = tryparseint(largest_num, -1)
+
+        else:
+            # otherwise
+            largest_num = -1
+
+        # now increaese largest num to get the next number we should write out
+        largest_num += 1
+
+        # delete whatever file that is if it exists
+        new_path = os.path.normcase("".join([
+            logpath,
+            filename,
+            __numdelim,
+            __numformat.format(largest_num)
+        ]))
+        trydel(new_path)
+
+        # and copy our main file over
+        old_path = os.path.normcase(logpath + filename)
+        copyfile(old_path, new_path)
+
+        # and delete the current file
+        trydel(old_path)
 
 
 init -100 python in mas_utils:

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -670,6 +670,7 @@ init -10 python:
 
 
     def _mas_AffLoad():
+        new_value = 0
         if (
                 persistent._mas_pctaieibe is not None
                 and persistent._mas_pctaneibe is not None

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -45,6 +45,89 @@ init python:
     mas_curr_affection_group = store.mas_affection.G_NORMAL
 
 init -1 python in mas_affection:
+    import os
+    import datetime
+    import store.mas_utils as mas_utils
+    import store
+
+    # affection log rotate
+    #  we do rotations every 100 sessions
+    if store.persistent._mas_affection_log_counter is None:
+        # start counter if None
+        store.persistent._mas_affection_log_counter = 0
+
+    elif store.persistent._mas_affection_log_counter >= 100:
+        # if 100, do a logrotate
+        mas_utils.logrotate(
+            os.path.normcase(renpy.config.basedir + "/log/"),
+            "aff_log.txt"
+        )
+        store.persistent._mas_affection_log_counter = 0
+
+    else:
+        # otherwise increase counter
+        store.persistent._mas_affection_log_counter += 1
+
+    # affection log setup
+    log = renpy.renpy.log.open("log/aff_log", append=True)
+    log_open = log.open()
+    log.raw_write = True
+
+    # LOG messages
+    # [current datetime]: monikatopic | magnitude | prev -> new 
+    _audit = "[{0}]: {1} | {2} | {3} -> {4}\n"
+
+    # [current_datetime]: !FREEZE! | monikatopic | magnitude | prev -> new
+    _audit_f = "[{0}]: {5} | {1} | {2} | {3} -> {4}\n"
+    _freeze_text = "!FREEZE!"
+    _bypass_text = "!BYPASS!"
+
+    def audit(change, new, frozen=False, bypass=False, ldsv=None):
+        """
+        Audits a change in affection.
+
+        IN:
+            change - the amount we are changing by
+            new - what the new affection value will be
+            frozen - True means we were frozen, false measn we are not
+            bypass - True means we bypassed, false means we did not
+            ldsv - Set to the string to use instead of monikatopic
+                NOTE: for load / save operations ONLY
+        """
+        if ldsv is None:
+            piece_one = store.persistent.current_monikatopic
+        else:
+            piece_one = ldsv
+
+        if frozen:
+            
+            # decide what piece 5 is
+            if bypass:
+                piece_five = _bypass_text
+            else:
+                piece_five = _freeze_text
+                
+
+            audit_text = _audit_f.format(
+                datetime.datetime.now(),
+                piece_one,
+                change,
+                store.persistent._mas_affection["affection"],
+                new,
+                piece_five
+            )
+
+        else:
+            audit_text = _audit.format(
+                datetime.datetime.now(),
+                piece_one,
+                change,
+                store.persistent._mas_affection["affection"],
+                new
+            )
+
+        log.write(audit_text)
+
 
     # numerical constants of affection levels
     BROKEN = 1
@@ -576,10 +659,14 @@ default persistent._mas_pctadeibe = None
 
 init -10 python:
     def _mas_AffSave():
-        inum, nnum, dnum = mas_utils._splitfloat(_mas_getAffection())
+        aff_value = _mas_getAffection()
+        inum, nnum, dnum = mas_utils._splitfloat(aff_value)
         persistent._mas_pctaieibe = bytearray(mas_utils._itoIS(inum))
         persistent._mas_pctaneibe = bytearray(mas_utils._itoIS(nnum))
         persistent._mas_pctadeibe = bytearray(mas_utils._itoIS(dnum))
+
+        # audit this change
+        store.mas_affection.audit(aff_value, aff_value, ldsv="SAVE")
 
 
     def _mas_AffLoad():
@@ -599,14 +686,19 @@ init -10 python:
                     mas_utils.ISCRAM.from_buffer(persistent._mas_pctadeibe)
                 ))
                 if inum < 0:
-                    actual_value = inum - (nnum / dnum)
+                    new_value = inum - (nnum / dnum)
                 else:
-                    actual_value = inum + (nnum / dnum)
+                    new_value = inum + (nnum / dnum)
 
-                persistent._mas_affection["affection"] = actual_value
             except:
                 # dont break me yo
-                persistent._mas_affection["affection"] = 0
+                new_value = 0
+
+        # audit this change
+        store.mas_affection.audit(new_value, new_value, ldsv="LOAD")
+
+        # and set what we got
+        persistent._mas_affection["affection"] = new_value
 
 
 # need to have affection initlaized post event_handler
@@ -1020,18 +1112,23 @@ init 20 python:
             persistent._mas_affection["today_exp"] = 0
             mas_UnfreezeGoodAffExp()
 
+        # calculate new value
+        frozen = persistent._mas_affection_goodexp_freeze
+        change = (amount * modifier)
+        new_value = persistent._mas_affection["affection"] + change
+        if new_value > 1000000:
+            new_value = 1000000
+
+        # audit the attempted change
+        affection.audit(change, new_value, frozen, bypass)
+
         # if we're not freezed or if the bypass flag is True
-        if not persistent._mas_affection_goodexp_freeze or bypass:
-
+        if not frozen or bypass:
             # Otherwise, use the value passed in the argument.
-            persistent._mas_affection["affection"] += (amount * modifier)
-
-            # it can't get higher than 1 million
-            if persistent._mas_affection["affection"] > 1000000:
-                persistent.mas_affection["affection"] = 1000000
+            persistent._mas_affection["affection"] = new_value
 
             if not bypass:
-                persistent._mas_affection["today_exp"] += (amount * modifier)
+                persistent._mas_affection["today_exp"] += change
                 if persistent._mas_affection["today_exp"] >= 7:
                     mas_FreezeGoodAffExp()
 
@@ -1057,14 +1154,19 @@ init 20 python:
 
         mas_apology_reason = reason
 
+        # calculate new vlaue
+        frozen = persistent._mas_affection_badexp_freeze
+        change = (amount * modifier)
+        new_value = persistent._mas_affection["affection"] - change
+        if new_value < -1000000:
+            new_value = -1000000
 
-        if not persistent._mas_affection_badexp_freeze:
+        # audit this attempted change
+        affection.audit(change, new_value, frozen)
+
+        if not frozen:
             # Otherwise, use the value passed in the argument.
-            persistent._mas_affection["affection"] -= (amount * modifier)
-
-            # it can't get lower than -1 million
-            if persistent._mas_affection["affection"] < -1000000:
-                persistent.mas_affection["affection"] = -1000000
+            persistent._mas_affection["affection"] = new_value
 
             # Updates the experience levels if necessary.
             mas_updateAffectionExp()
@@ -1073,7 +1175,15 @@ init 20 python:
     def mas_setAffection(
             amount=persistent._mas_affection["affection"]
         ):
-        if not persistent._mas_affection_badexp_freeze and not persistent.mas_affection_goodexp_freeze:
+        frozen = (
+            persistent._mas_affection_badexp_freeze
+            or persistent._mas_affection_goodexp_freeze
+        )
+
+        # audit the change (or attempt)
+        affection.audit(amount, amount, frozen)
+
+        if not frozen:
             # Otherwise, use the value passed in the argument.
             persistent._mas_affection["affection"] = amount
             # Updates the experience levels if necessary.

--- a/Monika After Story/game/zz_pianokeys.rpy
+++ b/Monika After Story/game/zz_pianokeys.rpy
@@ -320,7 +320,7 @@ label mas_piano_yr_prac:
 init -3 python in mas_piano_keys:
     import pygame # we need this for keymaps
     import os
-    log = renpy.renpy.log.open("pnm")
+    log = renpy.renpy.log.open("log/pnm")
 
     from store.mas_utils import tryparseint, tryparsefloat
 

--- a/Monika After Story/game/zz_transforms.rpy
+++ b/Monika After Story/game/zz_transforms.rpy
@@ -1,10 +1,6 @@
 # Module containing custom transform functions.
 # Last just because
 
-init -999 python:
-    # this is initially set to 60 seconds
-    renpy.not_infinite_loop(120)
-
 # special early access image accessors
 init -10 python:
 


### PR DESCRIPTION
This adds audit logging for affection, + logrotation.

## Testing
* Ensure that all new logs are now in a log folder in ddlc dir.

### affection logging
1. Launch game. 
2. Either use affection functions or run topics that do affection stuff.
3. close game.
4. verify the following:
    - On start, there should be an entry for LOAD. This is when we load the affection value
    - At end, there should be an entry for SAVE. This is when we save the affection value.
    - during topics, the first item should be the current topic (as label name).
    - gaining affection is represented by the change portion (->) increasing
    - losing affection is when the change portion (->) is decreasing
    - if we have a freeze, we should see `!FREEZE!` 
    - if we have a bypass during a freeze, we should see `!BYPASS!`. 

### logrotation
1. Set `persistent._mas_affection_log_counter` to 100.
2. Verify that on next launch, a number-suffixed aff_log.txt is added to the log dir.
3. Verify that on a subsequent launch, we dont add another log file.
**NOTE:** even if the highest number is 99, the next log number will continue to 100. We don't do wrap arounds here with logrotations.