### PR TITLE
year older removes the old birthday

### DIFF
--- a/Monika After Story/game/script-moods.rpy
+++ b/Monika After Story/game/script-moods.rpy
@@ -594,11 +594,26 @@ label mas_mood_yearolder:
     menu:
         m "Could today be your...{w}birthday?"
         "YES!":
-            $ persistent._mas_player_bday = datetime.date.today()
+            python:
+                persistent._mas_player_bday = datetime.date.today()
+                store.mas_calendar.addRepeatable_d(
+                    "player-bday",
+                    "Your Birthday", 
+                    persistent._mas_player_bday,
+                    []
+                )
+
             label .mas_mood_yearolder_yesloud:
                 jump mas_mood_yearolder_yes
         "Yes, unfortunately...":
-            $ persistent._mas_player_bday = datetime.date.today()
+            python:
+                persistent._mas_player_bday = datetime.date.today()
+                store.mas_calendar.addRepeatable_d(
+                    "player-bday",
+                    "Your Birthday", 
+                    persistent._mas_player_bday,
+                    []
+                )
             jump mas_mood_yearolder_yesu
 
         "No":
@@ -606,7 +621,14 @@ label mas_mood_yearolder:
 
             m "Now that we're talking about it, though..."
             call mas_bday_player_bday_select
-            $ persistent._mas_player_bday = selected_date
+            python:
+                persistent._mas_player_bday = selected_date
+                store.mas_calendar.addRepeatable_d(
+                    "player-bday",
+                    "Your Birthday", 
+                    persistent._mas_player_bday,
+                    []
+                )
 
             jump mas_mood_yearolder_no
 
@@ -653,7 +675,19 @@ label mas_mood_yearolder_false:
             menu:
                 m "Then is today your birthday?"
                 "Yes":
-                    $ persistent._mas_player_bday = datetime.date.today()
+                    python:
+                        store.mas_calendar.removeRepeatable_d(
+                            "player-bday",
+                            persistent._mas_player_bday
+                        )
+                        persistent._mas_player_bday = datetime.date.today()
+                        store.mas_calendar.addRepeatable_d(
+                            "player-bday",
+                            "Your Birthday", 
+                            persistent._mas_player_bday,
+                            []
+                        )
+
                     m 1hua "Happy birthday, [player]."
                     m 1eka "But don't lie to me next time."
                     jump mas_mood_yearolder_end
@@ -663,7 +697,19 @@ label mas_mood_yearolder_false:
                     m 2tkc "Alright, [player]."
                     m "Then..."
                     call mas_bday_player_bday_select
-                    $ persistent._mas_player_bday = selected_date
+                    python:
+                        store.mas_calendar.removeRepeatable_d(
+                            "player-bday",
+                            selected_date
+                        )
+                        persistent._mas_player_bday = selected_date
+                        store.mas_calendar.addRepeatable_d(
+                            "player-bday",
+                            "Your Birthday", 
+                            persistent._mas_player_bday,
+                            []
+                        )
+
 #                    m 2tfc "Don't lie to me next time."
 
                     jump mas_mood_yearolder_end


### PR DESCRIPTION
minor fix for the yearolder mood since it didnt change calendar right away

# Testing
## no birthday set
1. Set `persistent._mas_player_bday` to None. Unlock the `mas_mood_yearolder`. Restart game. (this is to clear the calendar's birthday as it would be if it was never set)
2. Run the Year older mood.
3. Picking any of the options (Saying Yes, Yes Unfortunatley, or No and selecting a bday) will now add the date to the calendar. 
4. Once the mood ends, verify the date was added to the calendar in the correct spot.

## birthday set
1. Make sure `persistent._mas_player_bday` is set to something. Unlock the `mas_mood_yearolder`. Restart game. (this will set the bday to the calendar)
2. Run the year older mood.
3. Say that the date monika remebered **is not** your birthday.
4. When monika asks if today is your birthday, either pick Yes or No. Either of these options should remove the old bday and add a new one to the calendar.
5. Once the mood ends, verify the date was added to the calendar in the correct spot and that the old date was removed.

**NOTE**: no dialogue review needed