### PR TITLE
Historical data saving

### DIFF
--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -159,7 +159,7 @@ python early:
     ]
 
 
-init -600 python:
+init -880 python:
     # THE DELAYED ACTION MAP
     # this is the one we actually use when running stuff
     # please note that this is internal use only.
@@ -420,11 +420,28 @@ init 995 python:
     # this is where we run the init level batch of delayed actions
     mas_runDelayedActions(MAS_FC_INIT)
 
-init -600 python in mas_delact:
+init -880 python in mas_delact:
     # we can assume store is imported for all mas_delacts
     import store
 
-init 994 python in mas_delact:
+    def _MDA_safeadd(*ids):
+        """
+        Adds MASDelayedAction ids to the persistent mas delayed action list.
+
+        NOTE: this is only meant for code that runs super early yet needs to
+        add MASDelayedActions. 
+
+        NOTE: This will NOT add duplicates.
+
+        IN:
+            ids - ids to add to the delayed action list
+        """
+        for _id in ids:
+            if _id not in store.persistent._mas_delayed_action_list:
+                store.persistent._mas_delayed_action_list.append(_id)
+
+
+init -875 python in mas_delact:
     # store containing a map for delayed action mapping
 
     # delayed action map:
@@ -434,8 +451,16 @@ init 994 python in mas_delact:
     #   NOTE: the result delayedaction does NOT have to be runnable at 995.
     MAP = {
         1: _greeting_ourreality_unlock,
-        2: _mas_monika_islands_unlock
+        2: _mas_monika_islands_unlock,
+        3: _mas_bday_postbday_notimespent_reset,
+        4: _mas_bday_pool_happy_bday_reset,
+        5: _mas_bday_surprise_party_cleanup_reset,
+        6: _mas_bday_surprise_party_hint_reset,
+        7: _mas_bday_spent_time_with_reset
     }
+
+
+init 994 python in mas_delact:
 
     # this is also where we initialize the delayed action map
     def loadDelayedActionMap():

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1331,22 +1331,22 @@ label ch30_reset:
     $ mas_startupPlushieLogic(4)
 
     ## should we reset birthday
-    python:
-        if (
-                persistent._mas_bday_need_to_reset_bday
-                and not mas_isMonikaBirthday()
-            ):
-            bday_ev = mas_getEV("mas_bday_pool_happy_bday")
-            if bday_ev:
-                bday_ev.conditional="mas_isMonikaBirthday()"
-                bday_ev.action=EV_ACT_UNLOCK
-                persistent._mas_bday_need_to_reset_bday = False
+#    python:
+#        if (
+#                persistent._mas_bday_need_to_reset_bday
+#                and not mas_isMonikaBirthday()
+#            ):
+#            bday_ev = mas_getEV("mas_bday_pool_happy_bday")
+#            if bday_ev:
+#                bday_ev.conditional="mas_isMonikaBirthday()"
+#                bday_ev.action=EV_ACT_UNLOCK
+#                persistent._mas_bday_need_to_reset_bday = False
 
-            bday_spent_ev = mas_getEV("mas_bday_spent_time_with")
-            if bday_spent_ev:
-                bday_spent_ev.action = EV_ACT_QUEUE
-                bday_spent_ev.start_date = datetime.datetime(mas_getNextMonikaBirthday().year, 9, 22, 22)
-                bday_spent_ev.end_date = datetime.datetime(mas_getNextMonikaBirthday().year, 9, 22, 23, 59)
+#            bday_spent_ev = mas_getEV("mas_bday_spent_time_with")
+#            if bday_spent_ev:
+#                bday_spent_ev.action = EV_ACT_QUEUE
+#                bday_spent_ev.start_date = datetime.datetime(mas_getNextMonikaBirthday().year, 9, 22, 22)
+#                bday_spent_ev.end_date = datetime.datetime(mas_getNextMonikaBirthday().year, 9, 22, 23, 59)
 
 
     ## o31 content

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1669,7 +1669,7 @@ init 5 python:
         del rules
 
 
-init 900 python in mas_delact:
+init -876 python in mas_delact:
     # this greeting requires a delayed action, since we cannot ensure that
     # the sprites for this were decoded correctly
 

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -58,6 +58,25 @@ default persistent._mas_o31_trick_or_treating_aff_gain = 0
 define mas_o31_marisa_chance = 90
 define mas_o31_rin_chance = 10
 
+init -814 python in mas_history:
+    # o31 programming point
+    def _o31_exit_pp(mhs):
+        ## just adds appropriate IDs to delayed action
+        # TODO
+        return
+
+
+init -810 python:
+    # MASHistorySaver for o31
+    store.mas_history.addMHS(MASHistorySaver(
+        "o31",
+        datetime.datetime(2018, 11, 2),
+        {
+            "_mas_o31_current_costume"
+        },
+        exit_pp=store.mas_history._o31_exit_pp
+    ))
+
 init 101 python:
     # o31 setup
     if persistent._mas_o31_seen_costumes is None:

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -13,6 +13,7 @@ default persistent._mas_o31_current_costume = None
 
 default persistent._mas_o31_seen_costumes = None
 # dict containing seen costumes for o31
