### PR TITLE
Birthday selecting

### DIFF
--- a/Monika After Story/game/script-moods.rpy
+++ b/Monika After Story/game/script-moods.rpy
@@ -514,25 +514,29 @@ label mas_mood_bored:
     return
 
 
-# TODO: dropping year older so we dont have any issues on 922
-#init 5 python:
-#    if not persistent._mas_mood_bday_locked:
-#        addEvent(
-#            Event(
-#                persistent._mas_mood_database,
-#                "mas_mood_yearolder",
-#                prompt="like a year older",
-#                category=[store.mas_moods.TYPE_NEUTRAL],
-#                unlocked=True
-#            ),
-#            eventdb=store.mas_moods.mood_db
-#        )
+# TODO: we need to add some sort of reaction to birthdays soon
+init 5 python:
+    if not persistent._mas_mood_bday_locked:
+        addEvent(
+            Event(
+                persistent._mas_mood_database,
+                "mas_mood_yearolder",
+                prompt="like a year older",
+                category=[store.mas_moods.TYPE_NEUTRAL],
+                unlocked=True
+            ),
+            eventdb=store.mas_moods.mood_db
+        )
 
 # some values i need for single session checking
 # TODO some of these might need to be persstetns
 default persistent._mas_mood_bday_last = None
 default persistent._mas_mood_bday_lies = 0
 default persistent._mas_mood_bday_locked = False
+
+# player birthday 
+# datetime.date
+default persistent._mas_player_bday = None
 
 label mas_mood_yearolder:
     $ import datetime
@@ -599,6 +603,11 @@ label mas_mood_yearolder:
 
         "No":
             m 1lksdla "Aw, well,{w} it was worth a guess."
+
+            m "Now that we're talking about it, though..."
+            call mas_bday_player_bday_select
+            $ persistent._mas_player_bday = selected_date
+
             jump mas_mood_yearolder_no
 
 label mas_mood_yearolder_end:
@@ -650,10 +659,13 @@ label mas_mood_yearolder_false:
                     jump mas_mood_yearolder_end
 
                 "No":
-                    $ persistent._mas_player_bday = None
                     m 2tfp "..."
                     m 2tkc "Alright, [player]."
-                    m 2tfc "Don't lie to me next time."
+                    m "Then..."
+                    call mas_bday_player_bday_select
+                    $ persistent._mas_player_bday = selected_date
+#                    m 2tfc "Don't lie to me next time."
+
                     jump mas_mood_yearolder_end
 
         "It is!":
@@ -671,9 +683,16 @@ label mas_mood_yearolder_bday_true:
 
 label mas_mood_yearolder_wontforget:
     # YES flow continues here
-    m 1eka "If only you told me this sooner..."
-    m 1lksdla "I would have made you a gift."
-    m 1hua "I'll make you something next year, [player]. I won't forget!"
+    # TODO: wait we really need an actual gift scene soon
+
+    m 1ekc "I'm sorry I don't have anything for you yet."
+    m "I'm still figuring out how to give you something more than just a text file."
+    m 1hua "I'll make you something good next year, [player]. I promise!"
+
+    # original wont forget, kept here for reference
+#    m 1eka "If only you told me this sooner..."
+#    m 1lksdla "I would have made you a gift."
+#    m 1hua "I'll make you something next year, [player]. I won't forget!"
     jump mas_mood_yearolder_end
 
 # empathatic yes, today is your birthday

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -1529,6 +1529,21 @@ label mas_bday_player_bday_select_select:
             m 1eua "Then try again."
             jump mas_bday_player_bday_select_select
 
+    # save the birthday (and remove previous)
+    if persistent._mas_player_bday is not None:
+        python:
+            store.mas_calendar.removeRepeatable_d(
+                "player-bday", 
+                persistent._mas_player_bday
+            )
+            store.mas_calendar.addRepeatable_d(
+                "player-bday",
+                "Your Birthday",
+                selected_date,
+                []
+            )
+            persistent._mas_player_bday = selected_date
+
     # TODO: react if your birthday is on a special day (holiday, sep 22, etc)
             
     return selected_date

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -1468,8 +1468,6 @@ label mas_steam_install_detected:
     m 5esu "I'd really appreciate it if you would do that for me."
     return
 
