### PR TITLE
Reactions to gifts

### DIFF
--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -4617,6 +4617,19 @@ image monika 2wfc = DynamicDisplayable(
     arms="crossed"
 )
 
+image monika 2wfd = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="furrowed",
+    eyes="wide",
+    nose="def",
+    mouth="small",
+    head="c",
+    left="1l",
+    right="2r",
+    arms="crossed"
+)
+
 image monika 2wud = DynamicDisplayable(
     mas_drawmonika,
     character=monika_chr,

--- a/Monika After Story/game/zz_reactions.rpy
+++ b/Monika After Story/game/zz_reactions.rpy
@@ -565,12 +565,11 @@ label mas_reaction_bday_cake:
         $ mas_gainAffection(modifier=2, bypass=True)
         m 1wud "Oh, [player]..."
         m "A... birthday cake?"
-        # show image bday_cake at zorder 11
+        # show mas_bday_cake zorder 11
         m 3sub "Gosh, this is so sweet of you!"
         m 1hub "I really love this a lot!"
-        m 1rksdlb "I really love this a lot!"
         m 1dkbfa "I’ll save it for now"
-        # hide image bday_cake
+        # hide mas_bday_cake
         m 3hua "I can’t wait to try it later!"
         m 1dsc "But..."
         m 3ekbfa "I wish we could eat it together..."
@@ -609,7 +608,7 @@ label mas_reaction_knife:
     m 1dfc "..."
     m 1rsc "I’m not taking this, [player]."
     m 1rfc "If you were trying to be funny, then you have {i}very{/i} poor taste."
-    $ gift_ev = mas_getEV("mas_reaction_cupcake")
+    $ gift_ev = mas_getEV("mas_reaction_knife")
     $ store.mas_filereacts.delete_file(gift_ev.category)
     return
 

--- a/Monika After Story/game/zz_reactions.rpy
+++ b/Monika After Story/game/zz_reactions.rpy
@@ -582,6 +582,37 @@ label mas_reaction_bday_cake:
     $ store.mas_filereacts.delete_file(gift_ev.category)
     return
 
+init 5 python:
+    addReaction("mas_reaction_cupcake", "cupcake")
+
+label mas_reaction_cupcake:
+    m 1wud "Is that a...cupcake?"
+    m 3hub "Wow, thanks [player]!"
+    m 3euc "Come to think of it, I’ve been meaning to make some cupcakes myself."
+    m 1eua "I wanted to learn how to bake good pastries like Natsuki did."
+    m 1rksdlb "Buuut I’ve yet to make a kitchen to use!"
+    m 3eub "Maybe in the future once I get better at programming, I’ll be able to make one here."
+    m 5hubfa "Would be nice to have another hobby other than writing, ehehe~"
+    $ gift_ev = mas_getEV("mas_reaction_cupcake")
+    $ store.mas_filereacts.delete_file(gift_ev.category)
+    return
+
+init 5 python:
+    addReaction("mas_reaction_knife", "knife")
+
+label mas_reaction_knife:
+    m 1euc "...?"
+    m 1wud "Is that...a knife?"
+    m 2wfc "Why would you want to give me that?"
+    m 2wfd "I don’t need this here!."
+    m 3tfc "...Someone else, maybe."
+    m 1dfc "..."
+    m 1rsc "I’m not taking this, [player]."
+    m 1rfc "If you were trying to be funny, then you have {i}very{/i} poor taste."
+    $ gift_ev = mas_getEV("mas_reaction_cupcake")
+    $ store.mas_filereacts.delete_file(gift_ev.category)
+    return
+
 # ending label for gift reactions, this just resets a thing
 label mas_reaction_end:
     $ persistent._mas_filereacts_just_reacted = False

--- a/Monika After Story/game/zz_reactions.rpy
+++ b/Monika After Story/game/zz_reactions.rpy
@@ -539,6 +539,49 @@ label mas_reaction_promisering:
     $ store.mas_filereacts.delete_file(gift_ev.category)
     return
 
+init 5 python:
+    addReaction("mas_reaction_plush", "plushie")
+
+label mas_reaction_plush:
+    m 1wud "What’s this, [player]?"
+    m "Are you trying to give me a plushie?"
+    m 1rksdlb "I appreciate the thought, but ..."
+    m 1ekd "For some reason, I can’t seem to bring it here."
+    m 1rkc "I wish I could ..."
+    m 1hua "But don’t worry, [player]!"
+    m 1hub "Ehehe~"
+    m 1hua "Thank you for trying!"
+    $ gift_ev = mas_getEV("mas_reaction_plush")
+    $ store.mas_filereacts.delete_file(gift_ev.category)
+    return
+
+init 5 python:
+    addReaction("mas_reaction_bday_cake", "birthdaycake")
+
+label mas_reaction_bday_cake:
+    if not mas_isMonikaBirthday():
+        m 1rksdlb "Today is not my birthday, did you forget when is it, [player]?"
+    else:
+        $ mas_gainAffection(modifier=2, bypass=True)
+        m 1wud "Oh, [player]..."
+        m "A... birthday cake?"
+        # show image bday_cake at zorder 11
+        m 3sub "Gosh, this is so sweet of you!"
+        m 1hub "I really love this a lot!"
+        m 1rksdlb "I really love this a lot!"
+        m 1dkbfa "I’ll save it for now"
+        # hide image bday_cake
+        m 3hua "I can’t wait to try it later!"
+        m 1dsc "But..."
+        m 3ekbfa "I wish we could eat it together..."
+        m 1dkbfa "A birthday cake is for sharing, after all~"
+        m 1ekbfa "Thank you for this, [player]."
+        if mas_isMoniAff(higher=True):
+            m 3hubfb "I love you! Ehehe~"
+    $ gift_ev = mas_getEV("mas_reaction_bday_cake")
+    $ store.mas_filereacts.delete_file(gift_ev.category)
+    return
+
 # ending label for gift reactions, this just resets a thing
 label mas_reaction_end:
     $ persistent._mas_filereacts_just_reacted = False

--- a/Monika After Story/game/zz_reactions.rpy
+++ b/Monika After Story/game/zz_reactions.rpy
@@ -14,6 +14,7 @@ default persistent._mas_filereacts_stop_map = dict()
 # mapping of file reacts that we should no longer react to ever again
 
 default persistent._mas_filereacts_historic = dict()
+# historic database used to track when and how many gifts Monika has received
 
 init 800 python:
     if len(persistent._mas_filereacts_failed_map) > 0:
@@ -349,7 +350,7 @@ init -1 python in mas_filereacts:
                 neutral = stats[_key]
         total = good + neutral + bad
         return (total, good, neutral, bad)
-        
+
 
 
     # init
@@ -658,11 +659,9 @@ label mas_reaction_bday_cake:
         $ mas_gainAffection(modifier=2, bypass=True)
         m 1wud "Oh, [player]..."
         m "A... birthday cake?"
-        # show mas_bday_cake zorder 11
         m 3sub "Gosh, this is so sweet of you!"
         m 1hub "I really love this a lot!"
         m 1dkbfa "I’ll save it for now"
-        # hide mas_bday_cake
         m 3hua "I can’t wait to try it later!"
         m 1dsc "But..."
         m 3ekbfa "I wish we could eat it together..."

--- a/Monika After Story/game/zz_reactions.rpy
+++ b/Monika After Story/game/zz_reactions.rpy
@@ -478,7 +478,21 @@ label mas_reaction_generic:
 #    addReaction("mas_reaction_gift_generic", None)
 
 label mas_reaction_gift_generic:
-    m "this is a test of the generic gift reaction"
+    if random.randint(1,2) == 1:
+        m 1esd "[player], are you trying to give me something?"
+        m 1rssdlb "I found it, but I can’t bring it here..."
+        m "I can’t seem to read it well enough."
+        m 3esa "But that’s alright!"
+        m 1esa "It’s the thought that counts after all, right?"
+        m "Thanks for being so thoughtful, [player]~"
+    else:
+        m 2dkd "{i}*sigh*{/i}"
+        m 4ekc "I’m sorry, [player]."
+        m 1ekd "I know you’re trying to give me something."
+        m 2rksdld "But for some reason I can’t read the file."
+        m 3euc "Don’t get me wrong, however."
+        m 3eka "I still appreciate that you tried giving something to me."
+        m 1hub "And for that, I’m thankful~"
     $ store.mas_filereacts.delete_file(None)
     return
 


### PR DESCRIPTION
Last batch of reactions, also has now a mini framework to get stats based on the gifts received, per day and keep record of all the gifts.

## Main
- Includes reactions for generic gifts, cupcake, knife, birthday cake and generic plushie.
- The mini framework contains 2 functions in particular that are helpful: `mas_generateGiftsReport` which returns a tuple of the count and type of gifts received in a certain date(defaults to today) and `mas_receivedGift` which registers that the gift was "received" which helps dealing with having an incorrect number of actual received gifts (like giving something that cannot be replaced twice like ring and quetzal plush), that one receives the eventlabel and it's used as an identifier, the generate report one will be used later to determine some dialogue flow.

## Testing 
Check the reactions to all the reachable gifts and the generic ones.