### PR TITLE
Islands dialogue and interactions possible fix

### DIFF
--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -1241,6 +1241,9 @@ label call_next_event:
             if "quit" in _return:
                 $persistent.closed_self = True #Monika happily closes herself
                 jump _quit
+            
+            if "nocontinue" in _return:
+                return False
 
         show monika 1 at t11 zorder MAS_MONIKA_Z with dissolve #Return monika to normal pose
 

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1719,4 +1719,4 @@ label greeting_ourreality:
     $ lockEventLabel("greeting_ourreality",eventdb=evhand.greeting_database)
     $ unlockEventLabel("mas_monika_islands")
     jump mas_monika_islands
-    return
+    return "nocontinue"

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -145,6 +145,7 @@ label mas_monika_islands:
     $ mas_RaiseShield_core()
     $ mas_OVLHide()
     $ disable_esc()
+    $ mas_RaiseShield_dlg()
     $ store.mas_hotkeys.no_window_hiding = True
     $ _mas_island_dialogue = False
     $ _mas_island_window_open = True
@@ -398,6 +399,7 @@ label mas_back_to_spaceroom:
             $ mas_OVLShow()
             $ enable_esc()
             $ store.mas_hotkeys.no_window_hiding = False
+            $ mas_DropShield_dlg()
             m 1eua "I hope you liked it, [player]~"
         "No":
             m "Alright, please continue looking around~"

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -154,7 +154,7 @@ label mas_monika_islands:
     if renpy.random.randint(1,100) == 1:
         $ _mas_island_shimeji = True
     show screen mas_show_islands()
-    return
+    return "nocontinue"
 
 label mas_monika_upsidedownisland:
     if _mas_island_dialogue:


### PR DESCRIPTION
#2146

Can't test anything right now but maybe this will be enough to solve the issue.

## What's the issue 
Basically it didn't matter how many shields or anything we raised when showing the event, mostly because once it showed the screen it doesn't wait until the screen is hidden and goes straight to the return which flows back to the call_next_event flow which drops the dialogue shields.

## The fix
Adding a new flow to call_next_event where we request that it doesn't take care of the shields nor the queued events, because we're not done with the current event.
For this I added a new flow that just returns when returning the "nocontinue" flag from an event. With that said event should take care about the shields and everything itself.
I also added the `mas_RaiseShield_dlg()` call  but probably after the change we don't need that one  anymore. I'll remove it if requested
 
## Testing
I'm not in an environment where I can test this myself, I'll test it myself when I get the chance(which will probably be in like 7 hours from nor more or less).
The testing should be simple:
- by getting the initial greeting while having the random dialogue enabled it should never start a random topic nor any hotkey button should be available.
- same thing but with the pooled topic.
 
If the issue persists I'll think of something else 