+# NOTE: NOT saved historically since this just tracks what has been seen
 
 default persistent._mas_o31_costume_greeting_seen = False
 # set to true after seeing a costume greeting
@@ -58,12 +59,12 @@ default persistent._mas_o31_trick_or_treating_aff_gain = 0
 define mas_o31_marisa_chance = 90
 define mas_o31_rin_chance = 10
 
-init -814 python in mas_history:
+#init -814 python in mas_history:
     # o31 programming point
-    def _o31_exit_pp(mhs):
+#    def _o31_exit_pp(mhs):
         ## just adds appropriate IDs to delayed action
         # TODO
-        return
+#        return
 
 
 init -810 python:
@@ -72,9 +73,27 @@ init -810 python:
         "o31",
         datetime.datetime(2018, 11, 2),
         {
-            "_mas_o31_current_costume"
-        },
-        exit_pp=store.mas_history._o31_exit_pp
+            "_mas_o31_current_costume": "o31.costume.was_worn",
+            "_mas_o31_costume_greeting_seen": "o31.costume.greeting.seen",
+            "_mas_o31_costumes_allowed": "o31.costume.allowed",
+
+            # this isn't very useful, but we need the reset
+            "_mas_o31_in_o31_mode": "o31.mode.o31",
+
+            "_mas_o31_dockstat_return": "o31.dockstat.returned_o31",
+            "_mas_o31_went_trick_or_treating_short": "o31.actions.tt.short",
+            "_mas_o31_went_trick_or_treating_mid": "o31.actions.tt.mid",
+            "_mas_o31_went_trick_or_treating_right": "o31.actions.tt.right",
+            "_mas_o31_went_trick_or_treating_long": "o31.actions.tt.long",
+            "_mas_o31_went_trick_or_treating_longlong": "o31.actions.tt.longlong",
+            "_mas_o31_went_trick_or_treating_abort": "o31.actions.tt.abort",
+            "_mas_o31_trick_or_treating_start_early": "o31.actions.tt.start.early",
+            "_mas_o31_trick_or_treating_start_normal": "o31.actions.tt.start.normal",
+            "_mas_o31_trick_or_treating_start_late": "o31.actions.tt.start.late",
+            "_mas_o31_trick_or_treating_aff_gain": "o31.actions.tt.aff_gain"
+
+        }
+#        exit_pp=store.mas_history._o31_exit_pp
     ))
 
 init 101 python:

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -65,7 +65,7 @@ init 5 python:
             )
         )
 
-init 900 python in mas_delact:
+init -876 python in mas_delact:
     # this event requires a delayed aciton, since we cannot ensure that
     # the sprites for this were decoded correctly
 

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -1229,6 +1229,7 @@ init -876 python in mas_delact:
 
     def _mas_bday_surprise_party_hint_reset_action(ev):
         # updates conditional and action
