### PR TITLE
Disabling quick menu and auto forward while using the selector

### DIFF
--- a/Monika After Story/game/zz_selector.rpy
+++ b/Monika After Story/game/zz_selector.rpy
@@ -30,14 +30,14 @@ init -20 python:
                 (png is added in the constructor)
             group - string id to group related selectable sprites. this really
                 applies only to acs, but in case other things need this.
-            unlocked - True if this selectable sprite can be selected, 
+            unlocked - True if this selectable sprite can be selected,
                 False otherwise.
             visible_when_locked - True if this should be visible when locked
                 False, otherwise.
                 Locked items will generally be displayed with a placeholder
                 thumb.
             hover_dlg - list of text to display when hovering over the object
-            first_select_dlg - text to display the first time you 
+            first_select_dlg - text to display the first time you
                 select this sprite
             select_dlg - list text to display everytime you select this sprite
                 (after the first time)
@@ -45,10 +45,10 @@ init -20 python:
         """
 
 
-        def __init__(self, 
+        def __init__(self,
                 _sprite_object,
                 display_name,
-                thumb, 
+                thumb,
                 group,
                 visible_when_locked=True,
                 hover_dlg=None,
@@ -69,7 +69,7 @@ init -20 python:
                 visible_when_locked - True if this item should be visible in
                     the screen when locked, False otherwise
                     (Default: True)
-                hover_dlg - list of text to display when hovering over the 
+                hover_dlg - list of text to display when hovering over the
                     object
                     (Default: None)
                 first_select_dlg - text to display the first time you select
@@ -77,7 +77,7 @@ init -20 python:
                     (Default: None)
                 select_dlg - list of text to display everytime you select this
                     sprite
-                    (after the first time)            
+                    (after the first time)
                     (Default: None)
             """
 #            self._check_dlg(hover_dlg)
@@ -154,7 +154,7 @@ init -20 python:
                 visible_when_locked - True if this item should be visible in
                     the screen when locked, False otherwise
                     (Default: True)
-                hover_dlg - list of text to display when hovering over the 
+                hover_dlg - list of text to display when hovering over the
                     object
                     (Default: None)
                 first_select_dlg - text to display the first time you select
@@ -162,8 +162,8 @@ init -20 python:
                     (Default: None)
                 select_dlg - list of text to display everytime you select this
                     sprite
-                    (after the first time)            
-                    (Default: None)            
+                    (after the first time)
+                    (Default: None)
             """
             if type(_sprite_object) != MASAccessory:
                 raise Exception("not an acs: {0}".format(group))
@@ -223,7 +223,7 @@ init -20 python:
                 visible_when_locked - True if this item should be visible in
                     the screen when locked, False otherwise
                     (Default: True)
-                hover_dlg - list of text to display when hovering over the 
+                hover_dlg - list of text to display when hovering over the
                     object
                     (Default: None)
                 first_select_dlg - text to display the first time you select
@@ -231,8 +231,8 @@ init -20 python:
                     (Default: None)
                 select_dlg - list of text to display everytime you select this
                     sprite
-                    (after the first time)            
-                    (Default: None)            
+                    (after the first time)
+                    (Default: None)
             """
             if type(_sprite_object) != MASHair:
                 raise Exception("not a hair: {0}".format(group))
@@ -292,7 +292,7 @@ init -20 python:
                 visible_when_locked - True if this item should be visible in
                     the screen when locked, False otherwise
                     (Default: True)
-                hover_dlg - list of text to display when hovering over the 
+                hover_dlg - list of text to display when hovering over the
                     object
                     (Default: None)
                 first_select_dlg - text to display the first time you select
@@ -300,8 +300,8 @@ init -20 python:
                     (Default: None)
                 select_dlg - list of text to display everytime you select this
                     sprite
