### PR TITLE
Light bday fixes

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1142,6 +1142,13 @@ label ch30_reset:
                 store.mas_sprites.ACS_MAP[acs_name]
             )
 
+    ## accessory hotfixes
+    # mainly to re add accessories that may have been removed for some reason
+    # this is likely to occur in crashes / reloads
+    python:
+        if persistent._mas_acs_enable_promisering:
+            monika_chr.wear_acs_pst(mas_acs_promisering)
+
     ## random chatter frequency reset
     $ mas_randchat.adjustRandFreq(persistent._mas_randchat_freq)
 

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -10,6 +10,9 @@ define mas_skip_mid_loop_eval = False
 # True means disable animations, False means enable
 default persistent._mas_disable_animations = False
 
+# affection hotfix for dates
+default persistent._mas_bday_date_affection_fix = False
+
 init -1 python in mas_globals:
     # global that are not actually globals.
 
@@ -54,6 +57,15 @@ init 970 python:
 
     if mas_isMonikaBirthday():
         persistent._mas_bday_opened_game = True
+
+    # quick fix for dates
+    # NOTE: remove this in 088
+    if (
+            persistent._mas_bday_date_affection_gained >= 50 and
+            not persistent._mas_bday_date_affection_fix
+        ):
+        mas_gainAffection(50, bypass=True)
+        persistent._mas_bday_date_affection_fix = True
 
 
 image mas_island_frame_day = "mod_assets/location/special/with_frame.png"

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1821,6 +1821,7 @@ label greeting_returned_home_bday:
         def cap_gain_aff(amount):
             persistent._mas_bday_date_affection_gained += amount
             if persistent._mas_bday_date_affection_gained <= 50:
+                amount = persistent._mas_bday_date_affection_gained - 50
                 mas_gainAffection(amount, bypass=True)
 
 

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1820,7 +1820,7 @@ label greeting_returned_home_bday:
 
         def cap_gain_aff(amount):
             persistent._mas_bday_date_affection_gained += amount
-            if persistent._mas_bday_date_affection_gained < 50:
+            if persistent._mas_bday_date_affection_gained <= 50:
                 mas_gainAffection(amount, bypass=True)
 
 

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -1090,7 +1090,7 @@ label mas_bday_surprise_party_reaction:
         def cap_gain_aff(amt):
             persistent._mas_bday_sbd_aff_given += amt
             if persistent._mas_bday_sbd_aff_given <= 70:
-                mas_gainAffection(20, bypass=True)
+                mas_gainAffection(amt, bypass=True)
 
         if has_cake:
             cap_gain_aff(20)


### PR DESCRIPTION
Small fixes for birthday events (non-urgent)

# key thighs
* fixing affection gain that was off for date and party reaction
* made sure that users with promsering enabled will have a promsering accessory in case of a crash / reload 
* gave everyone who had maxxed out date affection an extra 50 just because of the 50 error.

# Testing
## promsiering
1. take off promise ring
2. make sure the ring is enabled
3. relaunch game
4. monika should wear her ring now

## affection lump
1. change your `persistent._mas_bday_date_affection_gained` to 50+
2. relaunch game
3. you should gain 50 affection (**this should only happen once**)

the other things are trivial so they dont really need testing