### PR TITLE
Adding Hair down Programming Points and removing the lock/unlocks

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1204,46 +1204,17 @@ label ch30_reset:
 
     # reset hair / clothes
     python:
+        # first, unlock all hair / clothes events that could be reached
+        unlockEventLabel("monika_hair_ponytail")
+
+        if persistent._mas_hair_changed:
+            unlockEventLabel("monika_hair_down")
+    
         # setup hair / clothes
         monika_chr.change_outfit(
             store.mas_sprites.CLOTH_MAP[persistent._mas_monika_clothes],
             store.mas_sprites.HAIR_MAP[persistent._mas_monika_hair]
         )
-
-        if (
-                persistent._mas_hair_changed
-                and persistent._mas_likes_hairdown
-            ):
-            # hair adjustments only happen if the appropriate vent occured
-
-            # hair map
-            hair_map = {
-                "down": "monika_hair_down",
-                "def": "monika_hair_ponytail"
-                # "bun": "monika_hair_bun"
-            }
-
-
-            for hair in hair_map:
-                # this is so we kind of automate the locking / unlocking prcoess
-                if hair == monika_chr.hair.name:
-                    lockEventLabel(hair_map[hair])
-                else:
-                    unlockEventLabel(hair_map[hair])
-
-        # currenly, the clothes part has noc hecks
-        # clothes map
-        # NOTE: unused
-        clothes_map = {
-#            "def": "monika_clothes_school"
-        }
-
-
-        for clothes in clothes_map:
-            if clothes == monika_chr.clothes.name:
-                lockEventLabel(clothes_map[clothes])
-            else:
-                unlockEventLabel(clothes_map[clothes])
 
     # accessories rest
     python:

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1468,8 +1468,6 @@ label greeting_hairdown:
     menu:
         m "Do you like it?"
         "Yes":
-            # make it possible to switch hair at will
-            $ unlockEventLabel("monika_hair_ponytail")
             $ persistent._mas_likes_hairdown = True
 
             # maybe 6sub is better?
@@ -1491,7 +1489,6 @@ label greeting_hairdown:
             # you will never get this chance again
 
     # lock this greeting forever.
-    $ lockEventLabel("greeting_hairdown", evhand.greeting_database)
     $ persistent._mas_hair_changed = True # menas we have seen this
 
     # cleanup

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -7708,14 +7708,12 @@ label monika_hair_ponytail:
     show monika 1dsc
     pause 1.0
 
+    # this should auto lock/unlock stuff
     $ monika_chr.reset_hair()
 
     m 3hub "All done!"
     m 1eua "If you want me to let my hair down, just ask, okay?"
 
-    # lock this event, unlock hairdown
-    $ lockEventLabel("monika_hair_ponytail")
-    $ unlockEventLabel("monika_hair_down")
     return
 
 init 5 python:
@@ -7741,10 +7739,6 @@ label monika_hair_down:
 
     m 3hub "And it's down!"
     m 1eua "If you want my hair in a ponytail again, just ask away, [player]~"
-
-    # lock this event, unlock hairponytail
-    $ lockEventLabel("monika_hair_down")
-    $ unlockEventLabel("monika_hair_ponytail")
 
     return
 

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -1540,10 +1540,6 @@ init -2 python:
             IN:
                 new_cloth - new clothes to wear
             """
-            if self.clothes.name == new_cloth.name:
-                return
-
-            # otherwise, different, so do the regular progrmaming point rule
             self.clothes.exit(self)
             self.clothes = new_cloth
             self.clothes.entry(self)
@@ -1556,10 +1552,6 @@ init -2 python:
             IN:
                 new_hair - new hair to wear
             """
-            if self.hair.name == new_hair.name:
-                return
-
-            # otherwise, different, so do programming points
             self.hair.exit(self)
             self.hair = new_hair
             self.hair.entry(self)
@@ -2455,6 +2447,33 @@ init -2 python in mas_sprites:
     # NOTE: this will NOT be maintained on a restart
 
     ######### HAIR ###########
+    def _hair_def_entry(_moni_chr):
+        """
+        Entry programming point for ponytail
+        """
+        store.lockEventLabel("monika_hair_ponytail")
+
+
+    def _hair_def_exit(_moni_chr):
+        """
+        Exit programming point for ponytail
+        """
+        store.unlockEventLabel("monika_hair_ponytail")
+
+
+    def _hair_down_entry(_moni_chr):
+        """
+        Entry programming point for hair down
+        """
+        store.lockEventLabel("monika_hair_down")
+
+
+    def _hair_down_exit(_moni_chr):
+        """
+        Exit programming point for hair down
+        """
+        store.unlockEventLabel("monika_hair_down")
+
 
     ######### CLOTHES ###########
     def _clothes_rin_entry(_moni_chr):
@@ -2521,7 +2540,9 @@ init -1 python:
         MASPoseMap(
             default=True,
             use_reg_for_l=True
-        )
+        ),
+        entry_pp=store.mas_sprites._hair_def_entry,
+        exit_pp=store.mas_sprites._hair_def_exit
     )
     store.mas_sprites.init_hair(mas_hair_def)
 
@@ -2534,7 +2555,9 @@ init -1 python:
         MASPoseMap(
             default=True,
             use_reg_for_l=True
-        )
+        ),
+        entry_pp=store.mas_sprites._hair_down_entry,
+        exit_pp=store.mas_sprites._hair_down_exit
     )
     store.mas_sprites.init_hair(mas_hair_down)
 


### PR DESCRIPTION
Now that the #2856 is in, time to actaully use it

This adds some programming points for the ponytail and hair down hairs. 
Also removes all the unlocks/locks that we did before.

**NOTE:** to handle an issue with defaults, all hair events that could be unlocked are unlocked on start before the hair/clothes are set. The hair programming points will lock the appropraite events.

# Testing
## post hairdown greeting
1. start with a persistnt that has had hairdown greeting
2. launch MAS. 
3. Verify that when hair is down, hair down pool topic is locked, and when hair is ponytail, hair ponytail pool topic is locked.
4. Restart MAS and verify step 3 again.

## pre hairdown greeting
1. start with a persistent that has NOT had hairdown greeting
2. launch MAS
3. verify that both hair pool topics are locked.
4. Restart MAS.
5. Verify step 3 again.

## hair down greeting NO choice
1. start with a persistent that has NOT had hairdown greeting
2. trigger hairdown greeting. Select No.
3. Verify that the hair down pool topic option is unlocked.
4. Restart MAS and verify step 3 again.