### PR TITLE
Always Save hair and clothes

### DIFF
--- a/Monika After Story/game/splash.rpy
+++ b/Monika After Story/game/splash.rpy
@@ -330,16 +330,14 @@ label quit:
         if datetime.timedelta(0) < new_time <= mas_maxPlaytime():
             persistent.sessions['total_playtime'] = new_time
 
-
         # set the monika size
         store.mas_dockstat.setMoniSize(persistent.sessions["total_playtime"])
 
-    if persistent._mas_hair_changed:
-        $ persistent._mas_monika_hair = monika_chr.hair.name
-        $ persistent._mas_monika_clothes = monika_chr.clothes.name
+        # save current hair / clothes
+        persistent._mas_monika_hair = monika_chr.hair.name
+        persistent._mas_monika_clothes = monika_chr.clothes.name
 
-    # accessory saving
-    python:
+        # accessory saving
         persistent._mas_acs_pre_list = [
             acs.name
             for acs in monika_chr.acs[MASMonika.PRE_ACS]
@@ -356,18 +354,18 @@ label quit:
             if acs.stay_on_start
         ]
 
-    # remove special images
-    $ store.mas_island_event.removeImages()
-    $ store.mas_o31_event.removeImages()
+        # remove special images
+        store.mas_island_event.removeImages()
+        store.mas_o31_event.removeImages()
 
-    # delayed action stuff
-    $ mas_runDelayedActions(MAS_FC_END)
-    $ store.mas_delact.saveDelayedActionMap()
+        # delayed action stuff
+        mas_runDelayedActions(MAS_FC_END)
+        store.mas_delact.saveDelayedActionMap()
 
-    $ _mas_AffSave()
+        _mas_AffSave()
 
-    # delete the monika file if we aren't leaving
-    if not persistent._mas_dockstat_going_to_leave:
-        $ store.mas_utils.trydel(mas_docking_station._trackPackage("monika"))
+        # delete the monika file if we aren't leaving
+        if not persistent._mas_dockstat_going_to_leave:
+            store.mas_utils.trydel(mas_docking_station._trackPackage("monika"))
 
     return


### PR DESCRIPTION
Changes hair/clothes saving so it always happens, not just after hairdown.

# Testing
1. start with a fresh persistent
2. change monika's clothes or hair by doing `monika_chr.change_clothes(mas_clothes_rin)` or `monika_chr.change_hair(mas_hair_down)` in the console. **NOTE** if you change clothes to o31, you need to change o31 date as well.
3. restart MAS
4. verify clothes/hair were NOT reset.