+        # TODO: should we show to users who arleady did a surprise party?
         ev.conditional = (
             "datetime.date.today() < mas_monika_birthday and "
             "mas_monika_birthday.day - datetime.date.today().day == 1"

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -1229,12 +1229,16 @@ init -876 python in mas_delact:
 
     def _mas_bday_surprise_party_hint_reset_action(ev):
         # updates conditional and action
-        # TODO: should we show to users who arleady did a surprise party?
-        ev.conditional = (
-            "datetime.date.today() < mas_monika_birthday and "
-            "mas_monika_birthday.day - datetime.date.today().day == 1"
-        )
-        ev.action = store.EV_ACT_PUSH
+        threw_surprise_party = store.mas_HistVerify(
+            "922.actions.surprise.reacted",
+            True
+        )[0]
+        if not threw_surprise_party:
+            ev.conditional = (
+                "datetime.date.today() < mas_monika_birthday and "
+                "mas_monika_birthday.day - datetime.date.today().day == 1"
+            )
+            ev.action = store.EV_ACT_PUSH
         return True
 
 

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -297,6 +297,7 @@ label v0_3_1(version=version): # 0.3.1
 # 0.8.10
 label v0_8_10(version="v0_8_10"):
     python:
+        import store.mas_history as mas_history
 
         # reset and unlock past anniversaries
         if persistent.sessions is not None:
@@ -304,6 +305,15 @@ label v0_8_10(version="v0_8_10"):
             if first_sesh:
                 store.mas_anni.reset_annis(first_sesh)
                 store.mas_anni.unlock_past_annis()
+
+        # correctly save the sbd persistent data since we renamed it
+        if (
+                persistent._mas_bday_sbd_aff_given is not None
+                and persistent._mas_bday_sbd_aff_given > 0
+            ):
+            persistent._mas_history_archives[2018][
+                "922.actions.surprise.aff_given"
+            ] = persistent._mas_bday_sbd_aff_given
 
     return
 

--- a/Monika After Story/game/zz_history.rpy
+++ b/Monika After Story/game/zz_history.rpy
@@ -356,15 +356,6 @@ init -850 python:
                 raise Exception(
                     "History object '{0}' already exists".format(mhs_id)
                 )
-
-            self.id = mhs_id
-            self.setTrigger(trigger)  # use the set function for cleansing
-            self.use_year_before = use_year_before
-            self.mapping = mapping
-            self.dont_reset = dont_reset
-            self.entry_pp = entry_pp
-            self.exit_pp = exit_pp
-
             # init first sesh
             if MASHistorySaver.first_sesh == -1:
                 if persistent.sessions is not None:
@@ -375,6 +366,14 @@ init -850 python:
 
                 else:
                     MASHistorySaver.first_sesh = None
+
+            self.id = mhs_id
+            self.setTrigger(trigger)  # use the set function for cleansing
+            self.use_year_before = use_year_before
+            self.mapping = mapping
+            self.dont_reset = dont_reset
+            self.entry_pp = entry_pp
+            self.exit_pp = exit_pp
 
        
         @staticmethod
@@ -421,17 +420,17 @@ init -850 python:
             IN:
                 _trigger - trigger to change to
             """
-            _today = datetime.date.today()
+            _now = datetime.datetime.now()
 
             # grab first sesh
             # if we do not have a first sesh, then assume today is first
             # sessions
             first_sesh = MASHistorySaver.first_sesh
             if first_sesh is None:
-                first_sesh = _today
+                first_sesh = _now
 
             if (
-                    _trigger.year > (_today.year + 1)
+                    _trigger.year > (_now.year + 1)
                     or _trigger <= first_sesh
                 ):
                 # if the trigger year is at least 2 years beyond current, its

--- a/Monika After Story/game/zz_history.rpy
+++ b/Monika After Story/game/zz_history.rpy
@@ -619,3 +619,4 @@ init -810 python:
         },
         exit_pp=store.mas_history._bday_exit_pp
     ))
+

--- a/Monika After Story/game/zz_history.rpy
+++ b/Monika After Story/game/zz_history.rpy
@@ -280,6 +280,36 @@ init -850 python:
         return store.mas_history.lookup_otl(key, years_list)
 
 
+    def mas_HistVerify(key, _verify, *years):
+        """
+        Verifies if data at the given key matches the verification value.
+
+        IN:
+            key - data key to lookup
+            _verify - the data we want to match to
+            years - years to look up data (as args)
+                Dont pass in anything if you want to lookup all years since
+                2017
+
+        RETURNS: tuple of the following format:
+            [0]: true/False if we found data that matched the verification
+            [1]: list of years that matched the verification
+        """
+        if len(years) == 0:
+            years = range(2017, datetime.date.today().year+1)
+
+        found_data = mas_HistLookup_otl(key, years)
+        years_found = []
+
+        for year, data_tuple in found_data.iteritems():
+            status, _data = data_tuple
+            
+            if status == store.mas_history.L_FOUND and _data == _verify:
+                years_found.append(year)
+
+        return (len(years_found) > 0, years_found)
+
+
     ## MASHistorySaver stuff
     
     class MASHistorySaver(object):
@@ -533,6 +563,8 @@ init -800 python in mas_history:
     # now run the algorithm
     _runMHSAlg()
 
+    # save trigger data
+    saveMHSData()
 
 
 init -816 python in mas_delact:

--- a/Monika After Story/game/zz_history.rpy
+++ b/Monika After Story/game/zz_history.rpy
@@ -306,6 +306,8 @@ init -850 python:
                 self is passed to this
             exitpp - programming point called after saving data
                 self is passed to this
+            trigger_pp - programming point called to update trigger with
+                instead of the default year+1
         """
         import store.mas_history as mas_history
 
@@ -319,7 +321,8 @@ init -850 python:
                 use_year_before=False,
                 dont_reset=False,
                 entry_pp=None,
-                exit_pp=None
+                exit_pp=None,
+                trigger_pp=None
             ):
             """
             Constructor
@@ -350,6 +353,10 @@ init -850 python:
                 exit_pp - programming point called after saving data
                     self is passed to this
                     (Default: None)
+                trigger_pp - if not None, this pp is called with the current
+                    trigger when updating trigger, and the returned datetime 
+                    is used as the new trigger.
+                    (Default: None)
             """
             # sanity checks
             if mhs_id in self.mas_history.mhs_db:
@@ -374,6 +381,7 @@ init -850 python:
             self.dont_reset = dont_reset
             self.entry_pp = entry_pp
             self.exit_pp = exit_pp
+            self.trigger_pp = trigger_pp
 
        
         @staticmethod
@@ -478,8 +486,12 @@ init -850 python:
                 if not self.dont_reset:
                     source[p_key] = None
 
-            # change trigger year
-            self.trigger = MASHistorySaver.correctTriggerYear(self.trigger)
+            # update trigger
+            if self.trigger_pp is not None:
+                self.trigger = self.trigger_pp(self.trigger)
+
+            else:
+                self.trigger = MASHistorySaver.correctTriggerYear(self.trigger)
 
             if self.exit_pp is not None:
                 self.exit_pp(self)

--- a/Monika After Story/game/zz_history.rpy
+++ b/Monika After Story/game/zz_history.rpy
@@ -106,7 +106,7 @@ init -860 python in mas_history:
     # we did not find the key in the archives (for the given year)
 
     ### archive functions:
-    def lookup(key, year)
+    def lookup(key, year):
         """
         Looks up data in the historical archives.
 
@@ -134,7 +134,7 @@ init -860 python in mas_history:
         return (L_FOUND, data_file[key])
 
 
-    def lookup_ot(key, *years)
+    def lookup_ot(key, *years):
         """
         Looks up data overtime in the historical archives.
 