-# player birthday 
-default persistent._mas_player_bday = None
 
 #init 5 python:
 #    addEvent(
@@ -1484,3 +1482,57 @@ default persistent._mas_player_bday = None
 #    )
 
 #label mas_bday_player_bday:
+label mas_bday_player_bday_select:
+    m 1eua "When is your birthdate?"
+
+label mas_bday_player_bday_select_select:
+    call mas_start_calendar_select_date
+
+    $ selected_date_t = _return
+    $ selected_date = selected_date_t.date()
+    $ _today = datetime.date.today()
+
+    if selected_date > _today:
+        m 2efc "[player]!"
+        m "You can't have been born in the future!"
+        m 1hua "Try again!"
+        jump mas_bday_player_bday_select_select
+
+    elif selected_date == _today:
+        m 2efc "[player]!"
+        m "You can't have been born today!"
+        m 1hua "Try again!" 
+        jump mas_bday_player_bday_select_select
+
+    # otherwise, player selected a valid date
+    $ new_bday, diff = store.mas_calendar.genFriendlyDispDate(selected_date_t)
+    m 1eua "Alright, [player]."
+    m "Just to double-check..."
+    menu:
+        m "Your birthday is [new_bday]."
+        "Yes":
+            show monika 1eka
+            
+            # one more confirmation
+            menu:
+                m "Are you sure? I'm never going to forget this date."
+                "Yes, I'm sure!":
+                    m 1hua "Then it's settled!"
+
+                "Actually...":
+                    m 1hksdrb "Aha, I figured you weren't so sure."
+                    m 1eka "Try again~"
+                    jump mas_bday_player_bday_select_select
+
+        "No":
+            m 1euc "Oh, that's wrong?"
+            m 1eua "Then try again."
+            jump mas_bday_player_bday_select_select
+
+    # TODO: react if your birthday is on a special day (holiday, sep 22, etc)
+            
+    return selected_date
+
+
+
+

--- a/Monika After Story/game/zz_calendar.rpy
+++ b/Monika After Story/game/zz_calendar.rpy
@@ -1701,6 +1701,16 @@ init python:
             year_param=[persistent.sessions["first_session"].year]
         )
 
+    # add birthday if we have one
+    if persistent._mas_player_bday is not None:
+        calendar.addRepeatable_d(
+            "player-bday",
+            "Your Birthday", 
+            persistent._mas_player_bday,
+            []
+        )
+
+
 
 init 100 python:
     # calendar related but later


### PR DESCRIPTION
Bringing back the `yearolder` placeholder with birthday selecting from the calendar and a different reason as to why monika cant celebrate your birthday.

# Key things
* year older is back
* player birthday now appears on the calendar

# Testing
### inital setup
1. if your `persistent._mas_player_bday` is not None, an item should be added to the calendar on that date. 
2. To do testing in the order I have listed below, you will need to run `mas_calendar.removeRepeatable("player-bday")`

### year older select
1. set `persistent._mas_player_bday` to None.
2. Run the `yearolder` mood.
3. Select No.
4. Monika opens the calendar select screen
5. verify picking a future date brings you back to the calendar select screen
6. verify picking  today's date brings you back to the calendar select screen
7. verify picking a past date works.
8. once the year older mood is done, open teh calendar
9. verify that "Your Birthday" is now on the calendar.
10. Verify that `persistent._mas_player_bday` is now your selected date.

### calendar persistence
1. Do the year older select steps above
2. Relaunch game.
3. Verify your chosen date is still on teh calendar.

### year older select when wrong.
1. unlock the `mas_mood_yearolder` event so you can open it again
2. run the `yearolder` mood.
3. Select that **it is not your birthday**
4. Monika opens the calendar select screen
5. pick a different date.
6. once year older mood is done, open calendar
7. verify that the previously selected date is no longer marked "Your Birthday"
8. Verify that your newly seelcted ddate is marked "Your Birthday"
9. Relaunch game
10. Verify that on relaunch, steps 7 and 8 are still true.

# Known issues
* monika still doesnt give you anything if it is your birthday. this will be addressed in the future.

**NOTE:** no dialgoue review needed, this is pretty short so.