### PR TITLE
forcing checkout checkin log length

### DIFF
--- a/Monika After Story/game/zz_dockingstation.rpy
+++ b/Monika After Story/game/zz_dockingstation.rpy
@@ -1863,9 +1863,32 @@ init 200 python in mas_dockstat:
         """
         checkin_log = store.persistent._mas_dockstat_checkin_log
         checkout_log = store.persistent._mas_dockstat_checkout_log
+        checkin_len = len(checkin_log)
+        checkout_len = len(checkout_log)
 
-        if len(checkin_log) == 0 or len(checkout_log) == 0:
+        if checkin_len == 0 or checkout_len == 0:
             return datetime.timedelta(0)
+
+        if checkin_len != checkout_len:
+            # mis match logs, please log this.
+            mas_utils.writelog(
+                (
+                    "[WARNING]: checkin is {0}, checkout is {1}. "
+                    "Going to pop.\n"
+                ).format(checkin_len, checkout_len)
+            )
+
+            # and we will pop extras as well
+            if checkin_len > checkout_len:
+                larger_log = checkin_log
+                goal_size = checkout_len
+
+            else:
+                larger_log = checkout_log
+                goal_size = checkin_len
+
+            while len(larger_log) > goal_size:
+                larger_log.pop()
 
         if index is None:
             index = len(checkout_log)-1


### PR DESCRIPTION
#2716 

Not really solving a cause of a problem, but just preventing crashes and further issues.

This will even the checkin/checkout logs when calling diffCheckTime. yeah we lose some data, but at least no crashing and inconsistencies.

# Testing
1. pop some entries off either the checkout log or the checkin log.
2. run `mas_dockstat.diffCheckTimes`. 
3. verify no crash or error. verify that the checkout and checkin logs are the same length.