### PR TITLE
force update folder move its in game

### DIFF
--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -651,6 +651,7 @@ init python in mas_updater:
         """
         import time
         import os
+        import shutil
 
         curr_time = time.time()
 
@@ -665,27 +666,26 @@ init python in mas_updater:
         if last_updated > curr_time:
             last_updated = 0
 
-        #Make sure the update folder is where it should be
-        can_update = renpy.store.updater.can_update()
-        if not can_update:
-
+        # always move update folder if possible
+        game_update = os.path.normcase(renpy.config.basedir + "/game/update")
+        ddlc_update = os.path.normcase(renpy.config.basedir + "/update")
+        base_update = os.path.normcase(renpy.config.basedir)
+        if os.access(game_update, os.F_OK):
             try:
-                os.rename(
-                    os.path.normcase(renpy.config.basedir + "/game/update"),
-                    os.path.normcase(renpy.config.basedir + "/update")
-                )
+                if os.access(ddlc_update, os.F_OK):
+                    shutil.rmtree(ddlc_update)
+
+                shutil.move(game_update, base_update)
                 can_update = renpy.store.updater.can_update()
 
-                if not can_update:
-                    # still cant move the update folder. notify user
-                    renpy.game.persistent._mas_can_update = False
-
             except:
-                # we cant move the update folder. We should notify user
-                renpy.game.persistent._mas_can_update = False
+                can_update = False
 
         else:
-            renpy.game.persistent._mas_can_update = True
+            can_update = renpy.store.updater.can_update()
+
+        # notify user
+        renpy.game.persistent._mas_can_update = can_update
 
         if force:
             check_wait = 0


### PR DESCRIPTION
Addresses most updater issues by forcing the update folder in game to be moved into the basedir. 

Basically if we find an update folder in game, we delete the basedir's update folder and move the game one there. No exceptions.

## Testing
### moving update folder
1. move update folder in basedir to the gamedir.
2. Launch game. 
3. the update folder should be moved into the basedir.

### update folder already exists
1. Copy the update folder from basedir to gamedir.
2. Launch game.
3. the update folder in basedir should be deleted and replacd with the one from gamedir. No update folder should exist in gamedir.

### cannot delete update folder
1. Do the same as above, but make it so that basedir's update cannot be deleted somehow. (give it no write perms).
2. Launch game.
3. Open settings and click Update Now. 
4. A popup should appear saying game could not update becaues the folder could not be moved.