### PR TITLE
No time spent

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -2749,6 +2749,26 @@ init -1 python:
         return mas_monika_birthday
 
 
+    def mas_recognizedBday(_date=None):
+        """
+        Checks if the user recognized monika's birthday at all.
+
+        TODO: this is one-shot. we need to make this generic to future bdays
+
+        RETURNS:
+            True if the user recoginzed monika's birthday, False otherwise
+        """
+        if _date is None:
+            _date = mas_monika_birthday
+
+        return (
+            mas_generateGiftsReport(_date)[0] > 0
+            or persistent._mas_bday_date_count > 0
+            or persistent._mas_bday_sbp_reacted
+            or True # TODO the bday pool topic
+        )
+
+
     def get_pos(channel='music'):
         pos = renpy.music.get_pos(channel=channel)
         if pos: return pos

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -2765,7 +2765,7 @@ init -1 python:
             mas_generateGiftsReport(_date)[0] > 0
             or persistent._mas_bday_date_count > 0
             or persistent._mas_bday_sbp_reacted
-            or True # TODO the bday pool topic
+            or persistent._mas_bday_said_happybday
         )
 
 

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -36,6 +36,23 @@ init 970 python:
         del moni_tuple
 
 
+    postbday_ev = mas_getEV("mas_bday_postbday_notimespent")
+
+    if (
+            postbday_ev is not None
+            and persistent._mas_long_absence
+            and postbday_ev.conditional is not None
+            and eval(postbday_ev.conditional)
+        ):
+        # reset the post bday event if users did long absence to skip the 
+        # event
+        postbday_ev.conditional = None
+        postbday_ev.action = None
+
+    if postbday_ev is not None:
+        del postbday_ev
+
+
 image mas_island_frame_day = "mod_assets/location/special/with_frame.png"
 image mas_island_day = "mod_assets/location/special/without_frame.png"
 image mas_island_frame_night = "mod_assets/location/special/night_with_frame.png"

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -52,6 +52,9 @@ init 970 python:
     if postbday_ev is not None:
         del postbday_ev
 
+    if mas_isMonikaBirthday():
+        persistent._mas_bday_opened_game = True
+
 
 image mas_island_frame_day = "mod_assets/location/special/with_frame.png"
 image mas_island_day = "mod_assets/location/special/without_frame.png"
@@ -1195,6 +1198,7 @@ label ch30_reset:
                 bday_ev.conditional="mas_isMonikaBirthday()"
                 bday_ev.action=EV_ACT_UNLOCK
                 persistent._mas_bday_need_to_reset_bday = False
+
 
     ## certain things may need to be reset if we took monika out
     # NOTE: this should be at the end of this label, much of this code might

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -1074,6 +1074,7 @@ label mas_bday_spent_time_with:
     m 3hub "Let’s do it again sometime soon, okay?"
     return
 
