### PR TITLE
Extend posemap to hair and clothes

### DIFF
--- a/Monika After Story/game/dev/dev_exp_previewer.rpy
+++ b/Monika After Story/game/dev/dev_exp_previewer.rpy
@@ -45,6 +45,7 @@ init 999 python:
         we are about to go there
         """
         import pygame
+        import store.mas_sprites as mas_sprites
 
         # CONSTANTS
         VIEW_WIDTH = 1280
@@ -891,7 +892,10 @@ init 999 python:
         def _sel_hair(self, direct):
             self._adj_sel(direct, "hair")
             self._update_sel_tx("hair")
-            monika_chr.change_hair(self._get_spr_code("hair"))
+            monika_chr.change_hair(mas_sprites.HAIR_MAP.get(
+                self._get_spr_code("hair"),
+                mas_hair_def
+            ))
 
 
         def _sel_mouth(self, direct):
@@ -928,7 +932,10 @@ init 999 python:
         def _sel_torso(self, direct):
             self._adj_sel(direct, "torso")
             self._update_sel_tx("torso")
-            monika_chr.change_clothes(self._get_spr_code("torso"))
+            monika_chr.change_clothes(mas_sprites.CLOTH_MAP.get(
+                self._get_spr_code("torso"),
+                mas_clothes_def
+            ))
 
 
         ######################### button functions ###########################

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1115,7 +1115,7 @@ label ch30_reset:
 
             for hair in hair_map:
                 # this is so we kind of automate the locking / unlocking prcoess
-                if hair == monika_chr.hair:
+                if hair == monika_chr.hair.name:
                     lockEventLabel(hair_map[hair])
                 else:
                     unlockEventLabel(hair_map[hair])
@@ -1129,7 +1129,7 @@ label ch30_reset:
 
 
         for clothes in clothes_map:
-            if clothes == monika_chr.clothes:
+            if clothes == monika_chr.clothes.name:
                 lockEventLabel(clothes_map[clothes])
             else:
                 unlockEventLabel(clothes_map[clothes])

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1095,8 +1095,8 @@ label ch30_reset:
     python:
         # setup hair / clothes
         monika_chr.change_outfit(
-            persistent._mas_monika_clothes,
-            persistent._mas_monika_hair
+            store.mas_sprites.CLOTH_MAP[persistent._mas_monika_clothes],
+            store.mas_sprites.HAIR_MAP[persistent._mas_monika_hair]
         )
 
         if (

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1451,7 +1451,7 @@ label greeting_hairdown:
     # 5 - music is off (skip visual)
 
     # have monika's hair down
-    $ monika_chr.change_hair("down")
+    $ monika_chr.change_hair(mas_hair_down)
 
     call spaceroom
 

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -7662,7 +7662,7 @@ label monika_hair_down:
     show monika 1dsc
     pause 1.0
 
-    $ monika_chr.change_hair("down")
+    $ monika_chr.change_hair(mas_hair_down)
 
     m 3hub "And it's down!"
     m 1eua "If you want my hair in a ponytail again, just ask away, [player]~"

--- a/Monika After Story/game/splash.rpy
+++ b/Monika After Story/game/splash.rpy
@@ -331,8 +331,8 @@ label quit:
         store.mas_dockstat.setMoniSize(persistent.sessions["total_playtime"])
 
     if persistent._mas_hair_changed:
-        $ persistent._mas_monika_hair = monika_chr.hair
-        $ persistent._mas_monika_clothes = monika_chr.clothes
+        $ persistent._mas_monika_hair = monika_chr.hair.name
+        $ persistent._mas_monika_clothes = monika_chr.clothes.name
 
     # accessory saving
     python:

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -1980,9 +1980,8 @@ init -2 python:
 define monika_chr = MASMonika()
 
 init -1 python:
-    # HAIR (IMG 015)
+    # HAIR (IMG015)
     # Hairs are representations of image objects with propertes
-    # (like the accessories
     #
     # NAMING:
     # mas_hair_<hair name>
@@ -2001,12 +2000,70 @@ init -1 python:
     ### PONYTAIL WITH RIBBON (default)
     ## def
     # Monika's default hairstyle, aka the ponytail
-#    mas_hair_def = MASHair(
-#        "def",
-#        "def",
-#        MASPoseMap(
-#            default
+    mas_hair_def = MASHair(
+        "def",
+        "def",
+        MASPoseMap(
+            default=True,
+            use_reg_for_l=True
+        )
+    )
 
+    ### DOWN
+    ## down
+    # Hair is down, not tied up
+    mas_hair_down = MASHair(
+        "down",
+        "down",
+        MASPoseMap(
+            default=True,
+            use_reg_for_l=True
+        )
+    )
+
+    ### BUN WITH RIBBON
+    ## bun
+    # Hair tied into a bun, using the ribbon
+    mas_hair_bun = MASHair(
+        "bun",
+        "bun",
+        MASPoseMap(
+            default=True,
+            p5=None
+        )
+    )
+
+
+init -1 python:
+    # CLOTHES (IMG018)
+    # Clothes are representations of image objects with properties
+    #
+    # NAMING:
+    # mas_clothes_<clothes name>
+    #
+    # <clothes name> MUST BE UNIQUE
+    #
+    # NOTE: see the existing standards for clothes file naming
+    # NOTE: PoseMaps are used to determine which lean types exist for
+    #  a given clothes type, NOT filenames
+    #
+    # NOTE: template
+    ### HUMAN UNDERSTANDABLE NAME OF THIS CLOTHES
+    ## clothesidentifiername
+    # General description of the clothes
+
+    ### SCHOOL UNIFORM (default)
+    ## def
+    # Monika's school uniform
+    mas_clothes_def = MASClothes(
+        "def",
+        "def",
+        MASPoseMap(
+            default=True,
+            use_reg_for_l=True
+        ),
+        stay_on_start=True
+    )
 
 
 init -1 python:

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -261,26 +261,6 @@ init -5 python in mas_sprites:
     NIGHT_SUFFIX = ART_DLM + "n"
     FILE_EXT = ".png"
 
-    ### [BLK001]
-    # non leanable clothes
-    lean_clothes_blacklist = [
-        "test"
-    ]
-
-    ### [BLK002]
-    # non leanable hair
-    lean_hair_blacklist = [
-#        "down",  # Thanks to Trilasent for giving us leaning hair downs
-        "bun"
-    ]
-
-    ### [BLK003]
-    # non leanable accessories
-    lean_acs_blacklist = [
-#        "mug"
-        "test"
-    ]
-
     # list of available hairstyles
     HAIRS = [
         "def", # ponytail
@@ -293,6 +273,7 @@ init -5 python in mas_sprites:
     ]
 
     # tryparses for the hair and clothes
+    # TODO: adjust this for docking station when ready
     def tryparsehair(_hair, default="def"):
         """
         Returns the given hair if it exists, or the default if not exist
