### PR TITLE
File reactions

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -2269,6 +2269,15 @@ init -100 python in mas_utils:
         return data
 
 
+    def intersperse(_list, _sep):
+        """
+        Intersperses a list with the given separator
+        """
+        result_list = [_sep] * (len(_list) * 2 - 1)
+        result_list[0::2] = _list
+        return result_list
+
+
     class ISCRAM(ctypes.BigEndianStructure):
         _iscramfieldbuilder = [
             3, 3, 2, 1, 3, 2, 2, 1, 3, 3, 1, 3, 1

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -1243,11 +1243,12 @@ label call_next_event:
                 $persistent.closed_self = True #Monika happily closes herself
                 jump _quit
 
-        show monika idle at t11 zorder MAS_MONIKA_Z with dissolve #Return monika to normal pose
-
         # loop over until all events have been called
         if len(persistent.event_list) > 0:
             jump call_next_event
+
+        # return to normal pose
+        show monika idle at t11 zorder MAS_MONIKA_Z
 
         $ mas_DropShield_dlg()
 

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -88,6 +88,7 @@ init 850 python:
     mas_all_ev_db.update(store.mas_moods.mood_db)
     mas_all_ev_db.update(store.mas_stories.story_database)
     mas_all_ev_db.update(store.mas_compliments.compliment_database)
+    mas_all_ev_db.update(store.mas_filereacts.filereact_db)
 
     def mas_getEV(ev_label):
         """

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -5,6 +5,7 @@ default persistent.rejected_monika = None
 default initial_monika_file_check = None
 define modoorg.CHANCE = 20
 define mas_battery_supported = False
+define mas_skip_mid_loop_eval = False
 
 # True means disable animations, False means enable
 default persistent._mas_disable_animations = False
@@ -777,6 +778,11 @@ label ch30_post_greeting_check:
     # this label skips greeting selection as well as exp checks for game close
     # we assume here that you set selected_greeting if you needed to
 
+    # file reactions
+#    if mas_isMonikaBirthday():
+    if True:
+        $ mas_checkReactions()
+
     #Run actions for any events that need to be changed based on a condition
     $ evhand.event_database=Event.checkConditionals(evhand.event_database)
 
@@ -789,11 +795,6 @@ label ch30_post_greeting_check:
     # corruption check
     if mas_corrupted_per and not renpy.seen_label("mas_corrupted_persistent"):
         $ pushEvent("mas_corrupted_persistent")
-
-    # file reactions
-#    if mas_isMonikaBirthday():
-    if True:
-        $ mas_checkReactions()
 
     # push greeting if we have one
     if selected_greeting:
@@ -859,6 +860,9 @@ label ch30_loop:
     else:
         $ config.allow_skipping = False
 
+    if mas_skip_mid_loop_eval:
+        jump ch30_post_mid_loop_eval
+
     #Check time based events and grant time xp
     python:
         try:
@@ -906,10 +910,15 @@ label ch30_loop:
             # save the persistent
             renpy.save_persistent()
 
+label ch30_post_mid_loop_eval:
+
     #Call the next event in the list
     call call_next_event from _call_call_next_event_1
     # Just finished a topic, so we set current topic to 0 in case user quits and restarts
     $ persistent.current_monikatopic = 0
+
+    # reset the mid loop eval if we didnt' quit right away
+    $ mas_skip_mid_loop_eval = False
 
     #If there's no event in the queue, add a random topic as an event
     if not _return:

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -886,6 +886,9 @@ label ch30_loop:
             # Run delayed actions
             mas_runDelayedActions(MAS_FC_IDLE_ROUTINE)
 
+            # run file checks
+            # TODO
+
             #Update time
             calendar_last_checked=datetime.datetime.now()
 

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -17,6 +17,8 @@ init -1 python in mas_globals:
 
 
 init 970 python:
+    import store.mas_filereacts as mas_filereacts
+
     if persistent._mas_moni_chksum is not None:
         # do check for monika existence
         moni_tuple = store.mas_dockstat.findMonika(
@@ -788,6 +790,11 @@ label ch30_post_greeting_check:
     if mas_corrupted_per and not renpy.seen_label("mas_corrupted_persistent"):
         $ pushEvent("mas_corrupted_persistent")
 
+    # file reactions
+#    if mas_isMonikaBirthday():
+    if True:
+        $ mas_checkReactions()
+
     # push greeting if we have one
     if selected_greeting:
         $ pushEvent(selected_greeting)
@@ -887,7 +894,8 @@ label ch30_loop:
             mas_runDelayedActions(MAS_FC_IDLE_ROUTINE)
 
             # run file checks
-            # TODO
+#            if mas_isMonikaBirthday():
+            mas_checkReactions()
 
             #Update time
             calendar_last_checked=datetime.datetime.now()

--- a/Monika After Story/game/script-farewells.rpy
+++ b/Monika After Story/game/script-farewells.rpy
@@ -115,6 +115,8 @@ label mas_farewell_start:
     # otherwise, select a random farewell
     $ farewell = store.mas_farewells.selectFarewell()
     $ pushEvent(farewell.eventlabel)
+    # dont evalulate the mid loop checks since we are quitting
+    $ mas_skip_mid_loop_eval = True
 
     return
 

--- a/Monika After Story/game/zz_dockingstation.rpy
+++ b/Monika After Story/game/zz_dockingstation.rpy
@@ -183,6 +183,29 @@ init -45 python:
             return pkg_slip
 
 
+        def getPackageList(self, ext_filter=""):
+            """
+            Gets a list of the packages in the docking station.
+
+            IN:
+                ext_filter - extension filter to use when getting list.
+                    the '.' is added if not already given.
+                    If not given, we get all the packages
+                    (Default: "")
+
+            RETURNS: list of packages 
+            """
+            # correct filter if needed
+            if len(ext_filter) > 0 and not ext_filter.startswith("."):
+                ext_filter = "." + extfilter
+
+            return [
+                package
+                for package in os.listdir(self.station)
+                if package.endswith(ext_filter)
+            ]
+
+
         def getPackage(self, package_name):
             """
             Gets a package from the docking station

--- a/Monika After Story/game/zz_dockingstation.rpy
+++ b/Monika After Story/game/zz_dockingstation.rpy
@@ -227,7 +227,7 @@ init -45 python:
             """
             # correct filter if needed
             if len(ext_filter) > 0 and not ext_filter.startswith("."):
-                ext_filter = "." + extfilter
+                ext_filter = "." + ext_filter
 
             return [
                 package

--- a/Monika After Story/game/zz_dockingstation.rpy
+++ b/Monika After Story/game/zz_dockingstation.rpy
@@ -85,6 +85,7 @@ init -45 python:
         # 1 - docking station as str
         # 2 - exception (if applicable)
         ERR = "[ERROR] {0} | {1} | {2}\n"
+        ERR_DEL = "Failure removing package '{0}'."
         ERR_GET = "Failure getting package '{0}'."
         ERR_OPEN = "Failure opening package '{0}'."
         ERR_READ = "Failure reading package '{0}'."
@@ -183,6 +184,35 @@ init -45 python:
             return pkg_slip
 
 
+        def destroyPackage(self, package_name):
+            """
+            Attempts to destroy the given package in the docking station.
+
+            NOTE: exceptions are logged
+
+            IN:
+                package_name - name of the package to delete
+
+            RETURNS:
+                True if package no exist or was deleted. False otherwise
+            """
+            if not self.checkForPackage(package_name, False):
+                return True
+
+            # otherwise we have a package
+            try:
+                os.remove(self._trackPackage(package_name))
+                return True
+
+            except Exception as e:
+                mas_utils.writelog(self.ERR.format(
+                    self.ERR_DEL.format(package_name),
+                    str(self),
+                    repr(e)
+                ))
+                return False
+
+
         def getPackageList(self, ext_filter=""):
             """
             Gets a list of the packages in the docking station.
@@ -234,7 +264,7 @@ init -45 python:
                 mas_utils.writelog(self.ERR.format(
                     self.ERR_OPEN.format(package_name),
                     str(self),
-                    str(e)
+                    repr(e)
                 ))
                 if package is not None:
                     package.close()
@@ -845,7 +875,7 @@ init -45 python:
                 mas_utils.writelog(self.ERR.format(
                     self.ERR_GET.format(package_path),
                     str(self),
-                    str(e)
+                    repr(e)
                 ))
 
                 # in error case, assume failure

--- a/Monika After Story/game/zz_reactions.rpy
+++ b/Monika After Story/game/zz_reactions.rpy
@@ -1,9 +1,17 @@
 # FileReactions framework.
 # not too different from events
 
+default persistent._mas_filereacts_failed_map = dict()
+
+init 800 python:
+    if len(persistent._mas_filereacts_failed_map) > 0:
+        store.mas_filereacts.delete_all(persistent._mas_filereacts_failed_map)
+
 init -1 python in mas_filereacts:
     import store
+    import store.mas_utils as mas_utils
     import datetime
+    import random
     
     # file react database
     filereact_db = dict()
@@ -25,8 +33,9 @@ init -1 python in mas_filereacts:
 
     # connector quips
     connectors = None
+    gift_connectors = None
 
-    def addReaction(ev_label, fname_list, _action):
+    def addReaction(ev_label, fname_list, _action=store.EV_ACT_QUEUE):
         """
         Adds a reaction to the file reactions database.
 
@@ -34,6 +43,7 @@ init -1 python in mas_filereacts:
             ev_label - label of this event
             fname_list - list of filenames to react to (lowercase please)
             _action - the EV_ACT to do
+                (Default: EV_ACT_QUEUE)
         """
         # lowercase the list in case
         fname_list = sorted([x.lower() for x in fname_list])
@@ -55,15 +65,11 @@ init -1 python in mas_filereacts:
         """
         Initializes the connector quips
         """
-        global connectors
+        global connectors, gift_connectors
 
         # the connector is a MASQipList
         connectors = store.MASQuipList(allow_glitch=False, allow_line=False)
-
-        # add label connectors here
-        _conn_labels = [] 
-        for _connector in _conn_labels:
-            connectors.addLabelQuip(_connector)
+        gift_connectors = store.MASQuipList(allow_glitch=False, allow_line=False)
 
 
     def react_to_gifts(found_map, connect=True):
@@ -98,7 +104,127 @@ init -1 python in mas_filereacts:
         gifts_found.sort()
             
         # now we are ready to check for reactions
-        # TODO
+        # first we check for all file reacts:
+        all_reaction = filereact_map.get(gifts_found, None)
+
+        if all_reaction is not None:
+            return [all_reaction.eventlabel]
+
+        # otherwise, we need to do this more carefully
+        found_reacts = list()
+        for index in range(len(gifts_round)-1, -1, -1):
+            _gift = gifts_round[index]
+            reaction = filereact_map.get(_gift, None)
+
+            if _gift is not None:
+                # remove from the list and add to found
+                gifts_found.pop()
+                found_reacts.append(reaction.eventlabel)
+                found_reacts.append(gift_connectors.quip()[1])
+
+        # add in the generic gift reactions
+        if len(gifts_round) > 0:
+            for _gift in gifts_found:
+                found_reacts.append("mas_reaction_gift_generic")
+                found_reacts.append(gift_connectors.quip()[1])
+
+        # gotta remove the extra
+        found_reacts.pop()
+
+        # now return the list
+        return found_reacts
+
+
+    def _core_delete(_filename, _map):
+        """
+        Core deletion file function.
+
+        IN:
+            _filename - name of file to delete, if None, we delete one randomly
+            _map - the map to use when deleting file.
+        """
+        if len(_map) == 0:
+            return
+
+        # otherwise check for random deletion
+        if _filename is None:
+            _filename = random.choice(_map.keys()) 
+
+        file_to_delete = _map.get(_filename, None):
+        if file_to_delete is None:
+            return
+
+        if store.mas_docking_station.destroyPackage(file_to_delete):
+            # file has been deleted (or is gone). pop and go
+            _map.pop(file_to_delete)
+            return
+
+        # otherwise add to the failed map
+        store.persistent._mas_filereacts_failed_map[_filename] = file_to_delete
+
+
+    def delete_file(_filename):
+        """
+        Deletes a file off the found_react map
+
+        IN:
+            _filename - the name of the file to delete. If None, we delete
+                one randomly
+        """
+        _core_delete(_filename, foundreact_map)
+
+
+    def th_delete_file(_filename):
+        """
+        Deletes a file off the threaded found_react map
+        """
+        _core_delete(_filename, th_foundreact_map)
+
+
+    def delete_all(_map):
+        """
+        Attempts to delete all files in the given map.
+        Removes files in that map if they dont exist no more
+
+        IN:
+            _map - map to delete all 
+        """
+        _map_keys = _map.keys()
+        for _key in _map_keys:
+            _core_delete(_key, _map)
+
 
     _initConnectorQuips()
 
+
+### CONNECTORS [RCT000]
+
+# none here!
+
+## Gift CONNECTORS [RCT10]
+
+init 5 python:
+    store.mas_reactions.gift_connectors.addLabelQuip(
+        "mas_reaction_gift_connector_test"
+    )
+
+label mas_reaction_gift_connector_test:
+    m "this is a test of the connector system"
+    return
+
+
+### REACTIONS [RCT100]
+
+init 5 python:
+    addReaction("mas_reaction_generic", None)
+
+label mas_reaction_generic:
+    "This is a test"
+    return
+
+init 5 python:
+    addReaction("mas_reaction_gift_generic", None)
+
+label mas_reaction_gift_generic:
+    m "this is a test of the generic gift reaction"
+    return

--- a/Monika After Story/game/zz_reactions.rpy
+++ b/Monika After Story/game/zz_reactions.rpy
@@ -1,0 +1,104 @@
+# FileReactions framework.
+# not too different from events
+
+init -1 python in mas_filereacts:
+    import store
+    import datetime
+    
+    # file react database
+    filereact_db = dict()
+
+    # file reaction filename mapping
+    # key: filename or list of filenames
+    # value: Event
+    filereact_map = dict()
+
+    # currently found files react map 
+    # NOTE: highly volitatle. Expect this to change often
+    # key: lowercase filename, without extension
+    # value: on disk filename
+    foundreact_map = dict()
+
+    # spare foundreact map, designed for threaded use
+    # same keys/values as foundreact_map
+    th_foundreact_map = dict()
+
+    # connector quips
+    connectors = None
+
+    def addReaction(ev_label, fname_list, _action):
+        """
+        Adds a reaction to the file reactions database.
+
+        IN:
+            ev_label - label of this event
+            fname_list - list of filenames to react to (lowercase please)
+            _action - the EV_ACT to do
+        """
+        # lowercase the list in case
+        fname_list = sorted([x.lower() for x in fname_list])
+
+        # build new Event object
+        ev = store.Event(
+            store.persistent.event_database,
+            ev_label,
+            category=fname_list,
+            action=_action
+        )
+
+        # add it to the db and map
+        filereact_db[ev_label] = ev
+        filereact_map[fname_list] = ev
+
+
+    def _initConnectorQuips():
+        """
+        Initializes the connector quips
+        """
+        global connectors
+
+        # the connector is a MASQipList
+        connectors = store.MASQuipList(allow_glitch=False, allow_line=False)
+
+        # add label connectors here
+        _conn_labels = [] 
+        for _connector in _conn_labels:
+            connectors.addLabelQuip(_connector)
+
+
+    def react_to_gifts(found_map, connect=True):
+        """
+        call this function when you want to check files for reacting to gifts.
+
+        IN:
+            found_map - dict to use to insert found items.
+                NOTE: this function does NOT empty this dict.
+            connect - True will add connectors in between each reaction label
+                (Default: True)
+
+        RETURNS:
+            list of event labels in the order they should be shown
+        """
+        GIFT_EXT = ".gift"
+        raw_gifts = store.mas_docking_station.getPackageList(GIFT_EXT)
+
+        if len(raw_gifts) == 0:
+            return []
+
+        # otherwise we found some potential gifts
+        gifts_found = list()
+        # now lets lowercase this list whie also buliding a map of files
+        for _gift in raw_gifts:
+            gift_name, ext, garbage = _gift.partition(GIFT_EXT)
+            c_gift_name = gift_name.lower()
+            gifts_found.append(c_gift_name)
+            found_map[c_gift_name] = _gift
+
+        # then sort the list
+        gifts_found.sort()
+            
+        # now we are ready to check for reactions
+        # TODO
+
+    _initConnectorQuips()
+


### PR DESCRIPTION
The first step of the file reaction framework. this should help with initial tests of all the shit we gon do.

Main things are:
* file reaction database
* key functions for checking for reactions
* and some other shit

Everything is subject to renaming.

# Testing
### STartup Detection
1. Add `test1.gift` and `test2.gift`  to charactesr folder
2. Run game
3. Verify that Monika talks the test dialogue about the 2 files.
4. Verify that the files are deleted as their dialogue passes.

### Wait detection
1. Launch game.
2. During idle, add the 2 files to character folder.
3. Wait a minute.
4. Verify that Monika talks the test dialogue about the 2 files.
5. Verify that the files are deleted as their dialogue passes.
**NOTE** we may do multithreading here at some point to make this instant instead of delayed.

### delete fail
1. add the files.
2. make one of the files read-only (aka cannot be deleted because of perms)
3. launch game.
4. verify that monika gives her dialogue
5. verify that only that could be deleted was deleted
6. Wait a minute.
7. Verify that Monika does **not** talk about the file that still exists.
8. Relaunch game.
9. Verify that Monika does **not** talk about the file that still exists.
10. Restore delete perms to the file.
11. Relaunch game.
12. Vreify that Monika does **not** talk about the file.
13. Verify that the file gets deleted.

### file removal when delet fail.
Follow the same steps as the above delete fail, but instead of restoring write perms, just delete the file.
The effect should be exactly the same as above.

### no double reacts
1. Add the files
2. launch the game.
3. **Dont advance dialogue**
4. Check `persistent._mas_filereacts_just_reacted`. this should be true.
5. close game via close button (aka force close)
6. Realunch game
7. Verify that `persistent.event_list` does **not** have duplicated file reaction labels.
**NOTE** you can also check this by running `mas_checkReactions()` multiple times and verifying that `persistent.event_list` is not growing after each call to that function. 

### no reacts during goodbye.
1. launch the game.
2. when in idle, add the files.
3. open the talk menu, wait a minute, then click goodbye and pick a goodbye.
4. verify that the file reaction dialogue does not occur.
5. relaunch game.
6. remove the files.
7. Verify that the the filereaction dialogue does **not** occur.

**NOTE** there are lot of testing stuff in here, this will be removed once we put in the dialogue as well hammer out issues

# KNOWN ISSUES:
* reactions aren't instant during idle. This may be addressed via multithreading event stack checks and more.