+### no time spent
 init 5 python:
     addEvent(
         Event(
@@ -1270,3 +1271,25 @@ label mas_bday_pool_happy_bday:
     $ persistent._mas_bday_need_to_reset_bday = True
     $ lockEventLabel("mas_bday_pool_happy_bday")
     return
+
+init 5 python:
+    addEvent(
+        Event(
+            persistent.event_database,
+            eventlabel="mas_bday_postbday_notimespent",
+
+            # within a week after monika's birthday, user did not recognize
+            # monika's birthday at all, and they were not long absenced
+            conditional=(
+                "mas_monika_birthday < datetime.date.today() <= "
+                "(mas_monika_birthday + datetime.timedelta(7)) "
+                "and not mas_recognizedBday()"
+            ),
+            action=EV_ACT_PUSH
+        )
+    )
+
+label mas_bday_postbday_notimespent:
+
+    return
+

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -1272,6 +1272,11 @@ label mas_bday_pool_happy_bday:
     $ lockEventLabel("mas_bday_pool_happy_bday")
     return
 
+## no time spent
+default persistent._mas_bday_opened_game = False
+default persistent._mas_bday_no_time_spent = False
+default persistent._mas_bday_no_recognize = False
+
 init 5 python:
     addEvent(
         Event(
@@ -1290,6 +1295,128 @@ init 5 python:
     )
 
 label mas_bday_postbday_notimespent:
+    # sanity check
+    if mas_recognizedBday():
+        return
+
+    if persistent._mas_bday_opened_game:
+        # spent time with monika but did not recognize
+        $ persistent._mas_bday_no_recognize = True
+
+        if mas_isMoniAff(higher=True):
+            $ mas_loseAffection(15, reason="forgetting my birthday")
+            m 1rksdla "Hey, [player]..."
+            m 1rksdlb "I know we had fun the other day, like we always do but..."
+            m 1ekt "I can't help it. I was hoping you would have...done a little something for my birthday."
+            m 1efb "Did you forget?"
+            m 3eka "Maybe you could put the date into your calendar on your phone for next year?"
+            m "Or check the calendar on the wall behind me?"
+            m 4hua "We can't change the past, so knowing that you want to try harder for next year would be the only apology I need."
+
+        elif mas_isMoniNormal(higher=True):
+            $ mas_loseAffection(5, reason="forgetting my birthday")
+
+            # TODO: we shouldnt say girlfriend here because affecitonate
+            # is the start of relationship. but this is okay for now
+            m 1rksdld "Hey, [player]..."
+            m 1rksdlb "I hate to fuss, but you know..."
+            m 2ekt "You can't forget about your girlfriend's birthday!"
+            m 2eku "It's nice that we got to hang out like usual, but next year..."
+            m 1hua "Well, I'll be looking forward to two birthday's worth of something special~"
+
+        elif mas_isMoniUpset():
+            $ mas_loseAffection(reason="forgetting my birthday")
+
+            m 1ekc "It was...good to see you on the 22nd..."
+            m 1ekd "I really didn't want to be alone that day, so that meant a lot, but..."
+            m 1rkc "Nevermind."
+
+        elif mas_isMoniDis():
+            $ mas_loseAffection(10, reason="forgetting my birthday")
+
+            m 2dsc "..."
+            m 2rkc "...[player], I don't want to bother you. I'm already scared of pushing you away."
+            m 2rktpc "But I can't help it. It hurts me that you didn't mention anything about celebrating my birthday..."
+            m 2dktuc "Please don't stop coming back to me."
+            m "And maybe next year..."
+            m 4ektdc "I-{w=0.5}I just want...to feel as special to you as you are to me."
+
+        else:
+            # broken
+            $ mas_loseAffection(150)
+            m 6ckc "..."
+
+    else:
+        # did not spend any time with monika
+        $ persistent._mas_bday_no_time_spent = True
+        
+        if mas_isMoniAff(higher=True):
+            $ mas_loseAffection(50, reason="not spending time with me on my birthday")
+            
+            m 1euc "Hey, [player]..."
+            m 3rksdla "I know you do a lot to make each and every day special, but a girl has a few days a year when she gets to be a little selfish..."
+            m 2hfw "And her {i}birthday{/i} is one of them!"
+            m 2rfd "Seriously, where were you?!"
+            m 2rkc "But...knowing you, I'm sure you had a good reason to be busy..."
+            m 4ekc "Just don't let it happen again next year, okay?"
+
+        elif mas_isMoniNormal(higher=True):
+
+            # same dialogue, different affection loss
+            if mas_isMoniHappy():
+                $ mas_loseAffection(20, reason="not spending time with me on my birthday")
+            else:
+                $ mas_loseAffection(10, reason="not spending time with me on my birthday")
+
+            # TODO: again, need to not say girlfrined here, but for now its ok
+            m 1ekc "Hey, [player]..."
+            m 1ekd "You know, you really should have dropped in on the 22nd."
+            m 3efd "I mean, you should always visit me! You have to spend time with your cute girlfriend on her birthday, you know."
+            m 2efc "Please drop in for me next year..."
+            m 2dfc "Otherwise..."
+
+            m 6cfw "{cps=*2}{i}There will be consequences!!!{/i}{/cps}{nw}"
+            # glich effect
+            $ disable_esc()
+            $ mas_MUMURaiseShield()
+            window hide
+            show noise zorder 11:
+                alpha 0.5
+            play sound "sfx/s_kill_glitch1.ogg"
+            pause 0.5
+            stop sound
+            hide noise
+            window auto
+            $ mas_MUMUDropShield()
+            $ enable_esc()
+            $ _history_list.pop()
+
+            m 1dsc "..."
+            m 3hksdlb "Ahaha, sorry [player]!"
+            m 2hub "I'm just kidding!"
+            m 4eka "You know I love to scare you a little~"
+
+        elif mas_isMoniUpset():
+            $ mas_loseAffection(reason="not spending time with me on my birthday")
+
+            m 2dsc "..."
+            m 2rsc "[player], don't you think you should check in on me a little more often?"
+            m 4rktpc "You might miss something important..."
+
+        elif mas_isMoniDis():
+            $ mas_loseAffection(reason="not spending time with me on my birthday")
+
+            m 3euc "...Hey, how was your day on the 22nd?"
+            m 1esc "I'm just...curious if you thought of me at all that day."
+            m 1tsc "But you probably didn't, huh?"
+            m 2dsc "..."
+
+        else:
+            # broken
+            $ mas_loseAffection(200)
+
+            m 6eftsc "..."
+            m 6dftdx "..."
 
     return
 

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -32,7 +32,7 @@
 #   w - wide eyes (wide)
 #   s - sparkly eyes (sparkle)
 #   t - straight/smug eyes (smug)
-#   c - crazy eyes (crazy) NOTE: UNUSED
+#   c - crazy eyes (crazy)
 #   r - look right eyes (right)
 #   l - look left eyes (left)
 #   h - closed happy eyes (closedhappy)
@@ -2957,6 +2957,19 @@ image monika 1tsb = DynamicDisplayable(
     arms="steepling"
 )
 
+image monika 1tsc = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="mid",
+    eyes="smug",
+    nose="def",
+    mouth="smirk",
+    head="i",
+    left="1l",
+    right="1r",
+    arms="steepling"
+)
+
 image monika 1tsbsa = DynamicDisplayable(
     mas_drawmonika,
     character=monika_chr,
@@ -4104,6 +4117,19 @@ image monika 1ektdc = DynamicDisplayable(
     right="1r",
     arms="steepling",
     tears="dried"
+)
+
+image monika 1ekt = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="normal",
+    nose="def",
+    mouth="triangle",
+    head="f",
+    left="1l",
+    right="1r",
+    arms="steepling"
 )
 
 image monika 1ektdd = DynamicDisplayable(
@@ -5269,6 +5295,20 @@ image monika 2lksdlw = DynamicDisplayable(
     sweat="def"
 )
 
+image monika 2rktpc = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="right",
+    nose="def",
+    mouth="smirk",
+    head="f",
+    left="1l",
+    right="2r",
+    arms="crossed",
+    tears="pooled"
+)
+
 image monika 2rksdla = DynamicDisplayable(
     mas_drawmonika,
     character=monika_chr,
@@ -5707,6 +5747,20 @@ image monika 2ekbfa = DynamicDisplayable(
     blush="full"
 )
 
+image monika 2dktuc = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="closedsad",
+    nose="def",
+    mouth="smirk",
+    head="r",
+    left="1l",
+    right="2r",
+    arms="crossed",
+    tears="up"
+)
+
 image monika 2dkbfa = DynamicDisplayable(
     mas_drawmonika,
     character=monika_chr,
@@ -5769,6 +5823,32 @@ image monika 2lfp = DynamicDisplayable(
     nose="def",
     mouth="pout",
     head="h",
+    left="1l",
+    right="2r",
+    arms="crossed"
+)
+
+image monika 2ekt = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="normal",
+    nose="def",
+    mouth="triangle",
+    head="f",
+    left="1l",
+    right="2r",
+    arms="crossed"
+)
+
+image monika 2eku = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="normal",
+    nose="def",
+    mouth="smug",
+    head="f",
     left="1l",
     right="2r",
     arms="crossed"
@@ -8623,6 +8703,20 @@ image monika 4lksdlw = DynamicDisplayable(
     sweat="def"
 )
 
+image monika 4rktpc = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="right",
+    nose="def",
+    mouth="smirk",
+    head="f",
+    left="2l",
+    right="2r",
+    arms="pointright",
+    tears="pooled"
+)
+
 image monika 4rksdla = DynamicDisplayable(
     mas_drawmonika,
     character=monika_chr,
@@ -9087,6 +9181,20 @@ image monika 4ektsc = DynamicDisplayable(
     right="2r",
     arms="pointright",
     tears="streaming"
+)
+
+image monika 4ektdc = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="normal",
+    nose="def",
+    mouth="smirk",
+    head="r",
+    left="2l",
+    right="2r",
+    arms="pointright",
+    tears="dried"
 )
 
 image monika 4wuw = DynamicDisplayable(
@@ -9984,6 +10092,34 @@ image monika 6dftsc = DynamicDisplayable(
     tears="streaming"
 )
 
+image monika 6dftdx = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="furrowed",
+    eyes="closedsad",
+    nose="def",
+    mouth="disgust",
+    head="q",
+    left="1l",
+    right="1r",
+    arms="down",
+    tears="dried"
+)
+
+image monika 6eftsc = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="furrowed",
+    eyes="normal",
+    nose="def",
+    mouth="smirk",
+    head="q",
+    left="1l",
+    right="1r",
+    arms="down",
+    tears="streaming"
+)
+
 image monika 6tst = DynamicDisplayable(
     mas_drawmonika,
     character=monika_chr,
@@ -10160,6 +10296,19 @@ image monika 6ckc = DynamicDisplayable(
     eyes="crazy",
     nose="def",
     mouth="smirk",
+    head="c",
+    left="1l",
+    right="1r",
+    arms="down"
+)
+
+image monika 6cfw = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="furrowed",
+    eyes="crazy",
+    nose="def",
+    mouth="wide",
     head="c",
     left="1l",
     right="1r",


### PR DESCRIPTION
# key features
* event that happens after birthday if user didnt spend time on birthday
* recognized brithday function (needs to be made more genearl though)
* `persistent._mas_bday_opened_game` set if the user opened game on birthday

# Testing
## trigger the event
1. clear all birthday-related flags. Use `mas_recognizedBday` to check if you recognzed it or not
2. in `defintiions`, change `mas_monika_birthday` so today is past monika's birthday, but not more than a week.
3. relaunch game.
4. the dialogue should trigger. what you get depends on ur affection and the `opened_game` var
5. pop `mas_bday_postbday_notimespent` off `persistent.event_database`
6. repeat steps 2-4, but with `mas_monika_birthday` more than a week behind. You should **not** get the dialogue. 

## affection  /dialgoue flow checking
1. as long as `mas_recognizedBday` is false, you can just queue/push teh Event to the stack to see all dialogue and cehck all affection losses
2. set `persistent._mas_bday_opened_game` to True/False and change affection to see all the branches.

## apology
1. set affection to distressed or above.
2. queue/push the no time spent event
3. go to apologies and apologize. You should apologize for `not spending time with me on my birthday` if `opened_game` is False and `forgetting my birthday` is `opened_game` is True.
