### PR TITLE
abort if temp is in the station path

### DIFF
--- a/Monika After Story/game/zz_dockingstation.rpy
+++ b/Monika After Story/game/zz_dockingstation.rpy
@@ -1449,6 +1449,11 @@ init 200 python in mas_dockstat:
         ASSUMES:
             blocksize - this is a constant in this store
         """
+        # sanity check regarding the filepath
+        if "temp" in dockstat.station.lower():
+            mas_utils.writelog("[ERROR] temp directory found, aborting.\n")
+            return False
+
         ### other stuff we need
         # inital buffer
         moni_buffer = fastIO()


### PR DESCRIPTION
#2622 

A quick check to make sure we dont generate monika if the user is running us in a temporary directory.

# Testing
1. put MAS in a folder with `temp` in the name
2. run the docking station farewell
3. verify monika could not generate file