### PR TITLE
Fixes a date display function and more

### DIFF
--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -1634,6 +1634,13 @@ label mas_bday_player_bday_select_select:
     call mas_start_calendar_select_date
 
     $ selected_date_t = _return
+
+    if not selected_date_t:
+        m 2efc "[player]!"
+        m "You have to select a date!"
+        m 1hua "Try again!"
+        jump mas_bday_player_bday_select_select
+
     $ selected_date = selected_date_t.date()
     $ _today = datetime.date.today()
 

--- a/Monika After Story/game/zz_calendar.rpy
+++ b/Monika After Story/game/zz_calendar.rpy
@@ -991,7 +991,13 @@ init -1 python in mas_calendar:
         RETURNS:
             nice display string for the day
         """
-        return str(day) + NUM_MAP.get(day, "th")
+        if day in NUM_MAP:
+            suffix = NUM_MAP[day]
+
+        else:
+            suffix = NUM_MAP.get(day % 10, "th")
+
+        return str(day) + suffix
 
 
     def _formatYears(years):
@@ -1021,7 +1027,19 @@ init -1 python in mas_calendar:
 
     def genFriendlyDispDate(_datetime):
         """
+        NOTE: DEPRECATED
+
         Generates a display date using the given datetime
+
+        IN:
+            _datetime - datetime object to create good display date
+        """
+        return genFriendlyDispDate_d(_datetime.date())
+
+
+    def genFriendlyDispDate_d(_date):
+        """
+        Generates a display date using the given date
         This creates a display date in the format:
             Month Day, Year
         However, this is somewhat variable.
@@ -1039,22 +1057,21 @@ init -1 python in mas_calendar:
         is used.
 
         IN:
-            _datetime - datetime object to create good display date
+            _date - date object to create good display date
 
         RETURNS:
             tuple of the following format:
             [0]: nicely formatted display date, suitable for conversation
-            [1]: timedelta between today and the given _datetime
+            [1]: timedelta between today and the given _date
         """
         # the month is always fine to take out
-        disp_month = _datetime.strftime("%B")
+        disp_month = _date.strftime("%B")
 
         # display day is easy
-        disp_day = _formatDay(_datetime.day)
+        disp_day = _formatDay(_date.day)
 
         # to find out year, we need now
         _today = datetime.date.today()
-        _date = _datetime.date()
         _day_diff = _today - _date
         _year_diff = _today.year - _date.year
 
@@ -1095,13 +1112,40 @@ init -1 python in mas_calendar:
             # more than 10? use the 4 digit year
             _cout = [
                 disp_month,
-                disp_day,
-                ",",
+                disp_day + ",",
                 str(_date.year)
             ]
 
         # now return the formatting string + diff
         return (" ".join(_cout), _day_diff)
+
+
+
+    def genFormalDispDate(_date):
+        """
+        Generates a display date using the given date
+
+        This is considered "formal", in that it's not really realisitc when
+        used in normal conversation. For example, if today is august 24, you 
+        don't say 'this happened august 24th, 2016', you normally would say
+        'this happened x years ago today'.
+
+        IN:
+            _date - date object to create good display date
+
+        RETURNS:
+            tuple of the following format:
+            [0]: nicely formtted display date, suitable for text
+            [1]: timedelta between today and the given _date
+        """
+        return (
+            " ".join([
+                _date.strftime("%B"), # month
+                _formatDay(_date.day) + ",", # day
+                str(_date.year) # year
+            ]),
+            datetime.date.today() - _date
+        )
 
 
     def saveCalendarDatabase(encoder):


### PR DESCRIPTION
This fixes #2773 as well as adds a new function `genFormalDispDate` in the `mas_calendar` store for better date display in #3095 .

also maybe fixes #2967 ?

# Testing
1. open console, test `mas_calendar._formatDay` and `mas_calendar.genFormalDispDate` for a string that makes sense.
2. regression test the bday select event. Selecting 21-23 should have the appropriate suffix.