### PR TITLE
Adding Idle expressions

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -1297,6 +1297,7 @@ python early:
 #init -1 python:
     # new class to manage a list of quips
     class MASQuipList(object):
+        import random
         """
         Class that manages a list of quips. Quips have types which helps us
         when deciding how to execute quips. Also we have some properties that
@@ -1526,13 +1527,13 @@ python early:
             """
             if remove:
                 # if we need to remove, we should use randint instead
-                sel_index = renpy.random.randint(0, len(self.__quiplist) - 1)
+                sel_index = random.randint(0, len(self.__quiplist) - 1)
                 quip_type, quip_value = self.__quiplist.pop(sel_index)
 
             else:
                 # if we dont need to remove, we can just use renpy random
                 # choice
-                quip_type, quip_value = renpy.random.choice(self.__quiplist)
+                quip_type, quip_value = random.choice(self.__quiplist)
 
             # now do preocessing then send
             if quip_type == self.TYPE_GLITCH:

--- a/Monika After Story/game/dev/dev_affection-test.rpy
+++ b/Monika After Story/game/dev/dev_affection-test.rpy
@@ -1,5 +1,7 @@
 # Affection related checks
 
+default persistent._mas_disable_sorry = None
+
 init 5 python:
     addEvent(
         Event(

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -1304,28 +1304,7 @@ label prompt_menu:
         talk_menu.append(("Goodbye", "goodbye"))
         talk_menu.append(("Nevermind.","nevermind"))
 
-        # decide the say dialogue
-        if mas_isMoniBroken(lower=True):
-            menu_dlg = "..."
-
-        elif mas_isMoniDis():
-            menu_dlg = "...Yes?"
-
-        elif mas_isMoniUpset():
-            menu_dlg = "What is it?"
-
-        elif mas_isMoniLove(higher=True):
-            menu_dlg = "What's up?"
-
-        elif mas_isMoniAff(higher=True):
-            # affection and enamored
-            menu_dlg = "What would you like to talk about? <3"
-
-        else:
-            # normal and happy
-            menu_dlg = "What would you like to talk about?"
-
-        renpy.say(m, menu_dlg, interact=False)
+        renpy.say(m, store.mas_affection.talk_quip()[1], interact=False)
         madechoice = renpy.display_menu(talk_menu, screen="talk_choice")
 
     if madechoice == "unseen":

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -1304,7 +1304,28 @@ label prompt_menu:
         talk_menu.append(("Goodbye", "goodbye"))
         talk_menu.append(("Nevermind.","nevermind"))
 
-        renpy.say(m, "What would you like to talk about?", interact=False)
+        # decide the say dialogue
+        if mas_isMoniBroken(lower=True):
+            menu_dlg = "..."
+
+        elif mas_isMoniDis():
+            menu_dlg = "...Yes?"
+
+        elif mas_isMoniUpset():
+            menu_dlg = "What is it?"
+
+        elif mas_isMoniLove(higher=True):
+            menu_dlg = "What's up?"
+
+        elif mas_isMoniAff(higher=True):
+            # affection and enamored
+            menu_dlg = "What would you like to talk about? <3"
+
+        else:
+            # normal and happy
+            menu_dlg = "What would you like to talk about?"
+
+        renpy.say(m, menu_dlg, interact=False)
         madechoice = renpy.display_menu(talk_menu, screen="talk_choice")
 
     if madechoice == "unseen":

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -1242,7 +1242,7 @@ label call_next_event:
                 $persistent.closed_self = True #Monika happily closes herself
                 jump _quit
 
-        show monika 1 at t11 zorder MAS_MONIKA_Z with dissolve #Return monika to normal pose
+        show monika idle at t11 zorder MAS_MONIKA_Z with dissolve #Return monika to normal pose
 
         # loop over until all events have been called
         if len(persistent.event_list) > 0:
@@ -1287,6 +1287,9 @@ label prompt_menu:
 
         repeatable_events = Event.filterEvents(evhand.event_database,unlocked=True,pool=False)
     #Top level menu
+    # NOTE: should we force this to a particualr exp considering that 
+    # monika now rotates
+    # NOTE: actually we could use boredom setup in here.
     show monika at t21
     #To make the menu line up right we have to build it up manually
     python:
@@ -1327,7 +1330,7 @@ label prompt_menu:
     else: #nevermind
         $_return = None
 
-    show monika at t11
+    show monika idle at t11
     $ mas_DropShield_dlg()
     jump ch30_loop
 

--- a/Monika After Story/game/pong.rpy
+++ b/Monika After Story/game/pong.rpy
@@ -268,6 +268,8 @@ label demo_minigame_pong:
     $scene_change=True #Force scene generation
     call spaceroom from _call_spaceroom_3
 
+    show monika 1eua
+
     if winner == "monika":
         $ inst_dialogue = store.mas_pong.DLG_WINNER
 

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -22,7 +22,8 @@
 # following:
 #
 # LOVE (1000 and up)
-#     Monika is the happiest she could ever be and filled with a sense of euphoria because of it, completely enamoured and could die happy. She has no doubts the player loves her and that everything was worth it.
+#   Monika is completely comfortable with the player.
+#   (aka the comfortable stage in a relationship)
 # ENAMORED (400 up to 999)
 #     Exceptionally happy, the happiest she has ever been in her life to that point. Completely trusts the player and wants to make him/her as happy as she is.
 # AFFECTIONATE (100 up to 399)
@@ -650,6 +651,134 @@ init 15 python in mas_affection:
             return comparison >= 0
 
         return False
+
+    ### talk and play menu stuff
+
+    talk_menu_quips = dict()
+    play_menu_quips = dict()
+
+    def _init_talk_quips():
+        """
+        Initializes the talk quiplists
+        """
+        global talk_menu_quips
+        def save_quips(_aff, quiplist):
+            mas_ql = store.MASQuipList(allow_label=False)
+            for _quip in quiplist:
+                mas_ql.addLineQuip(_quip)
+            talk_menu_quips[_aff] = mas_ql
+
+
+        ## BROKEN quips
+        quips = [
+            "..."
+        ]
+        save_quips(BROKEN, quips)
+
+        ## DISTRESSED quips
+        quips = [
+            "...Yes?"
+        ]
+        save_quips(DISTRESSED, quips)
+
+        ## UPSET quips
+        quips = [
+            "What is it?"
+        ]
+        save_quips(UPSET, quips)
+
+        ## NORMAL quips
+        quips = [
+            "What would you like to talk about?"
+        ]
+        save_quips(NORMAL, quips)
+
+        ## HAPPY quips
+        quips = [
+            "What would you like to talk about?"
+        ]
+        save_quips(HAPPY, quips)
+
+        ## AFFECTIONATE quips
+        quips = [
+            "What would you like to talk about? <3"
+        ]
+        save_quips(AFFECTIONATE, quips)
+
+        ## ENAMORED quips
+        quips = [
+            "What would you like to talk about? <3",
+            "Yes, [player]?"
+        ]
+        save_quips(ENAMORED, quips)
+
+        ## LOVE quips
+        quips = [
+            "What's up?"
+        ]
+        save_quips(LOVE, quips)
+
+
+    def _init_play_quips():
+        """
+        Initializes the play quipliust
+        """
+        global play_menu_quips
+        def save_quips(_aff, quiplist):
+            mas_ql = store.MASQuipList(allow_label=False)
+            for _quip in quiplist:
+                mas_ql.addLineQuip(_quip)
+            play_menu_quips[_aff] = mas_ql
+
+
+        ## BROKEN quips
+        quips = [
+            "..."
+        ]
+        save_quips(BROKEN, quips)
+
+        ## DISTRESSED quips
+        quips = [
+            "...Sure."
+        ]
+        save_quips(DISTRESSED, quips)
+
+        ## UPSET quips
+        quips = [
+            "Which game?"
+        ]
+        save_quips(UPSET, quips)
+
+        ## NORMAL quips
+        quips = [
+            "What game would you like to play?"
+        ]
+        save_quips(NORMAL, quips)
+
+        ## HAPPY quips
+        quips = [
+            "What game would you like to play?"
+        ]
+        save_quips(HAPPY, quips)
+
+        ## AFFECTIONATE quips
+        quips = [
+            "What game would you like to play? <3"
+        ]
+        save_quips(AFFECTIONATE, quips)
+
+        ## ENAMORED quips
+        quips = [
+            "What game would you like to play? <3"
+        ]
+        save_quips(ENAMORED, quips)
+
+        ## LOVE quips
+        quips = [
+            "Yay! Let's play together!"
+        ]
+        save_quips(LOVE, quips)
+
 
 
 default persistent._mas_long_absence = False

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -779,6 +779,8 @@ init 15 python in mas_affection:
         ]
         save_quips(LOVE, quips)
 
+    _init_talk_quips()
+    _init_play_quips()
 
 
 default persistent._mas_long_absence = False

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -653,6 +653,11 @@ init 15 python in mas_affection:
         return False
 
     ### talk and play menu stuff
+    # [AFF015]
+    #
+    # initial contributions by:
+    #   @jmwall24
+    #   @multimokia
 
     talk_menu_quips = dict()
     play_menu_quips = dict()
@@ -677,13 +682,28 @@ init 15 python in mas_affection:
 
         ## DISTRESSED quips
         quips = [
-            "...Yes?"
+            "...Yes?",
+            "...Oh?",
+            "...Huh?",
+            "...Hm?",
+            "We can try talking, I guess.",
+            "I guess we can talk.",
+            "Oh...you want to talk?",
+            "If you want to talk, go ahead.",
+            "We can talk if you really want to.",
+            "Are you sure you want to talk to me?",
+            "You actually want to talk to me?"
         ]
         save_quips(DISTRESSED, quips)
 
         ## UPSET quips
         quips = [
-            "What is it?"
+            "What?",
+            "What do you want?",
+            "What now?",
+            "What is it?",
+            "Fine...we can talk.",
+            "Just...whatever, go ahead."
         ]
         save_quips(UPSET, quips)
 
@@ -701,20 +721,39 @@ init 15 python in mas_affection:
 
         ## AFFECTIONATE quips
         quips = [
-            "What would you like to talk about? <3"
+            "What would you like to talk about? <3",
+            "What would you like to talk about, [player]?",
+            "Yes, [player]?",
+            "What's on your mind, [player]?",
+            "What would you like to talk about, [player]?"
         ]
         save_quips(AFFECTIONATE, quips)
 
         ## ENAMORED quips
         quips = [
             "What would you like to talk about? <3",
-            "Yes, [player]?"
+            "What would you like to talk about, honey?",
+            "Yes, sweetheart?",
+            "Yes, honey?",
+            "Yes, dear?",
+            "What's on your mind, darling?",
+            "What would you like to talk about, sweetie?",
+            "What would you like to talk about, [player]?",
+            "Yes, [player]?",
+            "What's on your mind, [player]?",
+            "What would you like to talk about, [player]?"
         ]
         save_quips(ENAMORED, quips)
 
         ## LOVE quips
         quips = [
-            "What's up?"
+            "Hey, what's up?",
+            "What's on your mind?",
+            "Anything on your mind?",
+            "What's up, [player]?",
+            "What's up?",
+            "Anything you'd like to talk about?",
+            "We can talk about anything you like, [player]."
         ]
         save_quips(LOVE, quips)
 
@@ -739,43 +778,61 @@ init 15 python in mas_affection:
 
         ## DISTRESSED quips
         quips = [
-            "...Sure."
+            "...Sure.",
+            "...Fine.",
+            "I guess we can play a game.",
+            "I guess, if you really want to.",
+            "I suppose a game would be fine."
         ]
         save_quips(DISTRESSED, quips)
 
         ## UPSET quips
         quips = [
-            "Which game?"
+            "...Which game?",
+            "Okay...whatever, choose a game.",
+            "Fine, pick a game."
         ]
         save_quips(UPSET, quips)
 
         ## NORMAL quips
         quips = [
-            "What game would you like to play?"
+            "What would you like to play?",
+            "What did you have in mind?",
+            "Anything specific you'd like to play?"
         ]
         save_quips(NORMAL, quips)
 
         ## HAPPY quips
         quips = [
-            "What game would you like to play?"
+            "What would you like to play?",
+            "What did you have in mind?",
+            "Anything specific you'd like to play?"
         ]
         save_quips(HAPPY, quips)
 
         ## AFFECTIONATE quips
         quips = [
-            "What game would you like to play? <3"
+            "What would you like to play? <3",
+            "Choose anything you like, [player].",
+            "Pick anything you like, [player]."
         ]
         save_quips(AFFECTIONATE, quips)
 
         ## ENAMORED quips
         quips = [
-            "What game would you like to play? <3"
+            "What would you like to play? <3",
+            "Choose anything you like, [player].",
+            "Pick anything you like, [player].",
+            "Choose anything you like, honey.",
+            "Pick anything you like, sweetheart."
         ]
         save_quips(ENAMORED, quips)
 
         ## LOVE quips
         quips = [
-            "Yay! Let's play together!"
+            "Yay! Let's play together!",
+            "I'd love to play something with you!",
+            "I'd love to play with you!"
         ]
         save_quips(LOVE, quips)
 
@@ -818,7 +875,7 @@ init 15 python in mas_affection:
         quip = _dict_quip(play_menu_quips)
         if len(quip) > 0:
             return quip
-        return "What game would you like to play?"
+        return "What would you like to play?"
         
 
 

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -783,6 +783,45 @@ init 15 python in mas_affection:
     _init_play_quips()
 
 
+    def _dict_quip(_quips):
+        """
+        Returns a quip based on the current affection using the given quip
+        dict
+
+        IN:
+            _quips - quip dict to pull from
+
+        RETURNS:
+            quip or empty string if failure
+        """
+        quipper = _quips.get(store.mas_curr_affection, None)
+        if quipper is not None:
+            return quipper.quip()
+
+        return ""
+
+
+    def talk_quip():
+        """
+        Returns a talk quip based on the current affection
+        """
+        quip = _dict_quip(talk_menu_quips)
+        if len(quip) > 0:
+            return quip
+        return "What would you like to talk about?"
+
+
+    def play_quip():
+        """
+        Returns a play quip based on the current affection
+        """
+        quip = _dict_quip(play_menu_quips)
+        if len(quip) > 0:
+            return quip
+        return "What game would you like to play?"
+        
+
+
 default persistent._mas_long_absence = False
 default persistent._mas_pctaieibe = None
 default persistent._mas_pctaneibe = None

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -735,6 +735,10 @@ init 20 python:
     def _mas_getAffection():
         return persistent._mas_affection["affection"]
 
+    # numerical affection check
+    def mas_isBelowZero():
+        return _mas_getAffection() < 0
+
 
     ## affection comparison
     # [AFF020] Affection comparTos
@@ -1211,7 +1215,8 @@ init 20 python:
 
         # If affection level is less than -50 and the label hasn't been seen yet, push this event where Monika says she's upset with you and wants you to apologize.
         elif curr_affection <= -50 and not seen_event("mas_affection_apology"):
-            pushEvent("mas_affection_apology")
+            if not persistent._mas_disable_sorry:
+                pushEvent("mas_affection_apology")
         # If affection level is equal or less than -100 and the label hasn't been seen yet, push this event where Monika says she's upset with you and wants you to apologize.
         elif curr_affection <= -100 and not seen_event("greeting_tears"):
             unlockEventLabel("greeting_tears",eventdb=evhand.greeting_database)

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -464,26 +464,10 @@ label pick_a_game:
         )
 
         # decide the say dialogue