--- a/Monika After Story/game/zz_history.rpy
+++ b/Monika After Story/game/zz_history.rpy
@@ -358,6 +358,7 @@ init -850 python:
             self.setTrigger(trigger)  # use the set function for cleansing
             self.use_year_before = use_year_before
             self.mapping = mapping
+            self.dont_reset = dont_reset
             self.entry_pp = entry_pp
             self.exit_pp = exit_pp
 

--- a/Monika After Story/game/zz_history.rpy
+++ b/Monika After Story/game/zz_history.rpy
@@ -380,7 +380,7 @@ init -850 python:
             _now = datetime.datetime.now()
             _temp_trigger = _trigger.replace(year=_now.year)
 
-            if current_dt > _temp_trigger:
+            if _now > _temp_trigger:
                 # trigger has already past, set the trigger for next year
                 return _trigger.replace(year=_now.year + 1)
 
@@ -501,6 +501,7 @@ init -816 python in mas_delact:
 
 init -815 python in mas_history:
     ## Need a place define callbacks/programming points? Do it here I guess.
+    from store.mas_delact import _MDA_safeadd
 
     # BDAY
     def _bday_exit_pp(mhs):

--- a/Monika After Story/game/zz_history.rpy
+++ b/Monika After Story/game/zz_history.rpy
@@ -595,7 +595,102 @@ init -810 python:
     # NOTE: because player model variables are used basically everywhere, 
     #   rather than make a ton of player model MHS objects, lets just make a 
     #   generic one that runs on jan 1 of every year.
-    # TODO
+    #
+    # Sub cats:
+    #   lifestyle - what you do
+    #   emotions - emotional/mental states
+    #   family - family related stuff
+    #   actions - what you have done
+    #   location - location-based stuff
+    #   likes - likes/wants
+    #   know - knowledge
+    store.mas_history.addMHS(MASHistorySaver(
+        "pm",
+        datetime.datetime(2019, 1, 1),
+        {
+            # lifestyles (of the rich and famous)
+            "_mas_pm_religious": "pm.lifestyle.religious",
+            "_mas_pm_like_playing_sports": "pm.lifestyle.plays_sports",
+            "_mas_pm_meditates": "pm.lifestyle.meditates",
+            "_mas_pm_see_therapist": "pm.lifestyle.sees_therapist",
+
+            # lifestyle / ring
+            "_mas_pm_wearsRing": "pm.lifestyle.ring.wears_one",
+
+            # lifestyle / music
+            "_mas_pm_play_jazz": "pm.lifestyle.music.play_jazz",
+
+            # lifestyle / smoking
+            "_mas_pm_do_smoke": "pm.lifestyle.smoking.smokes",
+            "_mas_pm_do_smoke_quit": "pm.lifestyle.smoking.trying_to_quit",
+
+            # lifestyle / food
+            "_mas_pm_eat_fast_food": "pm.lifestyle.food.eats_fast_food",
+
+            # emotions
+            "_mas_pm_love_yourself": "pm.emotions.love_self",
+
+            # family
+            "_mas_pm_have_fam": "pm.family.have_family",
+            "_mas_pm_have_fam_sibs": "pm.family.have_siblings",
+            "_mas_pm_no_fam_bother": "pm.family.bothers_you",
+            "_mas_pm_have_fam_mess": "pm.family.is_mess",
+            "_mas_pm_have_fam_mess_better": "pm.family.will_get_better",
+            "_mas_pm_no_talk_fam": "pm.family.no_talk_about",
+            "_mas_pm_fam_like_monika": "pm.family.likes_monika",
+
+            # actions
+            "_mas_pm_drawn_art": "pm.actions.drawn_art",
+
+            # actions / prom
+            "_mas_pm_gone_to_prom": "pm.actions.prom.went",
+            "_mas_pm_prom_good": "pm.actions.prom.good",
+            "_mas_pm_had_prom_date": "pm.actions.prom.had_date",
+            "_mas_pm_prom_monika": "pm.actions.prom.wanted_monika",
+            "_mas_pm_prom_not_interested": "pm.actions.prom.no_interest",
+            "_mas_pm_prom_shy": "pm.actions.prom.too_shy",
+            "_mas_pm_no_prom": "pm.actions.prom.no_prom",
+
+            # actions / books
+            "_mas_pm_read_yellow_wp": "pm.actions.books.read_yellow_wp",
+
+            # actions / mas / zoom
+            "_mas_pm_zoomed_out": "pm.actions.mas.zoom.out",
+            "_mas_pm_zoomed_in": "pm.actions.mas.zoom.in",
+            "_mas_pm_zoomed_in_max": "pm.actions.mas.zoom.in_max",
+
+            # location
+            "_mas_pm_live_in_city": "pm.location.live_in_city",
+            "_mas_pm_live_near_beach": "pm.location.live_near_beach",
+
+            # likes
+            "_mas_pm_likes_horror": "pm.likes.horror",
+            "_mas_pm_likes_spoops": "pm.likes.spooks",
+            "_mas_pm_watch_mangime": "pm.likes.manga_and_anime",
+
+            # likes / monika
+            "_mas_pm_a_hater": "pm.likes.monika.not",
+
+            # likes / music
+            "_mas_pm_like_rap": "pm.likes.music.rap",
+            "_mas_pm_like_vocaloids": "pm.likes.music.vocaloids",
+            "_mas_pm_like_rock_n_roll": "pm.likes.music.rock_n_roll",
+            "_mas_pm_like_orchestral_music": "pm.likes.music.orchestral",
+            "_mas_pm_like_jazz": "pm.likes.music.jazz",
+            "_mas_pm_like_other_music": "pm.likes.music.other",
+
+            # likes / food
+            "_mas_pm_like_mint_ice_cream": "pm.likes.food.mint_ice_cream",
+
+            # knowledge
+            # knowledge / lang
+            "_mas_pm_lang_other": "pm.know.lang.other",
+            "_mas_pm_lang_jpn": "pm.know.lang.jpn"
+
+        },
+        use_year_before=True,
+        dont_reset=True
+    ))
 
     # BDAY
     # NOTE: kind of wish I put all the bday variables together. Since they are

