### PR TITLE
adding restricting of playtime

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -2717,6 +2717,11 @@ init -1 python:
     def mas_isMonikaBirthday():
         return datetime.date.today() == datetime.date(datetime.date.today().year, 9, 22)
 
+
+    def mas_maxPlaytime():
+        return datetime.datetime.now() - datetime.datetime(2017, 9, 22)
+
+
     def get_pos(channel='music'):
         pos = renpy.music.get_pos(channel=channel)
         if pos: return pos

--- a/Monika After Story/game/splash.rpy
+++ b/Monika After Story/game/splash.rpy
@@ -320,9 +320,12 @@ label quit:
             persistent.sessions["last_session_end"] 
             - persistent.sessions["current_session_start"]
         )
-        # gotta prevent negative time addons
-        if today_time > datetime.timedelta(0):
-            persistent.sessions['total_playtime'] += today_time
+        new_time = today_time + persistent.sessions["total_playtime"]
+
+        # prevent out of boudns time
+        if datetime.timedelta(0) < new_time <= mas_maxPlaytime():
+            persistent.sessions['total_playtime'] = new_time
+
 
         # set the monika size
         store.mas_dockstat.setMoniSize(persistent.sessions["total_playtime"])


### PR DESCRIPTION
#2361 

Adds a new function that returns the max possible playtime anyone could possibly have.

Also now cleans up time so users with playtime thats over the max possible will get reset to 100th of max playtime.
Users with playtime thats negative will get reset to 0.

if the playtime for a session goes over the max or goes below 0, it is not added to the internal time count.

# Testing
### adding negative time.
1. launch game.
2. set "current_session_start" to a datetime in the future.
3. close game.
4. reopen game and verify that `total_playtime` did not change.

### adding overage time
1. launch game.
2. set `current_session_start` to a datetime that is before 2017-09-22.
3. close game.
4. Reopen game and verify that `total_playtime` did not change.

### starting with negative time
1. launch game.
2. set `total_playtime` to a negative time.
3. close game.
4. Reopen game and verify that `total_playtime` is now 0.

### starting with overage time.
1. launch game.
2. set `total_playtime` to a value larger than max time. (`mas_maxPlaytime() + datetime.timedelta(1)`)
3. close game.
4. reopen game and verify that `total_playtime` is like 3 days. (basically a 100th of `mas_maxPlaytime()`)