-        if mas_isMoniBroken(lower=True):
-            menu_dlg = "..."
-
-        elif mas_isMoniDis():
-            menu_dlg = "...Sure."
-
-        elif mas_isMoniUpset():
-            menu_dlg = "Which game?"
-
-        elif mas_isMoniLove(higher=True):
-            menu_dlg = "Yay! Let's play together!"
-
-        elif mas_isMoniAff(higher=True):
-            menu_dlg = "What game would you like to play? <3"
-
-        else:
-            menu_dlg = "What game would you like to play?"
+        play_menu_dlg = store.mas_affection.play_quip()[1]
 
     menu:
-        m "[menu_dlg]"
+        m "[play_menu_dlg]"
         "Pong" if persistent.game_unlocks['pong']:
             if not renpy.seen_label('game_pong'):
                 $grant_xp(xp.NEW_GAME)

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -364,7 +364,7 @@ label spaceroom(start_bg=None,hide_mask=False,hide_monika=False):
                 show monika_day_room zorder MAS_BACKGROUND_Z
                 $ mas_calShowOverlay()
             if not hide_monika:
-                show monika 1 at t11 zorder MAS_MONIKA_Z
+                show monika idle at t11 zorder MAS_MONIKA_Z
                 with Dissolve(dissolve_time)
     else:
         if morning_flag or scene_change:
@@ -379,7 +379,7 @@ label spaceroom(start_bg=None,hide_mask=False,hide_monika=False):
                 $ mas_calShowOverlay()
                 #show monika_bg_highlight
             if not hide_monika:
-                show monika 1 at t11 zorder MAS_MONIKA_Z
+                show monika idle at t11 zorder MAS_MONIKA_Z
                 with Dissolve(dissolve_time)
 
     $scene_change = False
@@ -488,7 +488,7 @@ label pick_a_game:
         "Nevermind":
             m "Alright. Maybe later?"
 
-    show monika 1 at tinstant zorder MAS_MONIKA_Z
+    show monika idle at tinstant zorder MAS_MONIKA_Z
 
     $ mas_DropShield_dlg()
 

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -463,8 +463,27 @@ label pick_a_game:
             and not chess_disabled
         )
 
+        # decide the say dialogue
+        if mas_isMoniBroken(lower=True):
+            menu_dlg = "..."
+
+        elif mas_isMoniDis():
+            menu_dlg = "...Sure."
+
+        elif mas_isMoniUpset():
+            menu_dlg = "Which game?"
+
+        elif mas_isMoniLove(higher=True):
+            menu_dlg = "Yay! Let's play together!"
+
+        elif mas_isMoniAff(higher=True):
+            menu_dlg = "What game would you like to play? <3"
+
+        else:
+            menu_dlg = "What game would you like to play?"
+
     menu:
-        "What game would you like to play?"
+        m "[menu_dlg]"
         "Pong" if persistent.game_unlocks['pong']:
             if not renpy.seen_label('game_pong'):
                 $grant_xp(xp.NEW_GAME)
@@ -486,7 +505,10 @@ label pick_a_game:
         #         $ grant_xp(xp.NEW_GAME)
         #     call mas_monikamovie from _call_monikamovie
         "Nevermind":
-            m "Alright. Maybe later?"
+            # NOTE: changing this to no dialogue so we dont have to edit this
+            # for affection either
+            pass
+#            m "Alright. Maybe later?"
 
     show monika idle at tinstant zorder MAS_MONIKA_Z
 

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -9628,20 +9628,20 @@ image monika ATL_0_to_upset:
         choice 0.05:
             "monika 5tsc"
 
-    # select a wait time
+    # select wait time
     block:
         choice:
-            5.0
-        choice:
-            6.0
-        choice:
-            7.0
-        choice:
-            8.0
-        choice:
-            9.0
-        choice:
             10.0
+        choice:
+            12.0
+        choice:
+            14.0
+        choice:
+            16.0
+        choice:
+            18.0
+        choice:
+            20.0
     repeat
 
 # affectionate
@@ -9665,20 +9665,20 @@ image monika ATL_affectionate:
             choice 0.051020:
                 "monika 1hua"
 