--- a/Monika After Story/game/zz_history.rpy
+++ b/Monika After Story/game/zz_history.rpy
@@ -1,0 +1,401 @@
+# Historical data module
+#
+# How this works:
+#   Historical data is persistent data over time. 
+#
+# ORGANIZED:
+#   dicts of dicts:
+#   <year> : <subdict>
+#       year - just the 4/5 digit year (2018, 2017, and so on)
+#       subdict - as follows:
+#           <data key> : <data value>
+#               data key - key to identify this data. See below for layout
+#               data value - value to save
+#
+# DATA KEY LAYOUT:
+#   data keys need to follow a structure so we can ensure uniqueness:
+#   <topic category>.<sub category>.<sub sub category>.<name>
+#   EX: o31.activity.tricktreat.went_outside
+#   topic category - main topic category
+#       o31 - halloween
+#       d25 - chms
+#       922 - monika bday
+#       player_bday - player bday
+#       pm - player model 
+#       and so on
+#   sub category - fine tuned category if needed
+#       Use BASE if not needed
+#   sub sub category - even more fine tuned category if needed
+#       Use BASE if not needed
+#   name - variable name. this should be pretty descriptive
+#       
+# MAPPING
+#   Data saving is done by mapping a persistent variable name (as string) to
+#   the data key (as string).
+#   NOTE: we do NOT just use the persistent variable name as data key in the
+#       event that we wnat to save a non-persistent variable.
+#
+# MAPPING STORAGE
+#   New class called MASHistorySaver, contains a datetime and a mapping, 
+#   as well as the callbacks/programming points for a mapping.
+#   Also contains an ID for uniqueness. We use that ID in saving data.
+#
+#   The datetime determines the next time the mapping is saved. This will be
+#   auto adjusted to the next year. We also scan through datetimes and fix
+#   times that are beyond 1 year ahead (in the case of time traveling)
+#
+#   MASHistorySaver data is saved into a dict of tuples. We use the ID for key.
+#
+# CALLBACKS:
+#   When data mapping is done, there is option to run entry/exit programming
+#   points. Not sure if this is really helpful but we'll see.
+#
+# RUN:
+#   All MASHistorySaver objects are checked at init -800. This is designed to 
+#   be run after persistent backup system is run, but before lots of other
+#   things.
+#   The datetimes of each object are checked and if the current date is
+#   past this datetime we run the data save. This uses the mapping to save
+#   appropriate data into the historical dict.
+#
+#   All persistent variables that were saved are then set to None. This preps
+#   them for default values later in the pipeline
+#
+# STORAGE:
+#   all historical data is saved in `persistent._mas_history_archives`
+#   access is given via public functions. DO NOT ACCESS DIRECTLY
+#
+#   MASHistorySaver object data is stored in `persistent._mas_history_mhs_data`
+#   NEVER ACCESS THIS IN RUNTIME
+#   
+#   MASHistorySaver objects are created on start and stored in `mhs_db`
+#   Access is given via public functions. DO NOT ACCESS DIRECTLY
+
+init -860 python in mas_history:
+    import store
+    import datetime
+
+    ### initialize the archives
+    if store.persistent._mas_history_archives is None:
+        store.persistent._mas_history_archives = dict()
+
+    # add all years up to today in the archives
+    for year in range(2017, datetime.date.today().year + 1):
+        if year not in store.persistent._mas_history_archives:
+            store.persistent._mas_history_archives[year] = dict()
+    ### END init
+
+    ### MASHistorySaver data init
+    if store.persistent._mas_history_mhs_data is None:
+        store.persistent._mas_history_mhs_data = dict()
+    ### END init
+
+    mhs_db = dict()
+    # MASHistorySaver objects database
+
+    ### CONSTANTS
+
+    ## lookup constants
+    L_FOUND = 0
+    # we FOUND data for the year + key in the archives
+
+    L_NO_YEAR = 1
+    # we did not find the year in the archives
+
+    L_NO_KEY = 2
+    # we did not find the key in the archives (for the given year)
+
+    ### archive functions:
+    def lookup(key, year)
+        """
+        Looks up data in the historical archives.
+
+        IN:
+            key - data key to lookup
+            year - year to look up data
+
+        RETURNS: a tuple of the following format:
+            [0]: Lookup constant 
+            [1]: retrieved data (which may be None). This is always None if
+                we could not find year or key
+        """
+        archives = store.persistent._mas_history_archives
+
+        # get data from the year
+        data_file = archives.get(year, None)
+        if data_file is None:
+            return (L_NO_YEAR, None)
+
+        # otherwise year found! Check for key
+        if key not in data_file:
+            return (L_NO_KEY, None)
+
+        # key is here, return data
+        return (L_FOUND, data_file[key])
+
+
+    def lookup_ot(key, *years)
+        """
+        Looks up data overtime in the historical archives.
+
+        IN:
+            key - data key to lookup
+            years - years to look up data
+
+        RETURNS: SEE lookup_ot_l
+        """
+        return lookup_ot_l(key, years)
+
+
+    def lookup_otl(key, years_list):
+        """
+        Looks up data overtime in the historical archives.
+
+        IN:
+            key - data key to look up
+            years_list - list of years to lookup data
+
+        RETURNS: dict of the following format:
+            year: tuple (SEE lookup)
+        """
+        found_data = dict()
+
+        for year in years_list:
+            found_data[year] = lookup(key, year)
+
+        return found_data
+
+
+    ### archive saving functions: (NOT PUBLIC)
+    def _store(value, key, year):
+        """
+        Stores data in the historical archives.
+
+        NOTE: will OVERWRITE data that already exists.
+
+        IN:
+            value - value to store
+            key - data key to store value
+            year - year to store value
+        """
+        store.persistent._mas_history_archives[year][key] = value
+
+
+init -850 python:
+
+    ## public archive functions
+    def mas_HistLookup(key, year):
+        """
+        Looks up data in the historical archives.
+
+        IN:
+            key - data key to look up
+            year - year to look up data
+
+        RETURNS: a tuple of the following format:
+            [0]: mas_history lookup constant
+            [1]: retrieved data (which may be None). This is always None if
+                we could not find year or key
+        """
+        return store.mas_history.lookup(key, year)
+
+
+    def mas_HistLookup_ot(key, *years):
+        """
+        Looks up data overtime in the historical archives.
+
+        IN:
+            key - data key to look up
+            years - years to look updata
+
+        RETURNS: dict of the following format:
+            year: data tuple from mas_HistLookup
+        """
+        return store.mas_history.lookup_otl(key, years)
+
+
+    def mas_HistLookup_otl(key, years_list):
+        """
+        Looks up data overtime in the historical archives.
+
+        IN:
+            key - data key to look up
+            years_list - list of years to lookup data
+
+        RETURNS: dict of the following format:
+            year: data tuple from mas_HistLookup
+        """
+        return store.mas_history.lookup_otl(key, years_list)
+
+
+    ## MASHistorySaver stuff
+    
+    class MASHistorySaver(object):
+        """
+        Class designed to represent mapping of historial data that we need to
+        save over certain intervals.
+
+        PROPERTIES:
+            mhs_id - identifier of this MASHistorySaver object
+                NOTE: Must be unique
+            trigger - datetime to trigger the saving
+                NOTE: this is changed automatically when saving is done
+                NOTE: the trigger's year is what we use to determine where to
+                    save the historical data
+            mapping - mapping of persistent variable names to historical data
+                keys
+            use_year_before - True means that when saving data, we should use
+                trigger.year - 1 as the year to determine where to save
+                historical data. This is mainly for year-end events like 
+                d31 and new years
+            entry_pp - programming point called before saving data
+                self is passed to this
+            exitpp - programming point called after saving data
+                self is passed to this
+        """
+        import store.mas_history as mas_history
+
+        def __init__(self, 
+                mhs_id,
+                trigger,
+                mapping,
+                use_year_before=False,
+                entry_pp=None,
+                exit_pp=None
+            ):
+            """
+            Constructor
+
+            Throws exception if mhs_id is NOT unique
+
+            IN:
+                mhs_id - identifier of this MASHistorySaver object
+                    NOTE: Must be unique
+                trigger - datetime of when to trigger data saving for this
+                    NOTE: if the year of this datetime is 2 years ahead of the
+                        current year, we reset this to 1 year ahead of the
+                        current year.
+                    NOTE: this is changed every time we execute the saveing
+                        routine
+                    NOTE: trigger.year is used when saving historical data
+                mapping - mapping of the persistent variable names to 
+                    historical data keys
+                use_year_before - True will use trigger.year-1 when saving
+                    historical data instead of trigger.year. 
+                    (Default: False)
+                entry_pp - programming point called before saving data
+                    self is passed to this
+                    (Default: None)
+                exit_pp - programming point called after saving data
+                    self is passed to this
+                    (Default: None)
+            """
+            # sanity checks
+            if mhs_id in self.mas_history.mhs_db:
+                raise Exception(
+                    "History object '{0}' already exists".format(mhs_id)
+                )
+
+            self.mhs_id = mhs_id
+            self.setTrigger(trigger)  # use the set function for cleansing
+            self.use_year_before = use_year_before
+            self.mapping = mapping
+            self.entry_pp = entry_pp
+            self.exit_pp = exit_pp
+
+       
+        @staticmethod
+        def correctTriggerYear(_trigger):
+            """
+            Determines the correct year to set trigger to.
+
+            A triggers with a correct year are basically triggers that have not
+            passed yet. It's not as simple as increasing year since we have to
+            account for triggers that have yet to execute this year.
+
+            IN:
+                _trigger - trigger we are trying to change
+
+            RETURNS: _trigger with the correct year
+            """
+            current_date = datetime.date.today()
+            _temp_trigger = _trigger.replace(year=current_date.year)
+
+            if current_date > _temp_trigger:
+                # trigger has already past, set the trigger for next year
+                return _trigger.replace(year=current_date.year + 1)
+
+            # trigger has NOT passed yet, set the trigger for this year
+            return _temp_trigger
+
+
+        def fromTuple(self, data_tuple):
+            """
+            Loads data from the data tuple
+
+            IN:
+                data_tuple - tuple of the following format:
+                    [0]: datetime to set the trigger property
+            """
+            self.setTrigger(data_tuple[0])
+
+
+        def setTrigger(self, _trigger):
+            """
+            Sets the trigger of this object. This function does cleansing of
+            bad trigger dates.
+
+            IN:
+                _trigger - trigger to change to
+            """
+            current_date = datetime.date.today()
+            if _trigger.year > (current_date.year + 1):
+                # if the trigger year is at least 2 years beyond current, its
+                # definitely a time travel issue.
+
+                # but we need to determine if the trigger has already happend
+                # in teh current year or will happen this year so we can 
+                # both prevent overwrites and save data when we need to.
+                self.trigger = MASHistorySaver.correctTriggerYear(_trigger)
+
+            else:
+                # otherwise, no issues with the new trigger
+                self.trigger = _trigger
+
+
+        def save(self):
+            """
+            Runs the saving routine
+
+            NOTE: does NOT check trigger.
+
+            NOTE: will CHANGE trigger
+            """
+            if self.entry_pp is not None:
+                self.entry_pp(self)
+
+            # now to actually save
+            source = persistent.__dict__
+            dest = self.mas_history
+            save_year = self.trigger.year
+
+            # go through mapping and save data
+            for p_key in self.mapping:
+                p_data = source.get(p_key, None)
+                dest._store(p_data, self.mapping[p_key], save_year)
+
+            # change trigger year
+            self.trigger = MASHistorySaver.correctTriggerYear(self.trigger)
+
+            if self.exit_pp is not None:
+                self.exit_pp(self)
+
+
+        def toTuple(self):
+            """
+            Converts this MASHistorySaver object into a tuple
+
+            RETURNS tuple of the following format:
+                [0]: trigger - the trigger property of this object
+            """
+            return (self.trigger,)


