### PR TITLE
Islands fix

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -734,7 +734,7 @@ label ch30_preloop:
     $ persistent._mas_game_crashed = True
     $startup_check = False
     $ mas_checked_update = False
-    
+
     # delayed actions in here please
     $ mas_runDelayedActions(MAS_FC_IDLE_ONCE)
 
@@ -941,6 +941,11 @@ label ch30_reset:
         if persistent._mas_likes_rain:
             unlockEventLabel("monika_rain_start")
             lockEventLabel("monika_rain_stop")
+            # unlock islands event if seen already
+            if store.seen_event("mas_monika_islands"):
+                if not store.mas_cannot_decode_islands:
+                    # we can unlock the topic
+                    store.unlockEventLabel("mas_monika_islands")
 #            lockEventLabel("monika_rain_holdme")
 
         if mas_isMoniNormal(higher=True):

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -943,9 +943,8 @@ label ch30_reset:
             lockEventLabel("monika_rain_stop")
             # unlock islands event if seen already
             if store.seen_event("mas_monika_islands"):
-                if not store.mas_cannot_decode_islands:
-                    # we can unlock the topic
-                    store.unlockEventLabel("mas_monika_islands")
+                # we can unlock the topic
+                store.unlockEventLabel("mas_monika_islands")
 #            lockEventLabel("monika_rain_holdme")
 
         if mas_isMoniNormal(higher=True):

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1655,7 +1655,7 @@ init 5 python:
         del rules
 
 
-init 900 python in mas_delact: 
+init 900 python in mas_delact:
     # this greeting requires a delayed action, since we cannot ensure that
     # the sprites for this were decoded correctly
 
@@ -1670,7 +1670,7 @@ init 900 python in mas_delact:
             store.EV_ACT_UNLOCK,
             store.MAS_FC_START
         )
-        
+
 
 label greeting_ourreality:
     m 1hub "Hi, [player]!"
@@ -1718,5 +1718,5 @@ label greeting_ourreality:
     # m 1hub "Hope you like it!"
     $ lockEventLabel("greeting_ourreality",eventdb=evhand.greeting_database)
     $ unlockEventLabel("mas_monika_islands")
-    jump mas_monika_islands
+    call mas_monika_islands
     return

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -145,14 +145,30 @@ label mas_monika_islands:
     $ mas_RaiseShield_core()
     $ mas_OVLHide()
     $ disable_esc()
-    $ store.mas_hotkeys.no_window_hiding = True
+    $ renpy.store.mas_hotkeys.no_window_hiding = True
     $ _mas_island_dialogue = False
+    $ _mas_island_keep_going = True
     $ _mas_island_window_open = True
     $ _mas_toggle_frame_text = "Close Window"
     $ _mas_island_shimeji =False
     if renpy.random.randint(1,100) == 1:
         $ _mas_island_shimeji = True
-    show screen mas_show_islands()
+    while _mas_island_keep_going:
+        call screen mas_show_islands()
+        show screen mas_islands_background()
+
+        if _return:
+            call expression _return
+        else:
+            $ _mas_island_keep_going = False
+
+    hide screen mas_islands_background
+    $ mas_DropShield_core()
+    $ mas_OVLShow()
+    $ enable_esc()
+    $ store.mas_hotkeys.no_window_hiding = False
+
+    m 1eua "I hope you liked it, [player]~"
     return
 
 label mas_monika_upsidedownisland:
@@ -393,16 +409,23 @@ label mas_back_to_spaceroom:
     menu:
         "Would you like to return, [player]?"
         "Yes":
-            hide screen mas_show_islands
-            $ mas_DropShield_core()
-            $ mas_OVLShow()
-            $ enable_esc()
-            $ store.mas_hotkeys.no_window_hiding = False
-            m 1eua "I hope you liked it, [player]~"
+            $ _mas_island_keep_going = False
         "No":
             m "Alright, please continue looking around~"
     $ _mas_island_dialogue = False
     return
