### PR TITLE
Re-enable thanks compliment at love state

### DIFF
--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -489,12 +489,16 @@ init 15 python in mas_affection:
         """
         # change quit message
         layout.QUIT_NO = mas_layout.QUIT_NO_LOVE
+        store.unlockEventLabel("mas_compliment_thanks", eventdb=store.mas_compliments.compliment_database)
 
 
     def _loveToEnamored():
         """
         Runs when transitioning from love to enamored
         """
+        if store.seen_event("mas_compliment_thanks"):
+            store.lockEventLabel("mas_compliment_thanks", eventdb=store.mas_compliments.compliment_database)
+
         return
 
 

--- a/Monika After Story/game/script-compliments.rpy
+++ b/Monika After Story/game/script-compliments.rpy
@@ -377,7 +377,7 @@ label mas_compliment_thanks:
     m 4ekbfa "I guess we're both lucky that we have each other, [player]~"
     menu:
         "You mean everything to me, [m_name]":
-            if not mas_isMoniLove():
+            if mas_getEV('mas_compliment_thanks').shown_count == 0:
                 $ mas_gainAffection(10,bypass=True)
             m 1ekbfa "[player]... "
             m 1dubsu "Nothing makes me happier than hearing that coming from you."

--- a/Monika After Story/game/script-compliments.rpy
+++ b/Monika After Story/game/script-compliments.rpy
@@ -377,7 +377,8 @@ label mas_compliment_thanks:
     m 4ekbfa "I guess we're both lucky that we have each other, [player]~"
     menu:
         "You mean everything to me, [m_name]":
-            $ mas_gainAffection(10,bypass=True)
+            if not mas_isMoniLove():
+                $ mas_gainAffection(10,bypass=True)
             m 1ekbfa "[player]... "
             m 1dubsu "Nothing makes me happier than hearing that coming from you."
             m "No matter what the future may have for us both..."
@@ -385,7 +386,9 @@ label mas_compliment_thanks:
         "Yeah":
             m 1hub "Hehehe~"
             m 1eub "I love you, [player]."
-    $ lockEventLabel("mas_compliment_thanks", eventdb=store.mas_compliments.compliment_database)
+
+    if not mas_isMoniLove():
+        $ lockEventLabel("mas_compliment_thanks", eventdb=store.mas_compliments.compliment_database)
     return
 
 init 5 python:


### PR DESCRIPTION
#2262 
This pull request re-enables the compliment at love stage. It stays the same and doesn't get a dialogue change but no longer gives a considerable amount of affection.

## Testing

- Check that the compliment stays always available at Love stage
- Check that if you're at love stage it doesn't give you more affection
- Check that if you're at any other state it no longer appears if you've seen the compliment already.