-    # 5 to 10s wait times
+    # select wait time
     block:
         choice:
-            5.0
-        choice:
-            6.0
-        choice:
-            7.0
-        choice:
-            8.0
-        choice:
-            9.0
-        choice:
             10.0
+        choice:
+            12.0
+        choice:
+            14.0
+        choice:
+            16.0
+        choice:
+            18.0
+        choice:
+            20.0
 
     repeat
 
@@ -9708,20 +9708,20 @@ image monika ATL_enamored:
             choice 0.061224:
                 "monika 1huu"
 
-    # 5 to 10s wait times
+    # select wait time
     block:
         choice:
-            5.0
-        choice:
-            6.0
-        choice:
-            7.0
-        choice:
-            8.0
-        choice:
-            9.0
-        choice:
             10.0
+        choice:
+            12.0
+        choice:
+            14.0
+        choice:
+            16.0
+        choice:
+            18.0
+        choice:
+            20.0
 
     repeat
 
@@ -9753,20 +9753,20 @@ image monika ATL_love:
             choice 0.051020:
                 "monika 5eubla"
 
-    # 5 to 10s wait times
+    # select wait time
     block:
         choice:
-            5.0
-        choice:
-            6.0
-        choice:
-            7.0
-        choice:
-            8.0
-        choice:
-            9.0
-        choice:
             10.0
