### PR TITLE
fixing update migration script issues

### DIFF
--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -186,7 +186,7 @@ init python:
             updateTo = updates.version_updates[startVers]
 
             # we should only call update labels that we have
-            if renpy.has_label(updateTo):
+            if renpy.has_label(updateTo) and not renpy.seen_label(updateTo):
                 renpy.call_in_new_context(updateTo, updateTo)
             startVers = updates.version_updates[startVers]
 
@@ -199,27 +199,30 @@ init 10 python:
     # okay do we have a version number?
     if persistent.version_number is None:
         # here comes the logic train
-        if no_topics_list:
-            # we are in version 0.2.2 (the horror!)
-            updateGameFrom("v0_2_2")
 
-        elif (renpy.seen_label("monika_ribbon") or
-                "monika_ribbon" in persistent.monika_random_topics):
-            # we are in version 0.3.3
-            updateGameFrom("v0_3_3")
-
-        elif found_monika_ani:
-            # we are in version 0.3.2
-            updateGameFrom("v0_3_2")
-
-        elif (renpy.seen_label("monika_monika") or
-                "monika_monika" in persistent.monika_random_topics):
-            # we are in version 0.3.1
-            updateGameFrom("v0_3_1")
-
-        else:
-            # we are in version 0.3.0
-            updateGameFrom("v0_3_0")
+# NOTE: we are dropping this because of issues we are having with update
+#   scripts running when we least expect.
+#        if no_topics_list:
+#            # we are in version 0.2.2 (the horror!)
+#            updateGameFrom("v0_2_2")
+#
+#        elif (renpy.seen_label("monika_ribbon") or
+#                "monika_ribbon" in persistent.monika_random_topics):
+#            # we are in version 0.3.3
+#            updateGameFrom("v0_3_3")
+#
+#        elif found_monika_ani:
+#            # we are in version 0.3.2
+#            updateGameFrom("v0_3_2")
+#
+#        elif (renpy.seen_label("monika_monika") or
+#                "monika_monika" in persistent.monika_random_topics):
+#            # we are in version 0.3.1
+#            updateGameFrom("v0_3_1")
+#
+#        else:
+#            # we are in version 0.3.0
+#            updateGameFrom("v0_3_0")
 
         # set the version now
         persistent.version_number = config.version
@@ -241,6 +244,29 @@ init 10 python:
 
         # and clear update data
         clearUpdateStructs()
+
+
+    ### special function for resetting versions
+    def _mas_resetVersionUpdates():
+        """
+        Resets all version update script's seen status
+        """
+        late_updates = [
+            "v0_8_3",
+            "v0_8_4"
+        ]
+
+        renpy.call_in_new_context("vv_updates_topics")
+        ver_list = store.updates.version_updates.keys()
+
+        ver_list.extend(["mas_lupd_" + x for x in late_updates])
+        ver_list.append("v" + "_".join(
+            config.version[:config.version.index("-")].split(".")
+        ))
+
+        for _version in ver_list:
+            if _version in persistent._seen_ever:
+                persistent._seen_ever.pop(_version)
 
 
 # UPDATE SCRIPTS ==============================================================
@@ -839,7 +865,7 @@ label mas_lupd_v0_8_3:
 init 999 python:
     for __temp_version in persistent._mas_zz_lupd_ex_v:
         __lupd_v = "mas_lupd_" + __temp_version
-        if renpy.has_label(__lupd_v):
+        if renpy.has_label(__lupd_v) and not renpy.seen_label(__lupd_v):
             renpy.call_in_new_context(__lupd_v)
 
     persistent._mas_zz_lupd_ex_v = list()


### PR DESCRIPTION
#2406 

This addresses 2 main issues:
* update scripts that re-run when switching versions
* update scripts that run when starting a fresh persistent / importing ddlc data

Versions updates now check for seen and refuse to run seen'd update labels.
Because of ambiguity between starting a fresh game and using versions prior to 050, we are dropping migration support for 033 and earlier. Updating MAS from those versions may have unintended side effects.

## Testing

### switch version
1. add a var to a version update script that you can check with console to see if it ran.
2. launch game in latest version
3. launch game with same persistent in a different version of MAS
4. relaunch game in latest verison.
5. verify that the version update scripts did not run. (check console for your var)

### fresh persistent
1. add a var to a version update script that you can check with console
2. launch a fresh game.
3. verify that the version update scripts did not run.
4. Repeat steps 1-3, but importing DDLC data when it asks, then checking if scripts did not run

**NOTE:** to force update scripts to run, call `_mas_resetVersionUpdates` and then set `persistent.version_number` to an older version, then restart game.