### PR DESCRIPTION
This adds an automated historical data saver. Basically saving persistent data into a separate db so events that repeat (like 922, o31...) can repeat without us having to explicity make an update to reset vars.

# Key features
* new `MASHistorySaver` class. These objects contain mappings for persistent variables and data keys, as well as a trigger date and potential callbacks/programming points. On start, these object's trigger properties are checked and the saving algorithms ran appropraitely if the trigger time has past. These also reset trigger times to the next year, so we don't have to manually do anything.
* I've moved DelayedActions starter code earlier in the pipeline, so callbacks for `MASHistorySaver` objects can use delayedactions to run arbitrary code. The main thing they do is reset event properties at the init stage.
* `zz_history` has a massive comment at the top explaining a bunch of things. I will bring out the key things here:

## Data org
Historical data is organized by years, then special string keys. The years are ints and are what you expect. The string keys are designed to be organized like namespaces are in C# and other langs (dot separators). For example, whether or not the user put up banners for Monika's surprise party has a key of `922.actions.surprise.found_banners`. `922` is the main category/topic, followed by `actions`, and `surprise` as the sub category of actions. You don't have to use 3 bins here, you could just have `922.something` if it doesn't make sense to add sub categories. The main thing is using some sort of main topic identifier in the first bin so keys are organized.