@@ -309,6 +290,8 @@ init -5 python in mas_sprites:
 
         return default
 
+
+    # TODO: adjust this for docking station when ready
     def tryparseclothes(_clothes, default="def"):
         """
         Returns the given clothes if it exists, or the default if not exist

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -1635,17 +1635,63 @@ init -2 python:
                     pose_dict[k] = _def
 
 
+    # base class for MAS sprite things
+    class MASSpriteBase(renpy.store.object):
+        """
+        Base class for MAS sprite objects
+
+        PROPERTIES:
+            name - name of the item
+            img_sit - filename of the sitting version of the item
+            img_stand - filename of the standing version of the item
+            pose_map - MASPoseMap object that contains pose mappings
+            stay_on_start - determines if the item stays on startup
+        """
+
+        def __init__(self, 
+                name,
+                img_sit,
+                pose_map,
+                img_stand="",
+                stay_on_start=False
+            ):
+            """
+            MASSpriteBase constructor
+
+            IN:
+                name - name of this item
+                img_sit - filename of the sitting image
+                pose_map - MASPoseMAp object that contains pose mappings
+                img_stand - filename of the standing image
+                    If this is not passed in, this is considered blacklisted
+                    from standing sprites.
+                    (Default: "")
+                stay_on_start - True means the item should reappear on startup
+                    False means the item should always drop when restarting.
+                    (Default: False)
+            """
+            self.name = name
+            self.img_sit = img_sit
+            self.img_stand = img_stand
+            self.stay_on_start = stay_on_start
+            self.pose_map = pose_map
+
+            if type(pose_map) != MASPoseMap:
+                raise Exception("PoseMap is REQUIRED")
+
+
     # instead of clothes, these are accessories
-    class MASAccessory(renpy.store.object):
+    class MASAccessory(MASSpriteBase):
         """
         MASAccesory objects
 
         PROPERTIES:
-            name - name of the accessory
-            img_sit - filename of the sitting version of the accessory
-            img_stand - filename of the standing version of the accessory
-            priority - render priority of the accessory. Lower is rendred
-                first
+            rec_layer - recommended layer to place this accessory
+            priority - render priority. Lower is rendered first
+            no_lean - determins if the leaning versions are hte same as the
+                regular ones.
+
+        SEE MASSpriteBase for inherited properties
         """
 
 
@@ -1687,17 +1733,16 @@ init -2 python:
                     startup.
                     (Default: False)
             """
-            self.name = name
-            self.img_sit = img_sit
-            self.img_stand = img_stand
+            super(MASAccessory, self).__init__(
+                name,
+                img_sit,
+                pose_map,
+                img_stand,
+                stay_on_start
+            )
             self.__rec_layer = rec_layer
             self.priority=priority
             self.no_lean = no_lean
-            self.stay_on_start = stay_on_start
-            self.pose_map = pose_map
-
-            if type(pose_map) != MASPoseMap:
-                raise Exception("PoseMap is REQUIRED")
 
             # this is for "Special Effects" like a scar or a wound, that
             # shouldn't be removed by undressing.
@@ -1720,6 +1765,95 @@ init -2 python:
                 recommend MASMOnika accessory type for this accessory
             """
             return self.__rec_layer
+
+
+    class MASHair(MASSpriteBase):
+        """
+        MASHair objects
+
+        Representations of hair items
+
+        PROPERTIES:
+            (no additional)
+
+        SEE MASSpriteBase for inherited properties
+
+        POSEMAP explanations:
+            Use an empty string to 
+        """
+        
+        def __init__(self,
+                name,
+                img_sit,
+                pose_map,
+                img_stand="",
+                stay_on_start=True
+            ):
+            """
+            MASHair constructor
+
+            IN;
+                name - name of this hairstyle
+                img_sit - filename of the sitting image for this hairstyle
+                pose_map - MASPoseMap object that contains pose mappings
+                img_stand - filename of the standing image for this hairstyle
+                    If this is not passed in, this is considered blacklisted
+                        from standing sprites.
+                    (Default: "")
+                stay_on_strat - True means the hairstyle should reappear on
+                    startup. False means a restart clears the hairstyle
+                    (Default: True)
+            """
+            super(MASHair, self).__init__(
+                name,
+                img_sit,
+                pose_map,
+                img_stand,
+                stay_on_start
+            )
+
+
+    class MASClothes(MASSpriteBase):
+        """
+        MASClothes objects
+
+        Representations of clothes
+
+        PROPERTIES:
+            (no additional)
+
+        SEE MASSpriteBase for inherited properties
+        """
+        
+        def __init__(self,
+                name,
+                img_sit,
+                pose_map,
+                img_stand="",
+                stay_on_start=False
+            ):
+            """
+            MASClothes constructor
+
+            IN;
+                name - name of these clothes
+                img_sit - filename of the sitting image for these clothes
+                pose_map - MASPoseMap object that contains pose mappings
+                img_stand - filename of the standing image for these clothes
+                    If this is not passed in, this is considered blacklisted
+                        from standing sprites.
+                    (Default: "")
+                stay_on_start - True means the clothes should reappear on
+                    startup. False means a restart clears the clothes
+                    (Default: False)
+            """
+            super(MASClothes, self).__init__(
+                name,
+                img_sit,
+                pose_map,
+                img_stand,
+                stay_on_start
+            )
 
 
     # The main drawing function...
@@ -1844,6 +1978,36 @@ init -2 python:
 
 # Monika
 define monika_chr = MASMonika()
+
+init -1 python:
+    # HAIR (IMG 015)
+    # Hairs are representations of image objects with propertes
+    # (like the accessories
+    #
+    # NAMING:
+    # mas_hair_<hair name>
+    #
+    # <hair name> MUST BE UNIQUE
+    #
+    # NOTE: see the existing standards for hair file naming
+    # NOTE: PoseMaps are used to determin which lean types exist for
+    #   a given hair type, NOT filenames
+    #
+    # NOTE: template:
+    ### HUMAN UNDERSTANDABLE NAME OF HAIR STYLE
+    ## hairidentifiername
+    # General description of the hair style
+
+    ### PONYTAIL WITH RIBBON (default)
+    ## def
+    # Monika's default hairstyle, aka the ponytail
+#    mas_hair_def = MASHair(
+#        "def",
+#        "def",
+#        MASPoseMap(
+#            default
+
+
 
 init -1 python:
     # ACCESSORIES (IMG020)


### PR DESCRIPTION
#2756 

# key changes
* Hair (`MASHair`) and Clothes (`MASClothes`) are now objects instead of strings. 
   * they also contain `MASPoseMap` for fallback/existence checking
* all sprite objects now extend off the base class `MASSpriteBase` 
* **this updates the exp previewer, so anyone who uses it will need to update**

changing clothes/hair is basically the same as before, only difference is that you have to use an object like accessories does.

## MASSpriteBase
* base class for all sprites
* mainly contains identifier info as well as filename codes and the pose map

## MASSpriteFallbackBase
* extends `MASSpriteBase`
* adds a fallback property to say if the pose map is for fallbacks or not

## MASHair
* extends `MASSpriteFallbackBase`
* used for hair objects
* hair objects are at `IMG015`

## MASClothes
* extends `MASSpriteFallbackBase`
* used for clothes objects
* clothes objects are at `IMG018`

## MASAccessory
* changed to extend `MASSpriteBase`

## default usage
When not using the fallback mode, the hair/clothes objects are checked for the selected lean type and whether or not we need to blacklist the lean. Here's an example with the bun hairstyle blacklisting pose 5 (lean):
```python
mas_hair_bun = MASHair(
    "bun",
    "bun",
    MASPoseMap(
        default=True,
        p5=None
    )
)
```
**Only lean types are checked when not using fallback mode.** Setting regular poses to None will not change anything.

## the fallback system
The fallback system uses `MASPoseMap` to map poses to other poses. The sprite selection system checks this map and uses the fallback pose when appropriate.
Here is an example of the bun hairstyle using the fallback system to map poses 2 and 4 to 6 and 3 to 1:
```python
mas_hair_bun = MASHair(
    "bun",
    "bun",
    MASPoseMap(
        p1="steepling",
        p2="down",
        p3="steepling"
        p4="down",
        p6="down"
    ),
    fallback=True
)
```

**IMPORTANT:**
* non-lean types can only be mapped to other **non-lean types**.
* lean types can be mapped to **lean types** OR **steepling** (via setting the pose to None)

# Testing
## regression
* verify that all sprites look okay. you can use the exp previewer to double check everything
* change hair and verify things still look fine.
* verify that the hair down hairstyle is saved and reappears on restart
* verify that the hair down greeting/prompts still work

## non-fallback mode
1. change the hair code for a hairstyle so it matches the bun code above. (since we only have 1 lean pose, this is the only check we can do)
2. Verify that when the lean pose is None, the lean appears as steepling.

## fallback mode
1. change the hair code for a hairstyle so it does the fallback mode like the bun example above. You can use other mappings aslong as the lean/non-lean types are not interchanged
2. verify that the poses map to the appropriate pose according to your mapping
