### PR TITLE
RemoveImage logging deafult False

### DIFF
--- a/Monika After Story/game/zz_dockingstation.rpy
+++ b/Monika After Story/game/zz_dockingstation.rpy
@@ -1136,7 +1136,7 @@ init -11 python in mas_dockstat:
         return True
 
 
-    def removeImages(dockstat, image_dict, selective=[]):
+    def removeImages(dockstat, image_dict, selective=[], log=False):
         """
         Removes the decoded images at the end of their lifecycle
 
@@ -1146,6 +1146,8 @@ init -11 python in mas_dockstat:
             selective - list of image keys to delete
                 If not passed in, we delete everything in the image dict
                 (Default: [])
+            log - should we log a delete failure?
+                (Default: False)
 
         AKA quitting
         """
@@ -1154,7 +1156,7 @@ init -11 python in mas_dockstat:
 
         for b64_name in selective:
             real_name, chksum = image_dict[b64_name]
-            mas_utils.trydel(dockstat._trackPackage(real_name), log=True)
+            mas_utils.trydel(dockstat._trackPackage(real_name), log=log)
 
 
 init python in mas_dockstat:


### PR DESCRIPTION
Adds a logging property to Remove Images and sets it to default logging delete failures to False.

That way we dont get these in the log. It's not a big deal if things fail to delete anyway.

# Testing
1. launch game.
2. quit game
3. the file path not specified error should **not** appear in `mas_log`