### PR TITLE
Optimizing Sprite String creation

### DIFF
--- a/Monika After Story/game/dev/dev_sprite_timer.rpy
+++ b/Monika After Story/game/dev/dev_sprite_timer.rpy
@@ -1,0 +1,61 @@
+# timing sprite string generation
+init 5 python:
+    addEvent(
+        Event(
+            persistent.event_database,
+            eventlabel="dev_sprite_string_timer",
+            category=["dev"],
+            prompt="TIME SPRITE GEN",
+            pool=True,
+            unlocked=True
+        )
+    )
+
+label dev_sprite_string_timer:
+    m "how many iterations?"
+
+    python:
+        iterations = renpy.input("how many iterations?", allow="0123456789")
+
+        try:
+            iterations = int(iterations)
+        except:
+            iterations = 100000
+
+        def test_fun():
+            store.mas_sprites._ms_sitting(
+                monika_chr.clothes.name,
+                "def",
+                "up",
+                "normal",
+                "def",
+                "smile",
+                not morning_flag,
+                [],
+                [],
+                monika_chr.acs.get(MASMonika.PST_ACS, []),
+                None,
+                "steepling",
+                None,
+                None,
+                None,
+                None,
+                None
+            )
+
+    m "okay we do [iterations] times.{fast}"
+
+    python:
+        import time
+        t0 = time.clock()
+        for i in range(iterations):
+            test_fun()
+        t1 = time.clock()
+
+        total_time = t1-t0
+
+    m "that took [total_time] seconds!"
+    return
+
+
+

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -265,6 +265,9 @@ init -5 python in mas_sprites:
 #    y_step = 40
     y_step = 10
 
+    # adding optimized initial parts of the sprite string
+    PRE_SPRITE_STR = TRAN + "(" + L_COMP + "("
+
     # Prefixes for files
     PREFIX_BODY = "torso" + ART_DLM
     PREFIX_ARMS = "arms" + ART_DLM
@@ -528,9 +531,10 @@ init -5 python in mas_sprites:
 
     def build_loc():
         """
-        RETURNS location string for the sprite
+        RETURNS location string for the sprite as a tuple of strings.
+        Use this with an extend on the main sprite list
         """
-        return "".join(["(", str(adjust_x), ",", str(adjust_y), ")"])
+        return ("(", str(adjust_x), ",", str(adjust_y), ")")
 
 
     # sprite maker functions
@@ -1115,13 +1119,48 @@ init -5 python in mas_sprites:
         else:
             loc_str = LOC_REG
 
+        # location string tuple (for individual composites)
+        loc_str_tup = build_loc()
+        
+        # initial portions of list
+        sprite_str_list = [
+            PRE_SPRITE_STR,
+            loc_str
+        ]
+
+        # pre accessories
+        sprite_str_list.extend(
+            _ms_accessorylist(acs_pre_list, isnight, True, arms, lean=lean)
+        )
+
+        # between pre acs and body
+        sprite_str_list.append(",")
+        sprite_str_list.extend(loc_str_tup)
+        sprite_str_list.append(",")
+
+        # body
+        sprite_str_list.extend(
+            _ms_body(clothing, hair, isnight, lean=lean, arms=arms)
+        )
+
+        # between body and face acs
+        sprite_str_list.extend(
+            _ms_accessorylist(acs_mid_list, isnight, True, arms, lean=lean)
+        )
+
+        # between mid acs and face
+        sprite_str_list.append(",")
+        sprite_str_list.extend(loc_str_tup)
+        sprite_str_list.append(",")
+            
+
         return "".join([
             TRAN,
             "(",
             L_COMP,
             "(",
             loc_str,
-            _ms_accessorylist(acs_pre_list, isnight, True, arms, lean=lean),
+# HERE
             ",",
             build_loc(),
             ",",

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -1315,6 +1315,8 @@ init -5 python in mas_sprites:
         RETURNS:
             stock standing string
         """
+        # TODO: update this to work with the more optimized system for
+        # building sprites
         if single:
             return "".join([
                 I_COMP,
@@ -1327,7 +1329,7 @@ init -5 python in mas_sprites:
                 single,
                 FILE_EXT,
                 '"',
-                _ms_accessorylist(acs_list, False, False),
+#                _ms_accessorylist(acs_list, False, False),
                 ")"
             ])
 
@@ -1354,7 +1356,7 @@ init -5 python in mas_sprites:
             head,
             FILE_EXT,
             '"',
-            _ms_accessorylist(acs_list, False, False),
+#            _ms_accessorylist(acs_list, False, False),
             ")"
         ])
 


### PR DESCRIPTION
Currently sprites are generated via cascading `string.join` calls. 

This changes that so sprite strings are added to one giant list that gets `string.join` once.

The results are oustanding:

| iterations | og time (s) | new time (s) |
| --- | --: | --: |
| 100 000 |  10.3312759 | 5.870868147 |
| 100 000 | 10.4930907 | 6.092461492 | 
| 100 000 | 10.7800460 |  5.875143567 |
| 100 000 | 10.4637712 |  5.823860091 |
| 100 000 | 10.4860544 | 5.946609423 |

Original AVG: 10.51108477
Original AVG per iteration: 0.0001051

New AVG: 5.9217885
New AVG per iteration: 0.0000592

I also did some minor small optimizations, like hardcoding certain non-changing strings and only doing certain repeated conditional checks once.

# Testing
1. verify that no crashing
2. also check exp previewer for any crashes
3. also check if the opendoor greeting works normally (or just make `is_sitting` False)

**NOTE** standing sprite creation functions have **not** been optimized. Probably wont do that until we decide to add standing as a normal mode.