+        choice:
+            12.0
+        choice:
+            14.0
+        choice:
+            16.0
+        choice:
+            18.0
+        choice:
+            20.0
 
     repeat
 

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -2114,6 +2114,19 @@ image monika 1hub = DynamicDisplayable(
     arms="steepling"
 )
 
+image monika 1huu = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="up",
+    eyes="closedhappy",
+    nose="def",
+    mouth="smug",
+    head="j",
+    left="1l",
+    right="1r",
+    arms="steepling"
+)
+
 image monika 1tub = DynamicDisplayable(
     mas_drawmonika,
     character=monika_chr,
@@ -2519,6 +2532,32 @@ image monika 1subftsb = DynamicDisplayable(
     arms="steepling",
     blush="full",
     tears="streaming"
+)
+
+image monika 1kua = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="up",
+    eyes="winkleft",
+    nose="def",
+    mouth="smile",
+    head="a",
+    left="1l",
+    right="1r",
+    arms="steepling"
+)
+
+image monika 1sua = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="up",
+    eyes="sparkle",
+    nose="def",
+    mouth="smile",
+    head="a",
+    left="1l",
+    right="1r",
+    arms="steepling"
 )
 
 image monika 1sub = DynamicDisplayable(
@@ -8541,6 +8580,34 @@ image monika 5euc = DynamicDisplayable(
     single="3b"
 )
 
+image monika 5esu = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="mid",
+    eyes="normal",
+    nose="def",
+    mouth="smug",
+    head="",
+    left="",
+    right="",
+    lean="def",
+    single="3a"
+)
+
+image monika 5tsu = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="mid",
+    eyes="smug",
+    nose="def",
+    mouth="smug",
+    head="",
+    left="",
+    right="",
+    lean="def",
+    single="3a"
+)
+
 image monika 5hubfa = DynamicDisplayable(
     mas_drawmonika,
     character=monika_chr,
@@ -8625,6 +8692,21 @@ image monika 5ekbfa = DynamicDisplayable(
     right="",
     lean="def",
     blush="full",
+    single="3b"
+)
+
+image monika 5eubla = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="up",
+    eyes="normal",
+    nose="def",
+    mouth="smile",
+    head="",
+    left="",
+    right="",
+    lean="def",
+    blush="lines",
     single="3b"
 )
 
@@ -8943,6 +9025,21 @@ image monika 5luu = DynamicDisplayable(
     eyes="left",
     nose="def",
     mouth="smug",
+    head="",
+    left="",
+    right="",
+    lean="def",
+    single="3b"
+)
+
+# bored
+image monika 5tsc = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="mid",
+    eyes="smug",
+    nose="def",
+    mouth="smirk",
     head="",
     left="",
     right="",
@@ -9495,38 +9592,196 @@ image monika 6ATL_cryleftright:
 # similar to cryleft and right
 # meant for DISTRESSED
 image monika 6ATL_lookleftright:
+    # select an image
     block:
-        # select an image
-        block:
-            choice:
-                "monika 6rkc"
-            choice:
-                "monika 6lkc"
+        choice:
+            "monika 6rkc"
+        choice:
+            "monika 6lkc"
 
