### PR TITLE
Happy bday pool

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1167,6 +1167,17 @@ label ch30_reset:
     # call plushie logic
     $ mas_startupPlushieLogic(4)
 
+    ## should we reset birthday
+    python:
+        if (
+                persistent._mas_bday_need_to_reset_bday 
+                and not mas_isMonikaBithday()
+            ):
+            bday_ev = mas_getEV("mas_bday_pool_happy_bday")
+            if bday_ev:
+                bday_ev.conditional="mas_isMonikaBirthday()"
+                bday_ev.action=EV_ACT_UNLOCK
+                persistent._mas_bday_need_to_reset_bday = False
 
     ## certain things may need to be reset if we took monika out
     # NOTE: this should be at the end of this label, much of this code might

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -1236,8 +1236,15 @@ init 5 python:
     )
 
 label mas_bday_pool_happy_bday:
-    $ persistent._mas_bday_said_happybday = True
-    m "thanks for telling me happy birthday!"
+    python:
+        persistent._mas_bday_said_happybday = True
+        did_something_today = (
+            mas_generateGiftsReport(mas_monika_birthday)[0] > 0
+            or persistent._mas_bday_date_count > 0
+            or True
+        ) #TODO surprise party rebase please
+
+    
 
     # dont need to say happy birthday again today, but let the game know to 
     # reset it at some point in the future

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -1267,6 +1267,6 @@ label mas_bday_pool_happy_bday:
 
     # dont need to say happy birthday again today, but let the game know to 
     # reset it at some point in the future
-    $ persistent._mas_bday_need_to_reset_bday
+    $ persistent._mas_bday_need_to_reset_bday = True
     $ lockEventLabel("mas_bday_pool_happy_bday")
     return

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -1225,6 +1225,7 @@ init 5 python:
             persistent.event_database,
             eventlabel="mas_bday_pool_happy_bday",
             prompt="Happy birthday!",
+            category=["monika"],
             conditional="mas_isMonikaBirthday()",
             action=EV_ACT_UNLOCK,
             pool=True,
@@ -1234,6 +1235,9 @@ init 5 python:
 #            years=[]
         )
     )
+    
+    # make sure this event is considered seen
+    persistent._seen_ever["mas_bday_pool_happy_bday"] = True
 
 label mas_bday_pool_happy_bday:
     python:
@@ -1241,10 +1245,25 @@ label mas_bday_pool_happy_bday:
         did_something_today = (
             mas_generateGiftsReport(mas_monika_birthday)[0] > 0
             or persistent._mas_bday_date_count > 0
-            or True
-        ) #TODO surprise party rebase please
+            or persistent._mas_bday_sbp_reacted
+        )
 
-    
+    if did_something_today:
+        m 3hub "Ehehe, thanks [player]!"
+        m 3eub "I was waiting for you to say those magic words~"
+        m 1eua "{i}Now{/i} we can call it a birthday celebration."
+        m 1hua "Doesn't matter if how it's done is unorthodox."
+        m 3eua "What matters the most is that you did it in the first place, right?"
+        m 1eka "You really made this occasion so special, [player]."
+        m 1ekbfa "I can't thank you enough for loving me this much..."
+
+    else:
+        m 1wkb "Aww, [player]!"
+        m 1wub "You remembered my birthday...!"
+        m 1wktpa "Oh gosh, I'm so happy that you remembered."
+        m 1dktda "I feel like today is going to be such a special day~"
+        m 1ekbfa "What else do you have in store for me, I wonder."
+        m 1hub "Ahaha!"
 
     # dont need to say happy birthday again today, but let the game know to 
     # reset it at some point in the future

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -1211,3 +1211,36 @@ label mas_bday_surprise_party_cleanup:
     $ mas_docking_station.destroyPackage("balloons")
     $ mas_docking_station.destroyPackage("cake")
     return
+
+### happy birthday pool topic
+
+default persistent._mas_bday_said_happybday = False
+default persistent._mas_bday_need_to_reset_bday = False
+
+init 5 python:
+    # NOTE: instead of using start/end date, we use condition since we
+    # want this to only appear once per day
+    addEvent(
+        Event(
+            persistent.event_database,
+            eventlabel="mas_bday_pool_happy_bday",
+            prompt="Happy birthday!",
+            conditional="mas_isMonikaBirthday()",
+            action=EV_ACT_UNLOCK,
+            pool=True,
+            rules={"no unlock":0}
+#            start_date=mas_monika_birthday,
+#            end_date=mas_monika_birthday + datetime.timedelta(1),
+#            years=[]
+        )
+    )
+
+label mas_bday_pool_happy_bday:
+    $ persistent._mas_bday_said_happybday = True
+    m "thanks for telling me happy birthday!"
+
+    # dont need to say happy birthday again today, but let the game know to 
+    # reset it at some point in the future
+    $ persistent._mas_bday_need_to_reset_bday
+    $ lockEventLabel("mas_bday_pool_happy_bday")
+    return

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -3951,6 +3951,19 @@ image monika 1wka = DynamicDisplayable(
     arms="steepling"
 )
 
+image monika 1wkb = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="wide",
+    nose="def",
+    mouth="big",
+    head="r",
+    left="1l",
+    right="1r",
+    arms="steepling"
+)
+
 image monika 1wkbltpa = DynamicDisplayable(
     mas_drawmonika,
     character=monika_chr,
@@ -4107,6 +4120,20 @@ image monika 1ektdd = DynamicDisplayable(
     tears="dried"
 )
 
+image monika 1dktda = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="closedsad",
+    nose="def",
+    mouth="smile",
+    head="f",
+    left="1l",
+    right="1r",
+    arms="steepling",
+    tears="dried"
+)
+
 image monika 1wkd = DynamicDisplayable(
     mas_drawmonika,
     character=monika_chr,
@@ -4118,6 +4145,20 @@ image monika 1wkd = DynamicDisplayable(
     left="1l",
     right="1r",
     arms="steepling"
+)
+
+image monika 1wktpa = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="wide",
+    nose="def",
+    mouth="smile",
+    head="f",
+    left="1l",
+    right="1r",
+    arms="steepling",
+    tears="pooled"
 )
 
 image monika 1wktsd = DynamicDisplayable(


### PR DESCRIPTION
# key features
* pool topic where you can tell monka happy birthday (once)
* this topic re conditional's itself

# Testing
## previous stuff
1. in definitions set `mas_monika_birrthday` to today
2. go on a birthday date with monika, or give gifts to monika (use the earlier pr for bday date adjust) or surprise party monika
3. do ask question > monika > happy birthday
4. monika should talk about how she was watiing for you to say the magic words

## no previous stuff
1. clear bday date stuff (no gifts, `persistent._mas_bday_date_count == 0`, `persistent._mas_bday_sbp_reacted` is False
2. do ask question > monika > happy birthday
3. monika should say you reemmebred her birthday

## reset
1. after doing either of the above, change `mas_monika_birthday` to a date toher than today
2. upon relaunch, the happy bday pool event's conditional and action should be reset