-                    (after the first time)            
-                    (Default: None)            
+                    (after the first time)
+                    (Default: None)
             """
             if type(_sprite_object) != MASClothes:
                 raise Exception("not a clothes: {0}".format(group))
@@ -339,7 +339,7 @@ init -10 python in mas_selspr:
 
     ## screen constants
     SB_VIEWPORT_BOUNDS = (1075, 5, 200, 625, 5)
-    # keep this in sync with teh screen area 
+    # keep this in sync with teh screen area
 
     ## string constants
     DEF_DISP = "..."
@@ -397,10 +397,10 @@ init -10 python in mas_selspr:
                 (Default: True)
             hover_dlg - list of dialogue to say when the item is hovered over
                 (Default: None)
-            first_select_dlg - list of dialogue to say when the item is 
+            first_select_dlg - list of dialogue to say when the item is
                 selected for the first time
                 (Default: None)
-            select_dlg - list of dialogue to say when the item is selected 
+            select_dlg - list of dialogue to say when the item is selected
                 after the first time
                 (Default: None)
         """
@@ -444,12 +444,12 @@ init -10 python in mas_selspr:
                 (Default: True)
             hover_dlg - list of dialogue to say when the item is hovered over
                 (Default: None)
-            first_select_dlg - list of dialogue to say when the item is 
+            first_select_dlg - list of dialogue to say when the item is
                 selected for the first time
                 (Default: None)
-            select_dlg - list of dialogue to say when the item is selected 
+            select_dlg - list of dialogue to say when the item is selected
                 after the first time
-                (Default: None)        
+                (Default: None)
         """
         # no duplicates
         if clothes.name in CLOTH_SEL_MAP:
@@ -493,12 +493,12 @@ init -10 python in mas_selspr:
                 (Default: True)
             hover_dlg - list of dialogue to say when the item is hovered over
                 (Default: None)
-            first_select_dlg - list of dialogue to say when the item is 
+            first_select_dlg - list of dialogue to say when the item is
                 selected for the first time
                 (Default: None)
-            select_dlg - list of dialogue to say when the item is selected 
+            select_dlg - list of dialogue to say when the item is selected
                 after the first time
-                (Default: None)        
+                (Default: None)
         """
         # no duplicates
         if hair.name in HAIR_SEL_MAP:
@@ -530,7 +530,7 @@ init -10 python in mas_selspr:
         """
         Adjusts an aspect of monika based on the select type
 
-        NOTE: this also logs exceptions if they occur. Also will undo 
+        NOTE: this also logs exceptions if they occur. Also will undo
             a chnage that causes crash.
 
         IN:
@@ -558,7 +558,7 @@ init -10 python in mas_selspr:
                 remove_keys = old_map_view - new_map_view
                 remove_map = old_map
                 add_map = new_map
-        
+
             # remove what is excess
             for item_name in remove_keys:
                 moni_chr.remove_acs(
@@ -575,7 +575,7 @@ init -10 python in mas_selspr:
             # determine which map to change to
             if use_old:
                 select_map = old_map
-            
+
             else:
                 select_map = new_map
 
@@ -717,14 +717,14 @@ init -10 python in mas_selspr:
         # otherwise, now we get intersection and verify length
         return old_len == len(old_map_view & new_map_view)
 
-    
+
     def _save_selectable(source, dest):
         """
         Saves selectable data from the given source into the destination.
 
         IN:
             source - source data to read
-            dest - data place to save 
+            dest - data place to save
         """
         for item_name, item in source.iteritems():
             dest[item_name] = item.toTuple()
@@ -733,7 +733,7 @@ init -10 python in mas_selspr:
     def save_selectables():
         """
         Goes through the selectables and saves their unlocked property.
-        
+
         NOTE: we do this by adding the name into the appropriate persistent.
         also the data we want to save
         """
@@ -931,7 +931,7 @@ init -10 python in mas_selspr:
             super(MASSelectableSpriteMailbox, self).__init__()
             self.send_def_disp_text(def_disp_text)
             self.send_conf_enable(False)
-        
+
 
         def _get(self, headline):
             """