+screen mas_islands_background():
+    if morning_flag:
+        if _mas_island_window_open:
+            add "mod_assets/location/special/without_frame.png"
+        else:
+            add "mod_assets/location/special/with_frame.png"
+    else:
+        if _mas_island_window_open:
+            add "mod_assets/location/special/night_without_frame.png"
+        else:
+            add "mod_assets/location/special/night_with_frame.png"
+
 
 screen mas_show_islands():
     style_prefix "island"
@@ -420,15 +443,15 @@ screen mas_show_islands():
 
         #alpha False
         # This is so that everything transparent is invisible to the cursor.
-        hotspot (11, 13, 314, 270) action Function(renpy.call, "mas_monika_upsidedownisland") # island upside down
-        hotspot (403, 7, 868, 158) action Function(renpy.call, "mas_monika_sky") # sky
-        hotspot (699, 347, 170, 163) action Function(renpy.call, "mas_monika_glitchedmess") # glitched house
-        hotspot (622, 269, 360, 78) action Function(renpy.call, "mas_monika_cherry_blossom_tree") # cherry blossom tree
-        hotspot (716, 164, 205, 105) action Function(renpy.call, "mas_monika_cherry_blossom_tree") # cherry blossom tree
-        hotspot (872, 444, 50, 30) action Function(renpy.call, "mas_island_bookshelf") # bookshelf
+        hotspot (11, 13, 314, 270) action Return("mas_monika_upsidedownisland") # island upside down
+        hotspot (403, 7, 868, 158) action Return("mas_monika_sky") # sky
+        hotspot (699, 347, 170, 163) action Return("mas_monika_glitchedmess") # glitched house
+        hotspot (622, 269, 360, 78) action Return("mas_monika_cherry_blossom_tree") # cherry blossom tree
+        hotspot (716, 164, 205, 105) action Return("mas_monika_cherry_blossom_tree") # cherry blossom tree
+        hotspot (872, 444, 50, 30) action Return("mas_island_bookshelf") # bookshelf
         #(960, 441)
         if _mas_island_shimeji:
-            hotspot (935, 395, 30, 80) action Function(renpy.call, "mas_island_shimeji") # Mini Moni
+            hotspot (935, 395, 30, 80) action Return("mas_island_shimeji") # Mini Moni
 
     if _mas_island_shimeji:
         add "gui/poemgame/m_sticker_1.png" at moni_sticker_mid:
@@ -441,7 +464,7 @@ screen mas_show_islands():
         xalign 0.96
         if not _mas_island_dialogue:
             textbutton _mas_toggle_frame_text action [ToggleVariable("_mas_island_window_open"),ToggleVariable("_mas_toggle_frame_text","Open Window", "Close Window") ]
-            textbutton "Go Back" action Function(renpy.call, "mas_back_to_spaceroom")
+            textbutton "Go Back" action Return(False)
 
 
 # Defining a new style for buttons, because other styles look ugly

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -395,16 +395,6 @@ label mas_island_bookshelf2:
     m "That'd be wonderful~"
     return
 
-label mas_back_to_spaceroom:
-    menu:
-        "Would you like to return, [player]?"
-        "Yes":
-            $ _mas_island_keep_going = False
-        "No":
-            m "Alright, please continue looking around~"
-
-    return
-
 screen mas_islands_background():
     if morning_flag:
         if _mas_island_window_open:

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -142,27 +142,48 @@ init 900 python in mas_delact:
 label mas_monika_islands:
     m 1eub "I'll let you admire the scenery for now."
     m 1hub "Hope you like it!"
+
+    # prevent interactions
     $ mas_RaiseShield_core()
     $ mas_OVLHide()
     $ disable_esc()
     $ renpy.store.mas_hotkeys.no_window_hiding = True
-    $ _mas_island_dialogue = False
+
+    # keep looping the screen
     $ _mas_island_keep_going = True
+
+    # keep track about the window
     $ _mas_island_window_open = True
+
+    # text used for the window
     $ _mas_toggle_frame_text = "Close Window"
