### PR TITLE
Added splitting hair layers to sprite chart

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1221,6 +1221,14 @@ label ch30_reset:
             monika_chr.wear_acs_pre(
                 store.mas_sprites.ACS_MAP[acs_name]
             )
+        for acs_name in persistent._mas_acs_bbh_list:
+            monika_chr.wear_acs_bbh(
+                store.mas_sprites.ACS_MAP[acs_name]
+            )
+        for acs_name in persistent._mas_acs_bfh_list:
+            monika_chr.wear_acs_bfh(
+                store.mas_sprites.ACS_MAP[acs_name]
+            )
         for acs_name in persistent._mas_acs_mid_list:
             monika_chr.wear_acs_mid(
                 store.mas_sprites.ACS_MAP[acs_name]

--- a/Monika After Story/game/splash.rpy
+++ b/Monika After Story/game/splash.rpy
@@ -343,6 +343,16 @@ label quit:
             for acs in monika_chr.acs[MASMonika.PRE_ACS]
             if acs.stay_on_start
         ]
+        persistent._mas_acs_bbh_list = [
+            acs.name
+            for acs in monika_chr.acs[MASMonika.BBH_ACS]
+            if acs.stay_on_start
+        ]
+        persistent._mas_acs_bfh_list = [
+            acs.name
+            for acs in monika_chr.acs[MASMonika.BFH_ACS]
+            if acs.stay_on_start
+        ]
         persistent._mas_acs_mid_list = [
             acs.name
             for acs in monika_chr.acs[MASMonika.MID_ACS]

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -265,7 +265,7 @@ init -5 python in mas_sprites:
     adjust_x = default_x
     adjust_y = default_y
 #    y_step = 40
-    y_step = 10
+    y_step = 20
 
     # adding optimized initial parts of the sprite string
     PRE_SPRITE_STR = TRAN + "(" + L_COMP + "("
@@ -550,7 +550,6 @@ init -5 python in mas_sprites:
 
     def _ms_accessory(
             sprite_list,
-            pos_str,
             acs,
             n_suffix,
             issitting,
@@ -562,7 +561,6 @@ init -5 python in mas_sprites:
 
         IN:
             sprite_list - list to add sprites to
-            pos_str - position string to use
             acs - MASAccessory object
             n_suffix - night suffix to use
             issitting - True will use sitting pic, false will not
@@ -604,7 +602,7 @@ init -5 python in mas_sprites:
             return
 
         sprite_list.extend((
-            pos_str,
+            LOC_Z,
             ',"',
             A_T_MAIN
         ))
@@ -691,19 +689,18 @@ init -5 python in mas_sprites:
         sprite_list.append(")")
 
 
-    def _ms_arms(sprite_list, pos_str, clothing, arms, n_suffix):
+    def _ms_arms(sprite_list, clothing, arms, n_suffix):
         """
         Adds arms string
 
         IN:
             sprite_list - list to add sprite strings to
-            pos_str - position string to use
             clothing - type of clothing
             arms - type of arms
             n_suffix - night suffix to use
         """
         sprite_list.extend((
-            pos_str, 
+            LOC_Z,
             ',"',
             C_MAIN,
             clothing,
@@ -716,19 +713,18 @@ init -5 python in mas_sprites:
         ))
 
 
-    def _ms_blush(sprite_list, pos_str, blush, n_suffix, f_prefix):
+    def _ms_blush(sprite_list, blush, n_suffix, f_prefix):
         """
         Adds blush string
 
         IN:
             sprite_list - list to add sprite strings to
-            pos_str - position string to use
             blush - type of blush
             n_suffix - night suffix to use
             f_prefix - face prefix to use
         """
         sprite_list.extend((
-            pos_str,
+            LOC_Z,
             ',"',
             F_T_MAIN,
             f_prefix,
@@ -742,7 +738,6 @@ init -5 python in mas_sprites:
 
     def _ms_body(
             sprite_list,
-            pos_str,
             clothing,
             hair,
             n_suffix,
@@ -754,7 +749,6 @@ init -5 python in mas_sprites:
 
         IN:
             sprite_list - list to add sprite strings to
-            pos_str - position string to use
             clothing - type of clothing
             hair - type of hair
             n_suffix - night suffix to use
@@ -776,7 +770,6 @@ init -5 python in mas_sprites:
             ))
             _ms_torsoleaning(
                 sprite_list,
-                pos_str,
                 clothing,
                 hair,
                 lean,
@@ -789,27 +782,26 @@ init -5 python in mas_sprites:
                 LOC_REG,
                 ","
             ))
-            _ms_torso(sprite_list, pos_str, clothing, hair, n_suffix),
+            _ms_torso(sprite_list, clothing, hair, n_suffix),
             sprite_list.append(",")
-            _ms_arms(sprite_list, pos_str, clothing, arms, n_suffix)
+            _ms_arms(sprite_list, clothing, arms, n_suffix)
 
         # add the rest of the parts
         sprite_list.append(")")
 
 
-    def _ms_emote(sprite_list, pos_str, emote, n_suffix, f_prefix):
+    def _ms_emote(sprite_list, emote, n_suffix, f_prefix):
         """
         Adds emote string
 
         IN:
             sprite_list - list to add sprite strings to
-            pos_str - position string to use
             emote - type of emote
             n_suffix - night suffix to use
             f_prefix - face prefix to use
         """
         sprite_list.extend((
-            pos_str,
+            LOC_Z,
             ',"',
             F_T_MAIN,
             f_prefix,
@@ -821,19 +813,18 @@ init -5 python in mas_sprites:
         ))
 
 
-    def _ms_eyebags(sprite_list, pos_str, eyebags, n_suffix, f_prefix):
+    def _ms_eyebags(sprite_list, eyebags, n_suffix, f_prefix):
         """
         Adds eyebags string
 
         IN:
             sprite_list - list to add sprite strings to
-            pos_str - position string to use
             eyebags - type of eyebags
             n_suffix - night suffix to use
             f_prefix - face prefix to use
         """
         sprite_list.extend((
-            pos_str,
+            LOC_Z,
             ',"',
             F_T_MAIN,
             f_prefix,
@@ -845,19 +836,18 @@ init -5 python in mas_sprites:
         ))
 
 
-    def _ms_eyebrows(sprite_list, pos_str, eyebrows, n_suffix, f_prefix):
+    def _ms_eyebrows(sprite_list, eyebrows, n_suffix, f_prefix):
         """
         Adds eyebrow strings
 
         IN:
             sprite_list - list to add sprite strings to
-            pos_str - position string to use
             eyebrows - type of eyebrows
             n_suffix - night suffix to use
             f_prefix - face prefix to use
         """
         sprite_list.extend((
-            pos_str,
+            LOC_Z,
             ',"',
             F_T_MAIN,
             f_prefix,
@@ -869,19 +859,18 @@ init -5 python in mas_sprites:
         ))
 
 
-    def _ms_eyes(sprite_list, pos_str, eyes, n_suffix, f_prefix):
+    def _ms_eyes(sprite_list, eyes, n_suffix, f_prefix):
         """
         Adds eye string
 
         IN:
             sprite_list - list to add sprite strings to
-            pos_str - position string to use
             eyes - type of eyes
             n_suffix - night suffix to use
             f_prefix - face prefix to use
         """
         sprite_list.extend((
-            pos_str,
+            LOC_Z,
             ',"',
             F_T_MAIN,
             f_prefix,
@@ -895,7 +884,6 @@ init -5 python in mas_sprites:
 
     def _ms_face(
             sprite_list,
-            pos_str,
             eyebrows,
             eyes,
             nose,
@@ -914,7 +902,6 @@ init -5 python in mas_sprites:
 
         IN:
             sprite_list - list to add sprite strings to
-            pos_str - position string to use
             eyebrows - type of eyebrows
             eyes - type of eyes
             nose - type of nose
@@ -950,34 +937,34 @@ init -5 python in mas_sprites:
 
         # now for the required parts
         sprite_list.append(",")
-        _ms_eyes(sprite_list, pos_str, eyes, n_suffix, f_prefix)
+        _ms_eyes(sprite_list, eyes, n_suffix, f_prefix)
         sprite_list.append(",")
-        _ms_eyebrows(sprite_list, pos_str, eyebrows, n_suffix, f_prefix)
+        _ms_eyebrows(sprite_list, eyebrows, n_suffix, f_prefix)
         sprite_list.append(",")
-        _ms_nose(sprite_list, pos_str, nose, n_suffix, f_prefix)
+        _ms_nose(sprite_list, nose, n_suffix, f_prefix)
         sprite_list.append(",")
-        _ms_mouth(sprite_list, pos_str, mouth, n_suffix, f_prefix)
+        _ms_mouth(sprite_list, mouth, n_suffix, f_prefix)
 
         # and optional parts
         if eyebags:
             sprite_list.append(",")
-            _ms_eyebags(sprite_list, pos_str, eyebags, n_suffix, f_prefix)
+            _ms_eyebags(sprite_list, eyebags, n_suffix, f_prefix)
 
         if sweat:
             sprite_list.append(",")
-            _ms_sweat(sprite_list, pos_str, sweat, n_suffix, f_prefix)
+            _ms_sweat(sprite_list, sweat, n_suffix, f_prefix)
 
         if blush:
             sprite_list.append(",")
-            _ms_blush(sprite_list, pos_str, blush, n_suffix, f_prefix)
+            _ms_blush(sprite_list, blush, n_suffix, f_prefix)
 
         if tears:
             sprite_list.append(",")
-            _ms_tears(sprite_list, pos_str, tears, n_suffix, f_prefix)
+            _ms_tears(sprite_list, tears, n_suffix, f_prefix)
 
         if emote:
             sprite_list.append(",")
-            _ms_emote(sprite_list, pos_str, emote, n_suffix, f_prefix)
+            _ms_emote(sprite_list, emote, n_suffix, f_prefix)
 
         # finally the last paren
         sprite_list.append(")")
@@ -1037,19 +1024,18 @@ init -5 python in mas_sprites:
         ])
 
 
-    def _ms_mouth(sprite_list, pos_str, mouth, n_suffix, f_prefix):
+    def _ms_mouth(sprite_list, mouth, n_suffix, f_prefix):
         """
         Adds mouth string
 
         IN:
             sprite_list - list to add sprite strings to
-            pos_str - position string to use
             mouth - type of mouse
             n_suffix - night suffix to use
             f_prefix - face prefix to use
         """
         sprite_list.extend((
-            pos_str, 
+            LOC_Z,
             ',"',
             F_T_MAIN,
             f_prefix,
@@ -1061,13 +1047,12 @@ init -5 python in mas_sprites:
         ))
 
 
-    def _ms_nose(sprite_list, pos_str, nose, n_suffix, f_prefix):
+    def _ms_nose(sprite_list, nose, n_suffix, f_prefix):
         """
         Adds nose string
 
         IN:
             sprite_list - list to add sprite strings to
-            pos_str - position string to use
             nose - type of nose
             n_suffix - night suffix to use
             f_prefix - face prefix to use
@@ -1075,7 +1060,7 @@ init -5 python in mas_sprites:
         # NOTE: if we never get a new nose, we can just optimize this to 
         #   a hardcoded string
         sprite_list.extend((
-            pos_str,
+            LOC_Z,
             ',"',
             F_T_MAIN,
             f_prefix,
@@ -1217,7 +1202,6 @@ init -5 python in mas_sprites:
         # body
         _ms_body(
             sprite_str_list,
-            loc_build_str,
             clothing,
             hair,
             n_suffix,
@@ -1242,7 +1226,6 @@ init -5 python in mas_sprites:
         # face
         _ms_face(
             sprite_str_list,
-            loc_build_str,
             eyebrows,
             eyes,
             nose,
@@ -1378,19 +1361,18 @@ init -5 python in mas_sprites:
         ])
 
 
-    def _ms_sweat(sprite_list, pos_str, sweat, n_suffix, f_prefix):
+    def _ms_sweat(sprite_list, sweat, n_suffix, f_prefix):
         """
         Adds sweatdrop string
 
         IN:
             sprite_list - list to add sprite strings to
-            pos_str - position string to use
             sweat -  type of sweatdrop
             n_suffix - night suffix to use
             f_prefix - face prefix to use
         """
         sprite_list.extend((
-            pos_str,
+            LOC_Z,
             ',"',
             F_T_MAIN,
             f_prefix,
@@ -1402,19 +1384,18 @@ init -5 python in mas_sprites:
         ))
 
 
-    def _ms_tears(sprite_list, pos_str, tears, n_suffix, f_prefix):
+    def _ms_tears(sprite_list, tears, n_suffix, f_prefix):
         """
         Adds tear string
 
         IN:
             sprite_list - list to add sprite strings to
-            pos_str - position string to use
             tears - type of tears
             n_suffix - night suffix to use
             f_prefix - face prefix to use
         """
         sprite_list.extend((
-            pos_str,
+            LOC_Z,
             ',"',
             F_T_MAIN,
             f_prefix,
@@ -1426,19 +1407,18 @@ init -5 python in mas_sprites:
         ))
 
 
-    def _ms_torso(sprite_list, pos_str, clothing, hair, n_suffix):
+    def _ms_torso(sprite_list, clothing, hair, n_suffix):
         """
         Adds torso string
 
         IN:
             sprite_list - list to add sprite strings to
-            pos_str - position string to use
             clothing - type of clothing
             hair - type of hair
             n_suffix - night suffix to use
         """
         sprite_list.extend((
-            pos_str,
+            LOC_Z,
             ',"',
             C_MAIN,
             clothing,
@@ -1451,20 +1431,19 @@ init -5 python in mas_sprites:
         ))
 
 
-    def _ms_torsoleaning(sprite_list, pos_str, clothing, hair, lean, n_suffix):
+    def _ms_torsoleaning(sprite_list, clothing, hair, lean, n_suffix):
         """
         Adds torso leaning string
 
         IN:
             sprite_list - list to add sprite strings to
-            pos_str - position string to use
             clothing - type of clothing
             hair - type of ahri
             lean - type of leaning
             n_suffix - night suffix to use
         """
         sprite_list.extend((
-            pos_str,
+            LOC_Z,
             ',"',
             C_MAIN,
             clothing,

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -1183,6 +1183,19 @@ init -5 python in mas_sprites:
             loc_str
         ]
 
+        ## NOTE: render order:
+        #   1. pre-acs - every acs that should render before the body
+        #   2. back-hair - back portion of hair
+        #   3. post-back-hair-acs - acs that should render after back hair, but
+        #       before body
+        #   4. body - the actual body
+        #   5. pre-front-hair-acs - acs that should render after body, but
+        #       before front hair
+        #   6. front-hair - front portion of hair
+        #   7. mid - acs that render between body and face
+        #   8. face - face expressions
+        #   9. post-acs - acs that should render after basically everything
+
         # pre accessories
         _ms_accessorylist(
             sprite_str_list,
@@ -1478,16 +1491,27 @@ init -2 python:
         import store.mas_sprites as mas_sprites
 
         # CONSTANTS
-        PRE_ACS = 0 # PRE ACCESSORY
-        MID_ACS = 1 # MID ACCESSORY
-        PST_ACS = 2 # post accessory
+        PRE_ACS = 0 # PRE ACCESSORY (before body)
+        MID_ACS = 1 # MID ACCESSORY (right before face)
+        PST_ACS = 2 # post accessory (after face)
+        BBH_ACS = 3 # betweeen Body and Back Hair accessory
+        BFH_ACS = 4 # between Body and Front Hair accessory
 
-        def __init__(self, pre_acs=[], mid_acs=[], pst_acs=[]):
+
+        def __init__(self, 
+                pre_acs=[], 
+                mid_acs=[], 
+                pst_acs=[], 
+                bbh_acs=[],
+                bfh_acs=[]
+            ):
             """
             IN:
                 pre_acs - list of pre accessories to load with
                 mid_acs - list of mid accessories to load with
                 pst_acs - list of pst accessories to load with
+                bbh_acs - list of bbh accessories to load with
+                bfh_acs - list of bfh accessories to load with
             """
             self.name="Monika"
             self.haircut="default"
@@ -1501,8 +1525,14 @@ init -2 python:
             # list of lean blacklisted accessory names currently equipped
             self.lean_acs_blacklist = []
 
-            # accesories to be rendereed before the body
+            # accesories to be rendereed before anything
             self.acs_pre = []
+
+            # accessories to be rendered after back hair, before body
+            self.acs_bbh = []
+
+            # accessories to be rendered after body, before front hair
+            self.acs_bfh = []
 
             # accessories to be rendreed between body and face expressions
             self.acs_mid = []
@@ -1516,8 +1546,14 @@ init -2 python:
             self.acs = {
                 self.PRE_ACS: self.acs_pre,
                 self.MID_ACS: self.acs_mid,
-                self.PST_ACS: self.acs_post
+                self.PST_ACS: self.acs_post,
+                self.BBH_ACS: self.acs_bbh,
+                self.BFH_ACS: self.acs_bfh
             }
+
+            # use this dict to map acs IDs with which acs list they are in.
+            # this will increase speed of removal and checking.
+            self.acs_list_map = {}
 
 
         def __get_acs(self, acs_type):
@@ -1591,6 +1627,7 @@ init -2 python:
             RETURNS:
                 True if wearing accessory, false if not
             """
+            # TODO
             return (
                 self.is_wearing_acs_in(accessory, self.PST_ACS)
                 or self.is_wearing_acs_in(accessory, self.MID_ACS)
@@ -1634,6 +1671,7 @@ init -2 python:
             IN:
                 accessory - accessory to remove
             """
+            # TODO
             self.remove_acs_in(accessory, self.PRE_ACS)
             self.remove_acs_in(accessory, self.MID_ACS)
             self.remove_acs_in(accessory, self.PST_ACS)
@@ -1647,6 +1685,7 @@ init -2 python:
                 accessory - accessory to remove
                 acs_type - ACS type
             """
+            #TODO
             acs_list = self.__get_acs(acs_type)
 
             if acs_list is not None and accessory in acs_list:
@@ -1662,6 +1701,8 @@ init -2 python:
             Removes all accessories from all accessory lists
             """
             self.remove_all_acs_in(self.PRE_ACS)
+            self.remove_all_acs_in(self.BBH_ACS)
+            self.remove_all_acs_in(self.BFH_ACS)
             self.remove_all_acs_in(self.MID_ACS)
             self.remove_all_acs_in(self.PST_ACS)
 

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -103,6 +103,8 @@ define is_sitting = True
 
 # accessories list
 default persistent._mas_acs_pre_list = list()
+default persistent._mas_acs_bbh_list = list()
+default persistent._mas_acs_bfh_list = list()
 default persistent._mas_acs_mid_list = list()
 default persistent._mas_acs_pst_list = list()
 
@@ -1121,6 +1123,8 @@ init -5 python in mas_sprites:
             mouth,
             isnight,
             acs_pre_list,
+            acs_bbh_list,
+            acs_bfh_list,
             acs_mid_list,
             acs_pst_list,
             lean=None,
@@ -1538,7 +1542,7 @@ init -2 python:
             self.acs_mid = []
 
             # accessories to be rendered last
-            self.acs_post = []
+            self.acs_pst = []
 
             self.hair_hue=0 # hair color?
 
@@ -1546,7 +1550,7 @@ init -2 python:
             self.acs = {
                 self.PRE_ACS: self.acs_pre,
                 self.MID_ACS: self.acs_mid,
-                self.PST_ACS: self.acs_post,
+                self.PST_ACS: self.acs_pst,
                 self.BBH_ACS: self.acs_bbh,
                 self.BFH_ACS: self.acs_bfh
             }
@@ -2453,6 +2457,8 @@ init -2 python:
 
         # gather accessories
         acs_pre_list = character.acs.get(MASMonika.PRE_ACS, [])
+        acs_bbh_list = character.acs.get(MASMonika.BBH_ACS, [])
+        acs_bfh_list = character.acs.get(MASMonika.BFH_ACS, [])
         acs_mid_list = character.acs.get(MASMonika.MID_ACS, [])
         acs_pst_list = character.acs.get(MASMonika.PST_ACS, [])
 
@@ -2482,6 +2488,8 @@ init -2 python:
                 mouth,
                 not morning_flag,
                 acs_pre_list,
+                acs_bbh_list,
+                acs_bfh_list,
                 acs_mid_list,
                 acs_pst_list,
                 lean=lean,


### PR DESCRIPTION
This makes it possible to have hair versions that are independent of clothes by allowing for hair objects that can be split between back and front layers. All existing hair styles can still be used by setting the `MASHair` property `split` to False for those hair objects. 

Also added additional accessory layer spots, and a little bit of optimization when removing accessories.

The new render order:
1. pre-acs - all accessories that should be rendered before everything else.
2. back-hair - the back portion of a hair object (only if split is True)
3. pre-body-acs - accessories between the back hair and before the body (only if split is True)
4. body - the body (not including arms if not leaning) (only if split is True)
5. pre-front-hair-acs - accessories between the body and the front portion of a hair object (only if split is True)
6. front-hair - the front portion of a hair object (only if split is True)
7. arms - the arms (only if not leaning) (only if split is True) 
8. mid-acs - accessories that should be rendered between the body and face
9. face - face expressions
10. pst-acs - accessories that should be rendered after everything else.

Also did another small optimization with loc_strings, so we dont need to pass position strings to all sub composites.


# new file requirements:

## hair
All generic hair sprites (ones that can be used for any clothing), should be placed in `mod_assets/monika/h/`. The naming scheme is:
```python
hair-{hair name}-{front/back}{-n}.png
```
Use `front` or `back` to denote a front layer or a back layer.

## body/clothes
Body types (or clothes) that are no longer attached to hair should follow this naming scheme:
These should still be placed in the `c/<clothes>` folder.
```python
# non-leaning
body-def{-n}.png
# leaning
body-leaning-{lean type}{-n}.png
```

Use the original naming scheme (with `torso`) if the body sprites have hairstyles baked into them.

# custom hair
I have added a new hair object called `mas_hair_custom`. this is a special hair object that simply has the `split` property set to True. This allows for costumes with baked hairstyles (like marisa and rin) to work even after all existing hairstyles get split. Clothes that have baked hairstyles shoudl set their hair maps to use `custom` for all hair styles.

# Testing
## regression
1. verify that sprites look still look okay.
2. open exp previewer and verify that the poses all look okay.
3. verify that the o31 costumes still look okay.
4. verify zooming still looks okay (even with accessories)

## hair layer test
Setup:
* For this, I recommend grabbing the ponytail layer that @kaido1224 posted on discord.
1. Make a folder in `mod_assets/monika` called `h`.
2. Copy over `torso-bun` from `mod_assets/monika/c/def/` into `mod_assets/monika/h`.
3. Copy the ponytail layer into `mod_assets/monika/h` as well.
4. In the `h` folder, do the following:
    1. Rename `torso-bun` (and its night version) into `hair-bun-front`
    2. Rename `ponytail` into `hair-bun-back`
5. In `mod_assets/monika/c/def/`, do the following:
    1. Make a copy of `torso-bun` and call it `body-def`. (also make a night version)
6. open `sprite-chart` and set the `split` property of `mas_hair_bun` to True.

Test:
1. launch game.
2. Open console and do `monika_chr.change_hair(mas_hair_bun)`. 
3. verify no crash.
4. Monika should have the ponytail, but also the hair coming down the right side of her face, which is part of the bun hairstyle.
5. Also verify that the arms are rendered over the front hair (aka you can see them move and shit).
6. Exp previewer should probably still work maybe.
