### PR TITLE
Incorporating persistent data into the docking station

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -616,12 +616,13 @@ label ch30_autoload:
     if store.mas_dockstat.retmoni_status is not None:
         # non None means we have a status
         $ mas_from_empty = False
+        $ moni_status = store.mas_dockstat.retmoni_status
 
-        if store.mas_dockstat.retmoni_status == store.mas_dockstat.MAS_PKG_FO:
+        if (moni_status & store.mas_dockstat.MAS_PKG_FO) > 0:
             # TODOL: jump to the mas_dockstat_different_monika label
             jump mas_dockstat_empty_desk
 
-        if store.mas_dockstat.retmoni_status == store.mas_dockstat.MAS_PKG_F:
+        if (moni_status & store.mas_dockstat.MAS_PKG_F) > 0:
             jump mas_dockstat_found_monika
 
         # otherwise, lets jump to the empty desk

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1076,6 +1076,17 @@ label ch30_reset:
             if _now > _rh:
                 persistent._mas_monika_returned_home = None
 
+    ## resset playtime issues
+    python:
+        # reset total playtime to 0 if we got negative time.
+        # we could scale this, but it honestly is impossible for us to 
+        # figure out the original number accurately, and giving people free
+        # playtime doesn't sit well with me
+        if persistent.sessions is not None:
+            tp_time = persistent.sessions.get("total_playtime", None)
+            if tp_time < datetime.timedelta(0):
+                persistent.sessions["total_playtime"] = datetime.timedelta(0)
+
 
 
     return

--- a/Monika After Story/game/splash.rpy
+++ b/Monika After Story/game/splash.rpy
@@ -313,11 +313,19 @@ label before_main_menu:
     return
 
 label quit:
-    $ store.mas_calendar.saveCalendarDatabase(CustomEncoder)
-    $persistent.sessions['last_session_end']=datetime.datetime.now()
-    $persistent.sessions['total_playtime']=persistent.sessions['total_playtime']+ (persistent.sessions['last_session_end']-persistent.sessions['current_session_start'])
+    python:
+        store.mas_calendar.saveCalendarDatabase(CustomEncoder)
+        persistent.sessions['last_session_end']=datetime.datetime.now()
+        today_time = (
+            persistent.sessions["last_session_end"] 
+            - persistent.sessions["current_session_start"]
+        )
+        # gotta prevent negative time addons
+        if today_time > datetime.timedelta(0):
+            persistent.sessions['total_playtime'] += today_time
 
-    $ store.mas_dockstat.setMoniSize(persistent.sessions["total_playtime"])
+        # set the monika size
+        store.mas_dockstat.setMoniSize(persistent.sessions["total_playtime"])
 
     if persistent._mas_hair_changed:
         $ persistent._mas_monika_hair = monika_chr.hair

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -272,12 +272,22 @@ label v0_3_1(version=version): # 0.3.1
 label v0_8_6(version="v0_8_6"):
     python:
         import store.evhand as evhand
+        import datetime
         
         # unlock gender redo if we have seen the other event
         genderredo_ev = evhand.event_database.get("gender_redo", None)
         if genderredo_ev and renpy.seen_label("gender"):
             genderredo_ev.unlocked = True
             genderredo_ev.pool = True
+
+        # reset total playtime to 0 if we got negative time.
+        # we could scale this, but it honestly is impossible for us to 
+        # figure out the original number accurately, and giving people free
+        # playtime doesn't sit well with me
+        if persistent.sessions is not None:
+            tp_time = persistent.sessions.get("total_playtime", None)
+            if tp_time < datetime.timedelta(0):
+                persistent.sessions["total_playtime"] = datetime.timedelta(0)
 
     return
 

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -280,15 +280,6 @@ label v0_8_6(version="v0_8_6"):
             genderredo_ev.unlocked = True
             genderredo_ev.pool = True
 
-        # reset total playtime to 0 if we got negative time.
-        # we could scale this, but it honestly is impossible for us to 
-        # figure out the original number accurately, and giving people free
-        # playtime doesn't sit well with me
-        if persistent.sessions is not None:
-            tp_time = persistent.sessions.get("total_playtime", None)
-            if tp_time < datetime.timedelta(0):
-                persistent.sessions["total_playtime"] = datetime.timedelta(0)
-
     return
 
 # 0.8.4

--- a/Monika After Story/game/zz_dockingstation.rpy
+++ b/Monika After Story/game/zz_dockingstation.rpy
@@ -415,7 +415,7 @@ init -45 python:
                     package_name, 
                     pkg_slip, 
                     contents=None, 
-                    one_line=False,
+                    one_line=False, # TODO: change this to number of lines
                     b64=True,
                     bs=None
             ):


### PR DESCRIPTION
This makes docking station monika include persistent data.

This also has a fallback in case the persistent data fails to dump, in which case we use the original pipe-delimeted format.

### Testing
* only regression testing. Try using the take you somewhere goodbye and confirm that reinserting monika either before start or during empty desk works.
* additionally, you could copy the monika char and examine it int eh console to check if it did pickle correctly.

### Additonal
* this also fixes a potential issue where ngative time gets added to playtime. 
* i also added a reset check that changes playtime to 0 if its negative

NO dialogue review since no dialogue.