### PR TITLE
Better disable animations

### DIFF
--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -1077,7 +1077,7 @@ screen preferences():
                 vbox:
                     style_prefix "check"
                     label _("Graphics")
-                    textbutton _("Disable Animation") action [Preference("video sprites", "toggle"), Function(renpy.call, "spaceroom")]
+                    textbutton _("Disable Animation") action [ToggleField(persistent, "_mas_disable_animations"), Function(mas_drawSpaceroomMasks)]
                     textbutton _("Change Renderer") action Function(renpy.call_in_new_context, "mas_gmenu_start")
 
 

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -508,14 +508,23 @@ screen quick_menu():
             yalign 0.995
 
             #textbutton _("Back") action Rollback()
-            textbutton _("History") action ShowMenu('history')
+
+#            textbutton _("History") action ShowMenu('history')
+            textbutton _("History") action Function(_mas_quick_menu_cb, "history")
+
             textbutton _("Skip") action Skip() alternate Skip(fast=True, confirm=True)
             textbutton _("Auto") action Preference("auto-forward", "toggle")
-            textbutton _("Save") action ShowMenu('save')
-            textbutton _("Load") action ShowMenu('load')
+
+#            textbutton _("Save") action ShowMenu('save')
+            textbutton _("Save") action Function(_mas_quick_menu_cb, "save")
+
+#            textbutton _("Load") action ShowMenu('load')
+            textbutton _("Load") action Function(_mas_quick_menu_cb, "load")
             #textbutton _("Q.Save") action QuickSave()
             #textbutton _("Q.Load") action QuickLoad()
-            textbutton _("Settings") action ShowMenu('preferences')
+
+#            textbutton _("Settings") action ShowMenu("preferences")
+            textbutton _("Settings") action Function(_mas_quick_menu_cb, "preferences")
 
 
 ## This code ensures that the quick_menu screen is displayed in-game, whenever

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -1077,7 +1077,7 @@ screen preferences():
                 vbox:
                     style_prefix "check"
                     label _("Graphics")
-                    textbutton _("Disable Animation") action [ToggleField(persistent, "_mas_disable_animations"), Function(mas_drawSpaceroomMasks)]
+                    textbutton _("Disable Animation") action ToggleField(persistent, "_mas_disable_animations")
                     textbutton _("Change Renderer") action Function(renpy.call_in_new_context, "mas_gmenu_start")
 
 

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -6,11 +6,15 @@ default initial_monika_file_check = None
 define modoorg.CHANCE = 20
 define mas_battery_supported = False
 
+# True means disable animations, False means enable
+default persistent._mas_disable_animations = False
+
 init -1 python in mas_globals:
     # global that are not actually globals.
 
     # True means we are in the dialogue workflow. False means not
     dlg_workflow = False
+
 
 init 970 python:
     if persistent._mas_moni_chksum is not None:
@@ -95,24 +99,44 @@ image ut_slash:
 
 image room_glitch = "images/cg/monika/monika_bg_glitch.png"
 
-image room_mask = Movie(channel="window_1", play="mod_assets/window_1.webm",mask=None,image="mod_assets/window_1_fallback.png")
-image room_mask2 = Movie(channel="window_2", play="mod_assets/window_2.webm",mask=None,image="mod_assets/window_2_fallback.png")
-image room_mask3 = Movie(channel="window_3", play="mod_assets/window_3.webm",mask=None,image="mod_assets/window_3_fallback.png")
-image room_mask4 = Movie(channel="window_4", play="mod_assets/window_4.webm",mask=None,image="mod_assets/window_4_fallback.png")
+image room_mask = Movie(
+    channel="window_1",
+    play="mod_assets/window_1.webm",
+    mask=None
+)
+image room_mask_fb = "mod_assets/window_1_fallback.png"
+image room_mask2 = Movie(
+    channel="window_2",
+    play="mod_assets/window_2.webm",
+    mask=None
+)
+image room_mask2_fb = "mod_assets/window_2_fallback.png"
+image room_mask3 = Movie(
+    channel="window_3",
+    play="mod_assets/window_3.webm",
+    mask=None
+)
+image room_mask3_fb = "mod_assets/window_3_fallback.png"
+image room_mask4 = Movie(
+    channel="window_4",
+    play="mod_assets/window_4.webm",
+    mask=None
+)
+image room_mask4_fb = "mod_assets/window_4_fallback.png"
 
 # big thanks to sebastianN01 for the rain art!
 image rain_mask_left = Movie(
     channel="window_5",
     play="mod_assets/window_5.webm",
-    mask=None,
-    image="mod_assets/window_5_fallback.png"
+    mask=None
 )
+image rain_mask_left_fb = "mod_assets/window_5_fallback.png"
 image rain_mask_right = Movie(
     channel="window_6",
     play="mod_assets/window_6.webm",
-    mask=None,
-    image="mod_assets/window_6_fallback.png"
+    mask=None
 )
+image rain_mask_right_fb = "mod_assets/window_6_fallback.png"
 
 # spaceroom window positions
 transform spaceroom_window_left:
@@ -234,6 +258,10 @@ init python:
             morning_flag
             mas_is_raining
         """
+        # hide the existing masks 
+        renpy.hide("rm")
+        renpy.hide("rm2")
+
         if mas_is_raining:
             # raining takes priority
             left_window = "rain_mask_left"
@@ -248,6 +276,11 @@ init python:
             # night time
             left_window = "room_mask"
             right_window = "room_mask2"
+
+        # should we use fallbacks instead?
+        if persistent._mas_disable_animations:
+            left_window += "_fb"
+            right_window += "_fb"
 
         # now show the masks
         renpy.show(left_window, at_list=[spaceroom_window_left], tag="rm")

--- a/Monika After Story/game/zz_hotkeys.rpy
+++ b/Monika After Story/game/zz_hotkeys.rpy
@@ -158,12 +158,30 @@ init python:
                 mas_drawSpaceroomMasks()
 
 
+    def _mas_quick_menu_cb(screen_name):
+        """
+        Opens game menu to the appropraite quick screen.
+        NOTE: no checks are done here, please do not fuck this.
+        """
+        if not _windows_hidden:
+            prev_disable_animations = persistent._mas_disable_animations
+            renpy.call_in_new_context(
+                "_game_menu", 
+                _game_menu_screen=screen_name
+            )
+
+            # call backs for the game menu
+            if prev_disable_animations != persistent._mas_disable_animations:
+                mas_drawSpaceroomMasks()
+
+
     def _mas_hide_windows():
         """
         Wrapper around the _hide_windows label that hides windows
         """
         if not store.mas_hotkeys.no_window_hiding:
             renpy.call_in_new_context("_hide_windows")
+
 
     def set_keymaps():
         #

--- a/Monika After Story/game/zz_hotkeys.rpy
+++ b/Monika After Story/game/zz_hotkeys.rpy
@@ -150,7 +150,12 @@ init python:
         Wrapper aound _invoke_game_menu that follows additional ui rules
         """
         if not _windows_hidden:
+            prev_disable_animations = persistent._mas_disable_animations
             _invoke_game_menu()
+
+            # call backs for the game menu
+            if prev_disable_animations != persistent._mas_disable_animations:
+                mas_drawSpaceroomMasks()
 
 
     def _mas_hide_windows():


### PR DESCRIPTION
Drops the renpy call function when disabling animations and replaces it with a better system.

This will prevent context breaks from occurring again.

## Testing
1. set animations to disabled
2. relaunch game
3. go into settings and enable animations
4. verify that the animated sprites are visible in the windows

Repeat these steps for day/night time.
Repeat these steps going from enabled to disabled.