The actual structure is a dict of dicts, with years being the outer keys and string keys being the inner data keys. This is stored in `persistent._mas_history_archives`

## Historical data save alg
Historical data saving is automated using `MASHistorySaver` objects. These objects contain a trigger property which is just a datetime. When the current date is past this datetime, we run the saving algorithm. All this does is copy certain vars from `persistent` to the historical data db and reset the `persistent` variables that were copied (to None). this allows them to get default values later in the pipeline.

The trigger is automatically set to the next year when the alg is run. there is also support for custom trigger update code. (NOT TESTED)

This algorithm is run on startup at init -800.

## Time travel safeguards
### The future
If time traveling to the future, the triggers will run as normal. We can't differentiate between changed time and not opening the game for a while. New trigger dates (if using the default trigger update) will always be in the future, so even if you fast forward 20 years, the next set of trigger dates wont be just 1 year ahead from their last trigger date (they will be either your current year or current year+1)

### The past
If time traveling to the past, the triggers are adjusted so they make sense. Basically triggers that would activate 2+ years from the current year are changed so they either occur current year or current year + 1. 

### data integrety when time traveling
NOTE that if you travel to the past, you will have data in the historical database that is technically future data. (This is also releveant if you travel to the future then come back to the present). **Historical data is not cleaned when traveling to the past.** Because of this, it's up to callers to manage the logical issues that may result when trying to check historical data of a time traveler. 