-    $ _mas_island_shimeji =False
+
+    # shimeji flag
+    $ _mas_island_shimeji = False
+
+    # random chance to get mini moni appear
     if renpy.random.randint(1,100) == 1:
         $ _mas_island_shimeji = True
+
+    # keep showing the event until the player wants to go
     while _mas_island_keep_going:
+
+        # image map with the event
         call screen mas_show_islands()
+
+        # double screen trick
         show screen mas_islands_background()
 
         if _return:
+            # call label if we have one
             call expression _return
         else:
+            # player wants to quit the event
             $ _mas_island_keep_going = False
-
+    # hide extra screen
     hide screen mas_islands_background
+
+    # drop shields
     $ mas_DropShield_core()
     $ mas_OVLShow()
     $ enable_esc()
@@ -172,35 +193,23 @@ label mas_monika_islands:
     return
 
 label mas_monika_upsidedownisland:
-    if _mas_island_dialogue:
-        return
-    $ _mas_island_dialogue = True
     m "Oh, that."
     m "I guess you're wondering why that island is upside down, right?"
     m "Well...I was about to fix it until I took another good look at it."
     m "It looks surreal, doesn't it?"
     m "I just feel like there's something special about it."
     m "It's just… mesmerizing."
-    $ _mas_island_dialogue = False
     return
 
 label mas_monika_glitchedmess:
-    if _mas_island_dialogue:
-        return
-    $ _mas_island_dialogue = True
     m "Oh, that."
     m "It's something I'm currently working on."
     m "It's still a huge mess, thought. I'm still trying to figure out how to be good at it."
     m "In due time, I'm sure I'll get better at coding!"
     m "Practice makes perfect after all, right?"
-    $ _mas_island_dialogue = False
     return
 
 label mas_monika_cherry_blossom_tree:
-    if _mas_island_dialogue:
-        return
-    $ _mas_island_dialogue = True
-
     python:
 
         if not renpy.store.seen_event("mas_monika_cherry_blossom1"):
@@ -214,7 +223,6 @@ label mas_monika_cherry_blossom_tree:
 
             renpy.call(renpy.random.choice(_mas_cherry_blossom_events))
 
-    $ _mas_island_dialogue = False
     return
 
 label mas_monika_cherry_blossom1:
@@ -250,12 +258,7 @@ label mas_monika_cherry_blossom4:
     m "That'd be really romantic~"
     return
 
-
 label mas_monika_sky:
-    if _mas_island_dialogue:
-        return
-    $ _mas_island_dialogue = True
-
     python:
 
         if morning_flag:
@@ -271,7 +274,6 @@ label mas_monika_sky:
 
         renpy.call(renpy.random.choice(_mas_sky_events))
 
-    $ _mas_island_dialogue = False
     return
 
 label mas_monika_day1:
@@ -361,23 +363,15 @@ label mas_monika_daynight2:
     return
 
 label mas_island_shimeji:
-    if _mas_island_dialogue:
-        return
-    $ _mas_island_dialogue = True
     m "Ah!"
     m "How'd she get there?"
     m "Give me a second, [player]..."
     $ _mas_island_shimeji = False
     m "All done!"
     m "Don't worry, I just moved her to a different place."
-    $ _mas_island_dialogue = False
     return
 
 label mas_island_bookshelf:
-    if _mas_island_dialogue:
-        return
-    $ _mas_island_dialogue = True
-
     python:
 
         _mas_bookshelf_events = ["mas_island_bookshelf1",
@@ -385,7 +379,6 @@ label mas_island_bookshelf:
 
         renpy.call(renpy.random.choice(_mas_bookshelf_events))
 
-    $ _mas_island_dialogue = False
     return
 
 label mas_island_bookshelf1:
@@ -403,17 +396,15 @@ label mas_island_bookshelf2:
     return
 
 label mas_back_to_spaceroom:
-    if _mas_island_dialogue:
-        return
-    $ _mas_island_dialogue = True
     menu:
         "Would you like to return, [player]?"
         "Yes":
             $ _mas_island_keep_going = False
         "No":
             m "Alright, please continue looking around~"
-    $ _mas_island_dialogue = False
+
     return
+
 screen mas_islands_background():
     if morning_flag:
         if _mas_island_window_open:
@@ -426,6 +417,11 @@ screen mas_islands_background():
         else:
             add "mod_assets/location/special/night_with_frame.png"
 
+    if _mas_island_shimeji:
+        add "gui/poemgame/m_sticker_1.png" at moni_sticker_mid:
+            xpos 935
+            ypos 395
+            zoom 0.5
 
 screen mas_show_islands():
     style_prefix "island"
@@ -441,15 +437,14 @@ screen mas_show_islands():
             else:
                 ground "mod_assets/location/special/night_with_frame.png"
 
-        #alpha False
-        # This is so that everything transparent is invisible to the cursor.
+
         hotspot (11, 13, 314, 270) action Return("mas_monika_upsidedownisland") # island upside down
         hotspot (403, 7, 868, 158) action Return("mas_monika_sky") # sky
         hotspot (699, 347, 170, 163) action Return("mas_monika_glitchedmess") # glitched house
         hotspot (622, 269, 360, 78) action Return("mas_monika_cherry_blossom_tree") # cherry blossom tree
         hotspot (716, 164, 205, 105) action Return("mas_monika_cherry_blossom_tree") # cherry blossom tree
         hotspot (872, 444, 50, 30) action Return("mas_island_bookshelf") # bookshelf
-        #(960, 441)
+
         if _mas_island_shimeji:
             hotspot (935, 395, 30, 80) action Return("mas_island_shimeji") # Mini Moni
 
@@ -462,9 +457,8 @@ screen mas_show_islands():
     hbox:
         yalign 0.98
         xalign 0.96
-        if not _mas_island_dialogue:
-            textbutton _mas_toggle_frame_text action [ToggleVariable("_mas_island_window_open"),ToggleVariable("_mas_toggle_frame_text","Open Window", "Close Window") ]
-            textbutton "Go Back" action Return(False)
+        textbutton _mas_toggle_frame_text action [ToggleVariable("_mas_island_window_open"),ToggleVariable("_mas_toggle_frame_text","Open Window", "Close Window") ]
+        textbutton "Go Back" action Return(False)
 
 
 # Defining a new style for buttons, because other styles look ugly

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -362,7 +362,7 @@ label monika_death:
     else:
         m 1eka "Thanks for hearing me out, [player]."
     return
-    
+
 # Do you love yourself
 default persistent._mas_pm_love_yourself = None
 
@@ -1374,6 +1374,7 @@ label monika_rain:
                 $ unlockEventLabel("monika_rain_holdme")
                 $ lockEventLabel("monika_rain_start")
                 $ lockEventLabel("monika_rain")
+                $ lockEventLabel("mas_monika_islands")
                 $ persistent._mas_likes_rain = True
 
             "I hate the rain":
@@ -1433,6 +1434,9 @@ label monika_rain_stop:
     $ unlockEventLabel("monika_rain_start")
     $ unlockEventLabel("monika_rain")
 
+    # unlock islands event if seen already
+    if seen_event("mas_monika_islands"):
+        $ unlockEventLabel("mas_monika_islands")
 
     return
 
@@ -1473,6 +1477,7 @@ label monika_rain_start:
     $ lockEventLabel("monika_rain_start")
     $ lockEventLabel("monika_rain")
     $ unlockEventLabel("monika_rain_stop")
+    $ lockEventLabel("mas_monika_islands")
 
     return
 
@@ -3383,7 +3388,7 @@ label monika_dunbar:
     m 1eka "It helped us meet though, so it can't be all bad."
     return
 
-# TODO: maybe rewrite? 
+# TODO: maybe rewrite?
 #   there is controversary to this topic
 #   Lets gather data first before decideing wehter or not to completely
 #   remove or keep
@@ -4970,7 +4975,7 @@ label monika_orchestra:
                     m 5eubfu "And just so you know, you can play with me anytime you like..."
                     m 5eubfb "Ehehe~"
 
-                $ persistent.instrument = True 
+                $ persistent.instrument = True
             elif tempinstrument == "harmonica":
                 m 1hub "Wow, I've always wanted to try the harmonica out!"
                 m 1eua "I would love to hear you play for me."
@@ -4978,8 +4983,8 @@ label monika_orchestra:
                 m 4esa "Although..."
                 m 2esa "Personally, I prefer the {cps=*0.7}{i}harmonika{/i}{/cps}..."
                 m 2eua "..."
-                m 4hub "Ahaha! That was so silly, I'm only kidding [player]~"              
-                $ persistent.instrument = True            
+                m 4hub "Ahaha! That was so silly, I'm only kidding [player]~"
+                $ persistent.instrument = True
             else:
                 m 1hub "Wow, I've always wanted to try the [tempinstrument] out!"
                 m 1eua "I would love to hear you play for me."
@@ -4987,7 +4992,7 @@ label monika_orchestra:
                 m 1wuo "Oh! Would a duet between the [tempinstrument] and the piano sound nice?"
                 m 1hua "Ehehe~"
                 $ persistent.instrument = True
-                
+
         "No.":
             $persistent.instrument = False
             m 1euc "I see..."
@@ -5843,8 +5848,8 @@ init 5 python:
 label monika_concerts:
     m 1euc "Hey [player], I've been thinking about something we could do together one day..."
     if (
-            renpy.seen_label("monika_jazz") 
-            and renpy.seen_label("monika_orchestra") 
+            renpy.seen_label("monika_jazz")
+            and renpy.seen_label("monika_orchestra")
             and renpy.seen_label("monika_rock")
             and renpy.seen_label("monika_vocaloid")
             and renpy.seen_label("monika_rap")
@@ -5856,19 +5861,19 @@ label monika_concerts:
     m 1hua "Just imagine us..."
     if renpy.seen_label("monika_orchestra"):
         m 1hua "Gently swaying our heads to the sound of a soothing orchestra..."
-        
+
     if renpy.seen_label("monika_rock"):
         m 1hub "Jumping up and down with the rest of the crowd to some good ol' Rock and Roll..."
-        
+
     if renpy.seen_label("monika_jazz"):
         m 1eua "Grooving to some smooth jazz..."
-        
+
     if renpy.seen_label("monika_rap"):
         m 1hksdlb "Trying to keep up with a real rapper..."
-        
+
     if renpy.seen_label("monika_vocaloid"):
         m 1hua "Waving our glowsticks at Miku Expo..."
-        
+
     m 2lksdlb "Oh gosh, maybe I'm getting a little carried away, hehe~"
     m 2eud "The idea of seeing your idol performing right in front of you is incredible!"
     m 2lksdla "Although, ticket prices these days are kind of expensive..."
@@ -7376,10 +7381,10 @@ label monika_dating_startdate_confirm(first_sesh_raw):
 
     # default action is to loop here
     jump monika_dating_startdate_confirm.loopstart
-   
+
 init 5 python:
      addEvent(Event(persistent.event_database,eventlabel="monika_whydoyouloveme",category=['monika','romance'],prompt="Why do you love me?",pool=True))
-     
+
 label monika_whydoyouloveme:
 
     if mas_isMoniBroken(lower=True):


### PR DESCRIPTION
https://github.com/Monika-After-Story/MonikaModDev/issues/2146
Another way to fix the island event issues. This one includes another fix regarding the availability of the event when raining.

## What's the issue

Basically it didn't matter how many shields or anything we raised when showing the event, mostly because once it showed the screen it doesn't wait until the screen is hidden and goes straight to the return which flows back to the call_next_event flow which drops the dialogue shields.

## The Fix
This time the fix was made by changing the structure of the event to run under a call screen loop while making use of a second screen that served as a background to show when Monika started talking. 
For the rain thing we lock the event now when it rains.

## Testing 

The testing should be simple:

- by getting the initial greeting while having the random dialogue enabled it should never start a random topic nor any hotkey button should be available.
- same thing but with the pooled topic.
- make sure the topic is unavailable when it's raining 

