### PR TITLE
Fix for noshow of anniversaries

### DIFF
--- a/Monika After Story/game/script-anniversary.rpy
+++ b/Monika After Story/game/script-anniversary.rpy
@@ -55,7 +55,7 @@ init -1 python in mas_anni:
 #        return mas_utils.am3(new_date + datetime.timedelta(days=1))
 # NOTE: doing am3 leads to calendar problems
 #   we'll just restrict this to midnight to midnight -1
-        return mas_utils.mdnt(new_date)
+        return mas_utils.mdnt(new_date + datetime.timedelta(days=1))
 
     def build_anni_end(years=0, months=0, weeks=0):
         """

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -293,6 +293,21 @@ label v0_3_1(version=version): # 0.3.1
     return
 
 # non generic updates go here
+
+# 0.8.10
+label v0_8_10(version="v0_8_10"):
+    python:
+
+        # reset and unlock past anniversaries
+        if persistent.sessions is not None:
+            first_sesh = persistent.sessions.get("first_session", None)
+            if first_sesh:
+                store.mas_sprites.reset_annis(first_sesh)
+                unlock_past_annis()
+
+    return
+
+# 0.8.9
 label v0_8_9(version="v0_8_9"):
     python:
         import store.evhand as evhand

--- a/Monika After Story/game/updates_topics.rpy
+++ b/Monika After Story/game/updates_topics.rpy
@@ -40,6 +40,7 @@ label vv_updates_topics:
 
         # versions
         # use the v#_#_# notation so we can work with labels
+        vv0_8_10 = "v0_8_10"
         vv0_8_9 = "v0_8_9"
         vv0_8_8 = "v0_8_8"
         vv0_8_7 = "v0_8_7"
@@ -71,6 +72,7 @@ label vv_updates_topics:
         # update this dict accordingly to every new version
         # k:old version number -> v:new version number
         # some version changes skip some numbers because no major updates
+#        updates.version_updates[vv0_8_9] = vv0_8_10
         updates.version_updates[vv0_8_8] = vv0_8_9
         updates.version_updates[vv0_8_7] = vv0_8_9
         updates.version_updates[vv0_8_6] = vv0_8_9


### PR DESCRIPTION
#2853 

Main issue was build anniversary end code didn't add a day to the calculated date.

Versions before 087 were unaffected because they ran older update script code which gave annis proper `end_date`s.

Also added an update script to fix existing anni dates and unlock past anniversaries.

# Testing
## visible calendar days
1. start with a fresh persistent
2. once in idle mode (post introduction), click calendar and check for anniversary dates that make sense

## update script
1. start a new game in a version of MAS between 087 and 089.
2. In that version of MAS, verify that the `end_date` property of an anniversary event (i.e: `anni_1week`) is the same as its `start_date` property.
3. Save the persistent generated from the above steps.
4. uncomment `#        updates.version_updates[vv0_8_9] = vv0_8_10`, set `config.version` in `options` to `"0.8.10"`, and run MAS using the persistent from the above steps.
5. verify that the `start_date` and `end_date` properties are a day apart, also verify if the events show on calendar.