For example, if we are determining if the user celebrated monika's bday in the current year, we have to check if the bday has passed in this year before checking the historical db. Checking stuff in the past should not be subject to logical issues when time traveling.

### potential overwrite
NOTE that is also possible to overwrite past events by time traveling to the future (at least 2 years ahead of the target year), and then time traveling to the past/target year. Example:
1. user wants to redo 2018-9-22. They travel to some date in year 2021.
2. The triggers run, historical data is saved for 2019, 2020, potentially 2021. The triggers now point to a date in either 2021 or 2022.
3. User travels to 2018-9-21.
4. Triggers are flagged as bad triggers since they are more than a year in the future. Triggers are all cleaned so they would occur in 2018 since the user is before 9-22.
5. User goes through bday stuff and whatever. Bday flags are set.
6. User travels back to present day.
7. Since 9-30 passes (which is the trigger date for bday data), the flags are saved. They will overwrite any data that was previously stored in the year/data key combo.

As discussed on discord, we are not going to prevent overwriting of history. Time travel is srs biz.

## `MASDelayedAction` integration
`MASHistorySaver` objects can be given callbacks/programming points that run before and after they trigger. By pairing the after programming point with `MASDelayedActions`, we can run event property resets in concurrence with historical data saving. The process is a bit consuming since you need basically 2 functions per event, 1 to actually do the property reset, 1 to create teh `MASDelayedAction`. 

Since the historical alg runs at a pretty early init level, Event objects do not exist, and so delayed actions must be added as IDs to the `persistent._mas_delayed_action_list`, which is convereted into `MASDelayedActions` much later in the pipeline. There is a function `_MDA_safeadd` which lets you add IDs to that list while ensuring no duplicates are added.

## `MASHistorySaver` data
The only data we save from these objects are the trigger dates. They are stored in a persistent dict of tuples. **no direct access, please**.

The actual objects are stored in `mhs_db` in teh `mas_history` store, and are always generated on start. `MASHistorySaver` objects have a string id, this generally should be the same as the starting topic of the data key strings, but it's not enforced.

## important functions
### global functions
* `mas_HistLookup` - main lookup function to check some historical data. Returns a tuple, with the first item being a constant that be sort of used when determing if something happened/coudl have happened or not. This isn't 100% reliable because of the time traveling, though.
* `mas_HistLookup_ot` - lookup that can get data from one key over multiple years
* `mas_HistLookup_otl` - same as above but using a list of years instead of args
* `mas_HistVerify` - checks if a data key matches a given value. This also can check multiple years.

### `mas_history` functions
* `getMHS` - retrieves a MASHistorySaver object from teh database given its id

# TESTING
## setup
1. Get a persistent that did some of the bday stuff. (or all, it doesn't really matter, but make sure to note down what you did and what the data values are. Check the bottom of `zz_history` for the names of the persistent variables that will be saved). Make multiple copies of this.
2. Same as above but for o31 events. 

## Time traveling future trigger date
1. time travel to the future
2. verify that the trigger dates for the `MASHistorySaver` objects (check `mas_history.mhs_db`) make sense for the date you traveled. (no trigger date should be in teh past from ur current date)

## time traveling past trigger date
1. time travel to the past (or to the future first, then present)
2. verify that the trigger dates for the `MASHistorySaver` objects make sense. (all trigger dates should either happen the year you traveled to or year+1)

## bday data reset
1. Launch the game with the bday stuff persistent
2. open console and check the status of the persistent variables. They all should be reset to their defaults.
3. Check `persistent._mas_history_archives`. It should contain the previous bday data. compare this to what you noted down earlier
4. Additionally check the conditional/action/start_date/end_date properties for some of the birthday events: (cells marked with x are changed in the reset)

eventlabel | conditional | action | start_date | end_date
--- | --- | --- | --- | --- 
`mas_bday_postbday_notimespent` | x | x |  |  
`mas_bday_ppol_happy_bday` | x | x | |
`mas_bday_surprise_party_cleanup` | x | x |  |
`mas_bday_surprise_party_hint` | x | x | |
`mas_bday_spent_time_with` | x | x | x | x

**NOTE** `surprise_party_hint` will not get reset `conditional` and `action` if you threw a surprise party (aka `_mas_bday_sbp_reacted` is True)

## bday data reset no trigger
1. Change ur date to before 9-30-2018
2. Launch game with the bday stuff persistent 
3. Verify that **nothing happens**. aka, no historical data is saved, persistents are not reset, event properties are not reset.

## o31 data reset
1. Change ur date to before novemeber 2
2. Launch game with the o31 persistent
3. Verify that no changes occur. (no persistents reset, no data saved)

## o31 data reset
1. Launch the game with the o31 stuff persistent after november 2
2. open console check the status of the persistent variables. (check `script-holidays` for the o31 vars).
3. check `persistent._mas_history_archives`, should contain previous o31 data. Compare this to notes.

## player model save
1. change date to after jan 1 2019
2. check `persistent._mas_history_archives`, should contain player model data
3. verify that player model `persistent` variables were not reset