-        # select a wait time
-        block:
+    # select a wait time
+    block:
+        choice:
+            5.0
+        choice:
+            6.0
+        choice:
+            7.0
+        choice:
+            8.0
+        choice:
+            9.0
+        choice:
+            10.0
+    repeat
+
+### [IMG045]
+# special purpose ATLs that cant really be used for other things atm
+
+# Below 0 to upset affection
+image monika ATL_0_to_upset:
+    # select image
+    block:
+        choice 0.95:
+            "monika 1esa"
+        choice 0.05:
+            "monika 5tsc"
+
+    # select a wait time
+    block:
+        choice:
+            5.0
+        choice:
+            6.0
+        choice:
+            7.0
+        choice:
+            8.0
+        choice:
+            9.0
+        choice:
+            10.0
+    repeat
+
+# affectionate
+image monika ATL_affectionate:
+    # select image
+    block:
+        choice 0.02:
+            "monika 1eua"
+            1.0
             choice:
-                5.0
+                "monika 1sua"
+                4.0
             choice:
-                6.0
+                "monika 1kua"
+                1.5
+            "monika 1eua"
+
+        choice 0.98:
+            choice 0.94898:
+                "monika 1eua"
+            choice 0.051020:
+                "monika 1hua"
+
+    # 5 to 10s wait times
+    block:
+        choice:
+            5.0
+        choice:
+            6.0
+        choice:
+            7.0
+        choice:
+            8.0
+        choice:
+            9.0
+        choice:
+            10.0
+
+    repeat
+
+# enamored
+image monika ATL_enamored:
+
+    # select image
+    block:
+        choice 0.02:
+            "monika 1eua"
+            1.0
             choice:
-                7.0
+                "monika 1sua"
+                4.0
             choice:
-                8.0
+                "monika 1kua"
+                1.5
+            "monika 1eua"
+
+        choice 0.98:
+            choice 0.765306:
+                "monika 1eua"
+            choice 0.112245:
+                "monika 5esu"
+            choice 0.061224:
+                "monika 5tsu"
+            choice 0.061224:
+                "monika 1huu"
+
+    # 5 to 10s wait times
+    block:
+        choice:
+            5.0
+        choice:
+            6.0
+        choice:
+            7.0
+        choice:
+            8.0
+        choice:
+            9.0
+        choice:
+            10.0
+
+    repeat
+
+# love
+image monika ATL_love:
+    
+    # select image
+    block:
+        choice 0.02:
+            "monika 1eua"
+            1.0
             choice:
-                9.0
+                "monika 1sua"
+                4.0
             choice:
-                10.0
+                "monika 1kua"
+                1.5
+            "monika 1eua"
+
+        choice 0.98:
+            choice 0.510104:
+                "monika 1eua"
+            choice 0.255102:
+                "monika 5esu"
+            choice 0.091837:
+                "monika 5tsu"
+            choice 0.091837:
+                "monika 1huu"
+            choice 0.051020:
+                "monika 5eubla"
+
+    # 5 to 10s wait times
+    block:
+        choice:
+            5.0
+        choice:
+            6.0
+        choice:
+            7.0
+        choice:
+            8.0
+        choice:
+            9.0
+        choice:
+            10.0
+
+    repeat
 
 
 ### [IMG050]
 # condition-switched images for old school image selecting
 image monika idle = ConditionSwitch(
-    "mas_isMoniBroken(lower=True)", "monika 6ckc"
+    "mas_isMoniBroken(lower=True)", "monika 6ckc",
     "mas_isMoniDis()", "monika 6ATL_lookleftright",
     "mas_isMoniUpset()", "monika 2efc",
-    "mas_isMoniNormal()", "monika 1esa",
+    "mas_isMoniNormal() and mas_isBelowZero()", "monika ATL_0_to_upset",
     "mas_isMoniHappy()", "monika 1eua",
+    "mas_isMoniAff()", "monika ATL_affectionate",
+    "mas_isMoniEnamored()", "monika ATL_enamored",
+    "mas_isMoniLove()", "monika ATL_love",
+    "True", "monika 1esa",
     predict_all=True
 )
 

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -9339,7 +9339,7 @@ image monika 6lkc = DynamicDisplayable(
     mas_drawmonika,
     character=monika_chr,
     eyebrows="knit",
-    eyes="right",
+    eyes="left",
     nose="def",
     mouth="smirk",
     head="o",
@@ -9592,7 +9592,8 @@ image monika 6ATL_cryleftright:
 # similar to cryleft and right
 # meant for DISTRESSED
 image monika 6ATL_lookleftright:
-    # select an image
+
+    # select image
     block:
         choice:
             "monika 6rkc"
@@ -9623,7 +9624,7 @@ image monika ATL_0_to_upset:
     # select image
     block:
         choice 0.95:
-            "monika 1esa"
+            "monika 1esc"
         choice 0.05:
             "monika 5tsc"
 

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -9225,6 +9225,32 @@ image monika 6wfw = DynamicDisplayable(
     arms="down"
 )
 
+image monika 6rkc = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="right",
+    nose="def",
+    mouth="smirk",
+    head="o",
+    left="1l",
+    right="1r",
+    arms="down"
+)
+
+image monika 6lkc = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="right",
+    nose="def",
+    mouth="smirk",
+    head="o",
+    left="1l",
+    right="1r",
+    arms="down"
+)
+
 image monika 6sub = DynamicDisplayable(
     mas_drawmonika,
     character=monika_chr,
@@ -9233,6 +9259,19 @@ image monika 6sub = DynamicDisplayable(
     nose="def",
     mouth="big",
     head="b",
+    left="1l",
+    right="1r",
+    arms="down"
+)
+
+image monika 6ckc = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="crazy",
+    nose="def",
+    mouth="smirk",
+    head="c",
     left="1l",
     right="1r",
     arms="down"
@@ -9452,6 +9491,44 @@ image monika 6ATL_cryleftright:
                 0.8
 
         repeat
+
+# similar to cryleft and right
+# meant for DISTRESSED
+image monika 6ATL_lookleftright:
+    block:
+        # select an image
+        block:
+            choice:
+                "monika 6rkc"
+            choice:
+                "monika 6lkc"
+
+        # select a wait time
+        block:
+            choice:
+                5.0
+            choice:
+                6.0
+            choice:
+                7.0
+            choice:
+                8.0
+            choice:
+                9.0
+            choice:
+                10.0
+
+
+### [IMG050]
+# condition-switched images for old school image selecting
+image monika idle = ConditionSwitch(
+    "mas_isMoniBroken(lower=True)", "monika 6ckc"
+    "mas_isMoniDis()", "monika 6ATL_lookleftright",
+    "mas_isMoniUpset()", "monika 2efc",
+    "mas_isMoniNormal()", "monika 1esa",
+    "mas_isMoniHappy()", "monika 1eua",
+    predict_all=True
+)
 
 
 ### [IMG100]


### PR DESCRIPTION
#2055 

This also acts as an easy way to tell what affection level you are at.

## features
* idle mode now has varying expressions, based on affection
* talk and play menu dialogue is now different based on affection
* also added a neato dev line to disable the im sorry check

Idle expressions table:

| affection | sprite codes | descriptions |
|---|---|---|
| broken | 6ckc | broken or deranged? |
| distressed | 6rkc/6lkc | listly looking left and right, avoiding eye contact with player |
| upset | 2efc | looks angry |
| upset -> 0 | 1esc / 5tsc | non-smiling, bored |
| normal | 1esa | defualt |
| happy | 1eua | higher eyebrows than default |
| affectionate | 1eua / 1hua / 1sua / 1kua | variety of happy expressions |
| enamored | 1eua / 5esu / 5tsu / 1huu / 1sua / 1kua | variety of happy expressions |
| love | 1eua / 5esu / 5tsu / 1huu / 5eubla / 1sua / 1kua | variety of happy expressions |

The affectionate+ expressions use a particular set of percentages explained on the doc.

The talk and play menus use `MASQuipLists`, but are only limited to lines.
These are created in `mas_affection`.

## Testing
1. set random chatter to never
2. for each affection level, observe monika in idle mode.
3. also check talk menu and play menu for the changed dialogue.

Before testing upset and below, you should set `persistent._mas_disable_sorry` to True to stop the imsorry check from being brought up and enforced.

**NOTE** this is on content because of the art. Dialogue is so small so no review needed.