@@ -965,7 +965,7 @@ init -10 python in mas_selspr:
             Returns the value of the conf enable message
 
             RETURNS:
-                True if the confirmation button should be enabled, False 
+                True if the confirmation button should be enabled, False
                 otherwise
             """
             return self._read(MB_CONF)
@@ -989,14 +989,14 @@ init -10 python in mas_selspr:
             RETURNS: display text
             """
             return self._get(MB_DISP)
-            
+
 
         def send_conf_enable(self, enable):
             """
             Sends enable message
 
             IN:
-                enable - True means to enable, False means to disable 
+                enable - True means to enable, False means to disable
             """
             self._send(MB_CONF, enable)
 
@@ -1023,7 +1023,7 @@ init -10 python in mas_selspr:
 
 init -1 python:
     import random
-    
+
     ## custom displayable
     class MASSelectableImageButtonDisplayable(renpy.Displayable):
         """
@@ -1037,10 +1037,10 @@ init -1 python:
 
         WIDTH = 180 # default width
         TX_WIDTH = 170 # width of the text object
-        
+
         # technically this should change.
-        TOTAL_HEIGHT = 218 
-        SELECTOR_HEIGHT = 180 
+        TOTAL_HEIGHT = 218
+        SELECTOR_HEIGHT = 180
 
         # this is the default, but the real may change using the expanding
         # frame properties.
@@ -1057,8 +1057,8 @@ init -1 python:
         )
         MOUSE_WHEEL = (4, 5)
 
-        
-        def __init__(self, 
+
+        def __init__(self,
                 _selectable,
                 select_map,
                 viewport_bounds,
@@ -1143,7 +1143,7 @@ init -1 python:
 
             # these get changed
             self.hover_width = self.WIDTH
-            self.hover_height = self.TOTAL_HEIGHT 
+            self.hover_height = self.TOTAL_HEIGHT
 
             self.selected = False
             self.select_jump = False
@@ -1193,10 +1193,10 @@ init -1 python:
             line_index = 1
             for line in _disp_name:
                 r.blit(
-                    line, 
+                    line,
                     (
                         5,
-                        (line_index * self.TOP_FRAME_CHUNK) 
+                        (line_index * self.TOP_FRAME_CHUNK)
                         - line.get_size()[1]
                     )
                 )
@@ -1290,7 +1290,7 @@ init -1 python:
                 self.hover_jumped = False
 
             elif not self.hover_jumped:
-                # first time hovering 
+                # first time hovering
                 self.hover_jumped = True
 
                 # play hover sound
@@ -1381,11 +1381,11 @@ init -1 python:
 
         def _render_bottom_frame(self, hover, st, at):
             """
-            Renders the bottom frames, returns a list of the renders in order 
+            Renders the bottom frames, returns a list of the renders in order
             of bliting.
 
             IN:
-                hover - True means we are hovering (or are selected), false 
+                hover - True means we are hovering (or are selected), false
                     otherwise
 
             RETURNS:
@@ -1487,7 +1487,7 @@ init -1 python:
             if self.selected:
                 # TODO: this actually can break things if we dselect
                 #   probably should handle this a smarter way like if
-                #   something was selected originally, dont make it possible 
+                #   something was selected originally, dont make it possible
                 #   to deselect.
                 #   or make it select what was originally selected.
                 # deselect self
@@ -1585,9 +1585,9 @@ init -1 python:
 
         def _setup_display_name(self, st, at):
             """
-            Sets up item_name and item_name_hover with list of renders, ready 
+            Sets up item_name and item_name_hover with list of renders, ready
             for bliting.
-            
+
             IN:
                 st - st for renpy render
                 at - at for renpy render
@@ -1629,7 +1629,7 @@ init -1 python:
             self.top_frame_height = (
                 (self.TOP_FRAME_CHUNK * len(self.item_name_hover))
             )
-            
+
 
         def _split_render(self, disp_name, st, at):
             """
