### PR TITLE
fix coffee issue

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -2884,7 +2884,7 @@ init 2 python:
             "and (datetime.datetime.now() - persistent._mas_coffee_brew_time) "
             "> datetime.timedelta(0, {0})"
         ).format(end_brew)
-        brew_ev.action = EV_ACT_PUSH
+        brew_ev.action = EV_ACT_QUEUE
 
 
     def mas_drinkCoffee(_start_time=None):
@@ -2919,7 +2919,7 @@ init 2 python:
             "persistent._mas_coffee_cup_done is not None "
             "and datetime.datetime.now() > persistent._mas_coffee_cup_done"
         )
-        drink_ev.action = EV_ACT_PUSH
+        drink_ev.action = EV_ACT_QUEUE
 
         # increment cup count
         persistent._mas_coffee_cups_drank += 1

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -2939,6 +2939,8 @@ init 2 python:
         drink_ev.action = None
         persistent._mas_coffee_brew_time = None
         persistent._mas_coffee_cup_done = None
+        removeEventIfExist(brew_ev.eventlabel)
+        removeEventIfExist(drink_ev.eventlabel)
 
 
     def _mas_startupCoffeeLogic():
@@ -2985,6 +2987,7 @@ init 2 python:
                 if brew_ev.conditional is not None and eval(brew_ev.conditional):
                     # even though this in inaccurate, it works for the
                     # immersive purposes, so whatever.
+                    removeEventIfExist(brew_ev.eventlabel)
                     mas_drinkCoffee(persistent._mas_coffee_brew_time)
 
                     if not still_drink(persistent._mas_coffee_cup_done):
@@ -3004,6 +3007,7 @@ init 2 python:
                 brew_ev.conditional = None
                 brew_ev.action = None
                 persistent._mas_coffee_brew_time = None
+                removeEventIfExist(brew_ev.eventlabel)
 
                 # make sure she has the cup, just in case
                 if not monika_chr.is_wearing_acs(mas_acs_mug):

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -1324,6 +1324,9 @@ label prompt_menu:
     else: #nevermind
         $_return = None
 
+    if len(persistent.event_list) > 0:
+        $ mas_skip_mid_loop_eval = True
+
     show monika idle at t11
     $ mas_DropShield_dlg()
     jump ch30_loop

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -969,6 +969,18 @@ init python:
 
         return event_label
 
+
+    def removeEventIfExist(event_label):
+        """
+        Removes an event off the event list if it exists
+
+        IN:
+            event_label - label of the event to remove
+        """
+        if event_label in persistent.event_list:
+            persistent.event_list.remove(event_label)
+
+
     def seen_event(event_label):
         #
         # This checks if an event has either been seen or is already on the

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -1324,9 +1324,6 @@ label prompt_menu:
     else: #nevermind
         $_return = None
 
-    if len(persistent.event_list) > 0:
-        $ mas_skip_mid_loop_eval = True
-
     show monika idle at t11
     $ mas_DropShield_dlg()
     jump ch30_loop


### PR DESCRIPTION
contrary to the name of this branch, this actually just fixes an issue where coffee was shown first when doing talk menu stuff.

this is cause we were pushign intead of queueing.

this also adds a function for removing events of the event list if it exists

# Testing
1. make sure coffee is enabled
2. run `mas_resetCoffee` to ensure no coffee currently brewing/drinking.
3. if your time is outside the regular coffee range, change `mas_coffee.COFFEE_TIME_START` and `mas_coffee.COFFEE_TIME_END` to expand coffee range
4. run `mas_brewCoffee`
5. open talk menu and wait at least 5 minutes
6. run a talk menu option that pushes an Event.
7. Verify that monika talks about coffee being done **after** the Event is finished.