@@ -1738,21 +1738,21 @@ init -1 python:
                 MOUSEDOWN + mouse is over us
             """
             if ev.type in self.MOUSE_EVENTS:
-                
+
                 if ev.type == pygame.MOUSEMOTION:
                     if not self.locked:
                         self.hovered = self._is_over_me(x, y)
                         renpy.redraw(self, 0)
 
                 elif ev.type == pygame.MOUSEBUTTONDOWN:
-                    
+
                     if ev.button in self.MOUSE_WHEEL:
-                        # TODO: scrolling in mouse wheel is not perfect, 
+                        # TODO: scrolling in mouse wheel is not perfect,
                         #   the previously hovered item gest hovered instead
                         #   of what we actually want.
                         if not self.locked:
                             self.hovered = self._is_over_me(x, y)
-                            renpy.redraw(self, 0)           
+                            renpy.redraw(self, 0)
 
                     elif ev.button == 1:
                         # left click
@@ -2023,6 +2023,15 @@ label mas_selector_sidebar_select(items, select_type, preview_selections=True, o
         old_view = old_select_map.viewkeys()
         new_view = select_map.viewkeys()
 
+        # disable menu interactions to prevent bugs
+        disable_esc()
+
+        # store current auto forward mode state
+        afm_state = _preferences.afm_enable
+
+        # and disable it
+        _preferences.afm_enable = False
+
     show screen mas_selector_sidebar(disp_items, mailbox, "mas_selector_sidebar_select_confirm", "mas_selector_sidebar_select_cancel")
 
 label mas_selector_sidebar_select_loop:
@@ -2061,6 +2070,10 @@ label mas_selector_sidebar_select_loop:
 label mas_selector_sidebar_select_confirm:
     hide screen mas_selector_sidebar
 
+    # re-enable the menu and restore afm
+    $ _preferences.afm_enable = afm_state
+    $ enable_esc()
+
     python:
         if not save_on_confirm:
             store.mas_selspr._clean_select_map(
@@ -2086,6 +2099,10 @@ label mas_selector_sidebar_select_confirm:
 label mas_selector_sidebar_select_cancel:
     hide screen mas_selector_sidebar
 
+    # re-enable the menu and restore afm
+    $ _preferences.afm_enable = afm_state
+    $ enable_esc()
+
     python:
         store.mas_selspr._clean_select_map(
             select_map,
@@ -2103,7 +2120,7 @@ label mas_selector_sidebar_select_cancel:
         )
 
     return False
-   
+
 # ACS sidebar selector label
 #
 # SEE mas_selector_sidebar_select for info on input params.
@@ -2124,7 +2141,7 @@ label mas_selector_sidebar_select_acs(items, preview_selections=True, only_unloc
 #
 # RETURNS: True if we are confirming the changes, False if not
 label mas_selector_sidebar_select_hair(items, preview_selections=True, only_unlocked=True, save_on_confirm=True, mailbox=None, select_map={}):
-    
+
     call mas_selector_sidebar_select(items, store.mas_selspr.SELECT_HAIR, preview_selections, only_unlocked, save_on_confirm, mailbox, select_map)
 
     return _return
@@ -2136,7 +2153,7 @@ label mas_selector_sidebar_select_hair(items, preview_selections=True, only_unlo
 #
 # RETURNS: True if we are confirming the changes, False if not
 label mas_selector_sidebar_select_clothes(items, preview_selections=True, only_unlocked=True, save_on_confirm=True, mailbox=None, select_map={}):
-    
+
     call mas_selector_sidebar_select(items, store.mas_selspr.SELECT_CLOTH, preview_selections, only_unlocked, save_on_confirm, mailbox, select_map)
 
     return _return


### PR DESCRIPTION
https://github.com/Monika-After-Story/MonikaModDev/issues/3085

With this one that bug should no longer appear, since we disable auto forward and the menu options while showing the selector screen.

## Testing 
Make sure the bug mentioned in the linked issue can no longer be reproduced.

