### PR TITLE
New Event property: Affection range

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -388,6 +388,25 @@ python early:
             )
 
 
+        def checkAffection(self, aff_level):
+            """
+            Checks if the given aff_level is within range of this event's
+            aff_range.
+
+            IN:
+                aff_level - aff_level to check
+
+            RETURNS: True if aff_level is within range of event's aff_range,
+                False otherwise
+            """
+            if self.aff_range is None:
+                return True
+
+            # otheerwise check the range
+            low, high = self.aff_range
+            return store.mas_affection._betweenAff(low, aff_level, high)
+
+
         @staticmethod
         def getSortPrompt(ev):
             #
@@ -481,7 +500,8 @@ python early:
                 seen=None,
                 excl_cat=None,
                 moni_wants=None,
-                sensitive=None
+                sensitive=None,
+                aff=None,
             ):
             #
             # Filters the given event object accoridng to the given filters
@@ -497,6 +517,11 @@ python early:
             from collections import Counter
 
             # now lets filter
+
+            # check if event contains the monika wants this rule
+            if moni_wants is not None and event.monikaWantsThisFirst() != moni_wants:
+                return False
+
             if unlocked is not None and event.unlocked != unlocked:
                 return False
 
@@ -504,6 +529,9 @@ python early:
                 return False
 
             if pool is not None and event.pool != pool:
+                return False
+
+            if aff is not None and not event.checkAffection(aff):
                 return False
 
             if seen is not None and renpy.seen_label(event.eventlabel) != seen:
@@ -535,10 +563,6 @@ python early:
             if sensitive is not None and event.sensitive != sensitive:
                 return False
 
-            # check if event contains the monika wants this rule
-            if moni_wants is not None and event.monikaWantsThisFirst() != moni_wants:
-                return False
-
             # we've passed all the filtering rules somehow
             return True
 
@@ -554,7 +578,8 @@ python early:
                 seen=None,
                 excl_cat=None,
                 moni_wants=None,
-                sensitive=None
+                sensitive=None,
+                aff=None
             ):
             #
             # Filters the given events dict according to the given filters.
@@ -600,6 +625,8 @@ python early:
             #           AKA: we only filter sensitve topics if sensitve mode is
             #           enabled.
             #       (Default: None)
+            #   aff - affection level to match aff_range
+            #       (Default: None)
             #
             # RETURNS:
             #   if full_copy is True, we return a completely separate copy of
@@ -619,7 +646,8 @@ python early:
                     and seen is None
                     and excl_cat is None
                     and moni_wants is None
-                    and sensitive is None)):
+                    and sensitive is None
+                    and aff is None)):
                 return events
 
             # copy check
@@ -651,7 +679,7 @@ python early:
                 if Event._filterEvent(v,category=category, unlocked=unlocked,
                         random=random, pool=pool, action=action, seen=seen,
                         excl_cat=excl_cat,moni_wants=moni_wants,
-                        sensitive=sensitive):
+                        sensitive=sensitive, aff=aff):
 
                     filt_ev_dict[k] = v
 

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -104,6 +104,18 @@ python early:
     #       (Default: None)
     #   sensitive - True means this is a sensitve topic, False means it is not
     #       (Default: False)
+    #   aff_range - tuple of the following format:
+    #       [0]: - low limit of affection where this event is available
+    #           (inclusive)
+    #           If None, assumed to be no lower limit
+    #       [1]: - upper limit of affection where this event is available
+    #           (inclusive)
+    #           If None, assumed to be no uppwer limit
+    #       If None, then event is considered to be always available regardless
+    #       of affection level
+    #       NOTE: the tuple items should be AFFECTION STATES.
+    #           not using an affection state may break things
+    #       (Default: None)
     class Event(object):
 
         # tuple constants
@@ -125,7 +137,8 @@ python early:
             "rules":14,
             "last_seen":15,
             "years":16,
-            "sensitive":17
+            "sensitive":17,
+            "aff_range":18
         }
 
         # name constants
@@ -169,7 +182,8 @@ python early:
                 rules=dict(),
                 last_seen=None,
                 years=None,
-                sensitive=False
+                sensitive=False,
+                aff_range=None
             ):
 
             # setting up defaults
@@ -189,6 +203,20 @@ python early:
                 raise Exception(
                     "'{0}' - rules property cannot be None".format(eventlabel)
                 )
+
+            # we'll simplify aff_range so we dont have to deal with extra
+            #   storage
+            if aff_range is not None:
+                low, high = aff_range
+                if low is None and high is None:
+                    aff_range = None
+
+            # and then check for valid affection states
+            # NOTE: we assume that the affection store is visible by now
+            if not store.mas_affection._isValidAffRange(aff_range):
+                raise Exception("{0} | bad aff range: {1}".format(
+                    eventlabel, str(aff_range)
+                ))
 
             self.eventlabel = eventlabel
             self.per_eventdb = per_eventdb
@@ -221,7 +249,8 @@ python early:
                 rules,
                 last_seen,
                 years,
-                sensitive
+                sensitive,
+                aff_range
             )
 
             stored_data_row = self.per_eventdb.get(eventlabel, None)

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -517,11 +517,6 @@ python early:
             from collections import Counter
 
             # now lets filter
-
-            # check if event contains the monika wants this rule
-            if moni_wants is not None and event.monikaWantsThisFirst() != moni_wants:
-                return False
-
             if unlocked is not None and event.unlocked != unlocked:
                 return False
 
@@ -561,6 +556,10 @@ python early:
 
             # sensitivyt
             if sensitive is not None and event.sensitive != sensitive:
+                return False
+
+            # check if event contains the monika wants this rule
+            if moni_wants is not None and event.monikaWantsThisFirst() != moni_wants:
                 return False
 
             # we've passed all the filtering rules somehow

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -88,7 +88,7 @@ init -500 python:
 init 850 python:
     # mainly to create centralized database for calendar lookup
     # (and possible general db lookups)
-    mas_all_ev_db = dict()
+    mas_all_ev_db = {}
     mas_all_ev_db.update(store.evhand.event_database)
     mas_all_ev_db.update(store.evhand.farewell_database)
     mas_all_ev_db.update(store.evhand.greeting_database)
@@ -1472,7 +1472,11 @@ label prompt_menu:
     $ mas_RaiseShield_dlg()
 
     python:
-        unlocked_events = Event.filterEvents(evhand.event_database,unlocked=True)
+        unlocked_events = Event.filterEvents(
+            evhand.event_database,
+            unlocked=True,
+            aff=mas_curr_affection
+        )
         sorted_event_keys = Event.getSortedKeys(unlocked_events,include_none=True)
 
         unseen_events = []
@@ -1480,7 +1484,12 @@ label prompt_menu:
             if not seen_event(event):
                 unseen_events.append(event)
 
-        repeatable_events = Event.filterEvents(evhand.event_database,unlocked=True,pool=False)
+        repeatable_events = Event.filterEvents(
+            evhand.event_database,
+            unlocked=True,
+            pool=False,
+            aff=mas_curr_affection
+        )
     #Top level menu
     # NOTE: should we force this to a particualr exp considering that 
     # monika now rotates
@@ -1561,7 +1570,8 @@ label prompts_categories(pool=True):
 #            full_copy=True,
 #                category=[False,current_category],
             unlocked=True,
-            pool=pool
+            pool=pool,
+            aff=mas_curr_affection
         )
 
         # add all categories the master category list
@@ -1612,7 +1622,8 @@ label prompts_categories(pool=True):
 #                    full_copy=True,
                     category=(False,current_category),
                     unlocked=True,
-                    pool=pool
+                    pool=pool,
+                    aff=mas_curr_affection
                 )
 
                 # add deeper categories to a list

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -46,8 +46,12 @@ init -500 python:
         False, # rules
         True, # last_seen
         False, # years
-        False # sensitive
+        False, # sensitive
+        False # aff_range
     )
+
+    # NOTE: aff_range is unlocked because making adjustments to topics would
+    #   become really difficult if we just kept this locked
 
     # set defaults
 #    if (

--- a/Monika After Story/game/event-rules.rpy
+++ b/Monika After Story/game/event-rules.rpy
@@ -512,6 +512,9 @@ init -1 python:
 
     class MASAffectionRule(object):
         """
+        NOTE: DEPRECATED
+        Use the aff_range property for Events instead
+
         Static Class used to create affection specific rules in tuple form.
         That tuple is then stored in a dict containing this rule name constant.
         Each rule is defined by a min and a max determining a range of affection

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -1874,8 +1874,8 @@ label monika_affection_nickname:
             "okasa"
         ]
 
-    # for later code
-    aff_nickname_ev = mas_getEV("monika_affection_nickname")
+        # for later code
+        aff_nickname_ev = mas_getEV("monika_affection_nickname")
 
     if not persistent._mas_offered_nickname:
         m 1euc "I've been thinking, [player]..."

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -1874,6 +1874,9 @@ label monika_affection_nickname:
             "okasa"
         ]
 
+    # for later code
+    aff_nickname_ev = mas_getEV("monika_affection_nickname")
+
     if not persistent._mas_offered_nickname:
         m 1euc "I've been thinking, [player]..."
         m 3eud "You know how there are potentially infinite Monikas right?"

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -696,6 +696,9 @@ init 15 python in mas_affection:
                 if to_down is not None:
                     to_down()
 
+        # finally, rebuild the event lists
+        store.mas_rebuildEventLists()
+
 
     def runAffGPPs(start_affg, end_affg):
         """

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -45,6 +45,221 @@ init python:
     mas_curr_affection = store.mas_affection.NORMAL
     mas_curr_affection_group = store.mas_affection.G_NORMAL
 
+init -900 python in mas_affection:
+    # this is very early because they are importnat constants
+    
+    # numerical constants of affection levels
+    BROKEN = 1
+    DISTRESSED = 2
+    UPSET = 3
+    NORMAL = 4
+    HAPPY = 5
+    AFFECTIONATE = 6
+    ENAMORED = 7
+    LOVE = 8
+
+    # natural order of affection levels
+    _aff_order = [
+        BROKEN,
+        DISTRESSED,
+        UPSET,
+        NORMAL,
+        HAPPY,
+        AFFECTIONATE,
+        ENAMORED,
+        LOVE
+    ]
+
+    # dict map of affection levels. This is purely for O(1) checking
+    _aff_level_map = {}
+    for _item in _aff_order:
+        _aff_level_map[_item] = _item
+
+    # cascade map of affection levels
+    # basically, given a level, which is the next level closet to NORMAL
+    _aff_cascade_map = {
+        BROKEN: DISTRESSED,
+        DISTRESSED: UPSET,
+        UPSET: NORMAL,
+        HAPPY: NORMAL,
+        AFFECTIONATE: HAPPY,
+        ENAMORED: AFFECTIONATE,
+        LOVE: ENAMORED
+    }
+
+
+    # numerical constants of affection groups
+    G_SAD = -1
+    G_HAPPY = -2
+    G_NORMAL = -3
+
+    # natural order of affection groups
+    _affg_order = [
+        G_SAD,
+        G_NORMAL,
+        G_HAPPY
+    ]
+
+    # cascade map of affection groups
+    # basically, given a group , which is the next group closet to Normal
+    _affg_cascade_map = {
+        G_SAD: G_NORMAL,
+        G_HAPPY: G_NORMAL
+    }
+
+    # compare functions for affection / group
+    def _compareAff(aff_1, aff_2):
+        """
+        See mas_compareAff for explanation
+        """
+        # it's pretty easy to tell if we have been given the same items
+        if aff_1 == aff_2:
+            return 0
+
+        # otherwise, need to check for aff existence to get index
+        if aff_1 not in _aff_order or aff_2 not in _aff_order:
+            return 0
+
+        # otherwise both proivded affections exist, lets index
+        if _aff_order.index(aff_1) < _aff_order.index(aff_2):
+            return -1
+
+        return 1
+
+
+    def _compareAffG(affg_1, affg_2):
+        """
+        See mas_compareAffG for explanation
+        """
+        # same stuff?
+        if affg_1 == affg_2:
+            return 0
+
+        # check for aff group exist
+        if affg_1 not in _affg_order or affg_2 not in _affg_order:
+            return 0
+
+        # otherwise, both groups exist, index
+        if _affg_order.index(affg_1) < _affg_order.index(affg_2):
+            return -1
+
+        return 1
+
+
+    def _betweenAff(aff_low, aff_check, aff_high):
+        """
+        checks if the given affection level is between the given low and high.
+        See mas_betweenAff for explanation
+        """
+        aff_check = _aff_level_map.get(aff_check, None)
+
+        # sanity checks
+        if aff_check is None:
+            # aff_check not a valid affection?
+            return False
+            
+        # clean the affection compares
+        aff_low = _aff_level_map.get(aff_low, None)
+        aff_high = _aff_level_map.get(aff_high, None)
+
+        if aff_low is None and aff_high is None:
+            # if both items are None, we basically assume that both bounds
+            # are set to unlimited.
+            return True
+
+        if aff_low is None:
+            # dont care about the lower bound, so check if lower than
+            # higher bound
+            return _compareAff(aff_check, aff_high) <= 0
+
+        if aff_high is None:
+            # dont care about the upper bound, so check if higher than lower
+            # bound
+            return _compareAff(aff_check, aff_low) >= 0
+
+        # otherwise, both low and high ranges are not None, so we
+        # can actually check between the 2
+        comp_low_high = _compareAff(aff_low, aff_high)
+        if comp_low_high > 0:
+            # low is actually greater than high. Therefore, the given
+            # affection cannot possible be between the 2, probably.
+            return False
+
+        if comp_low_high == 0:
+            # they are the same, just check for equivalence
+            return _compareAff(aff_low, aff_check) == 0
+
+        # otherwise, we legit need to check range
+        return (
+            _compareAff(aff_low, aff_check) <= 0
+            and _compareAff(aff_check, aff_high) <= 0
+        )
+
+
+    def _isValidAff(aff_check):
+        """
+        Returns true if the given affection is a valid affection state
+
+        NOTE: None is considered valid
+        """
+        if aff_check is None:
+            return True
+
+        return aff_check in _aff_level_map
+
+
+    def _isValidAffRange(aff_range):
+        """
+        Returns True if the given aff range is a valid aff range.
+
+        IN:
+            aff_range - tuple of the following format:
+                [0]: lower bound
+                [1]: upper bound
+            NOTE: Nones are considerd valid.
+        """
+        if aff_range is None:
+            return True
+
+        low, high = aff_range
+
+        if not _isValidAff(low):
+            return False
+
+        if not _isValidAff(high):
+            return False
+
+        if low is None and high is None:
+            return True
+
+        return _compareAff(low, high) <= 0
+
+
+    # thresholds values
+
+    # Affection experience changer thresholds
+    AFF_MAX_POS_TRESH = 100
+    AFF_MIN_POS_TRESH = 30
+    AFF_MIN_NEG_TRESH = -30
+    AFF_MAX_NEG_TRESH = -75
+
+    # Affection levels thresholds
+    AFF_BROKEN_MIN = -100
+    AFF_DISTRESSED_MIN = -75
+    AFF_UPSET_MIN = -30
+    AFF_HAPPY_MIN = 30
+    AFF_AFFECTIONATE_MIN = 100
+    AFF_ENAMORED_MIN = 400
+    AFF_LOVE_MIN = 1000
+
+    # Affection general mood threshold
+    AFF_MOOD_HAPPY_MIN = 30
+    AFF_MOOD_SAD_MIN = -30
+
+    # lower affection cap for time
+    AFF_TIME_CAP = -101
+
+
 init -1 python in mas_affection:
     import os
     import datetime
@@ -148,123 +363,6 @@ init -1 python in mas_affection:
             new
         ))
 
-
-    # numerical constants of affection levels
-    BROKEN = 1
-    DISTRESSED = 2
-    UPSET = 3
-    NORMAL = 4
-    HAPPY = 5
-    AFFECTIONATE = 6
-    ENAMORED = 7
-    LOVE = 8
-
-    # natural order of affection levels
-    _aff_order = [
-        BROKEN,
-        DISTRESSED,
-        UPSET,
-        NORMAL,
-        HAPPY,
-        AFFECTIONATE,
-        ENAMORED,
-        LOVE
-    ]
-
-    # cascade map of affection levels
-    # basically, given a level, which is the next level closet to NORMAL
-    _aff_cascade_map = {
-        BROKEN: DISTRESSED,
-        DISTRESSED: UPSET,
-        UPSET: NORMAL,
-        HAPPY: NORMAL,
-        AFFECTIONATE: HAPPY,
-        ENAMORED: AFFECTIONATE,
-        LOVE: ENAMORED
-    }
-
-
-    # numerical constants of affection groups
-    G_SAD = -1
-    G_HAPPY = -2
-    G_NORMAL = -3
-
-    # natural order of affection groups
-    _affg_order = [
-        G_SAD,
-        G_NORMAL,
-        G_HAPPY
-    ]
-
-    # cascade map of affection groups
-    # basically, given a group , which is the next group closet to Normal
-    _affg_cascade_map = {
-        G_SAD: G_NORMAL,
-        G_HAPPY: G_NORMAL
-    }
-
-    # compare functions for affection / group
-    def _compareAff(aff_1, aff_2):
-        """
-        See mas_compareAff for explanation
-        """
-        # it's pretty easy to tell if we have been given the same items
-        if aff_1 == aff_2:
-            return 0
-
-        # otherwise, need to check for aff existence to get index
-        if aff_1 not in _aff_order or aff_2 not in _aff_order:
-            return 0
-
-        # otherwise both proivded affections exist, lets index
-        if _aff_order.index(aff_1) < _aff_order.index(aff_2):
-            return -1
-
-        return 1
-
-
-    def _compareAffG(affg_1, affg_2):
-        """
-        See mas_compareAffG for explanation
-        """
-        # same stuff?
-        if affg_1 == affg_2:
-            return 0
-
-        # check for aff group exist
-        if affg_1 not in _affg_order or affg_2 not in _affg_order:
-            return 0
-
-        # otherwise, both groups exist, index
-        if _affg_order.index(affg_1) < _affg_order.index(affg_2):
-            return -1
-
-        return 1
-
-
-    # thresholds values
-
-    # Affection experience changer thresholds
-    AFF_MAX_POS_TRESH = 100
-    AFF_MIN_POS_TRESH = 30
-    AFF_MIN_NEG_TRESH = -30
-    AFF_MAX_NEG_TRESH = -75
-
-    # Affection levels thresholds
-    AFF_BROKEN_MIN = -100
-    AFF_DISTRESSED_MIN = -75
-    AFF_UPSET_MIN = -30
-    AFF_HAPPY_MIN = 30
-    AFF_AFFECTIONATE_MIN = 100
-    AFF_ENAMORED_MIN = 400
-    AFF_LOVE_MIN = 1000
-
-    # Affection general mood threshold
-    AFF_MOOD_HAPPY_MIN = 30
-    AFF_MOOD_SAD_MIN = -30
-
-    # lower affection cap for time
-    AFF_TIME_CAP = -101
 
 # need these utility functiosn post event_handler
 init 15 python in mas_affection:
@@ -1070,6 +1168,27 @@ init 20 python:
 
     ## affection comparison
     # [AFF020] Affection comparTos
+    def mas_betweenAff(aff_low, aff_check, aff_high):
+        """
+        Checks if the given affection is between the given affection levels.
+
+        If low is actually greater than high, then False is always returned
+
+        IN:
+            aff_low - the lower bound of affecton to check with (inclusive)
+                if None, then we assume no lower bound
+            aff_check - the affection to check
+            aff_high - the upper bound of affection to check with (inclusive)
+                If None, then we assume no upper bound
+
+        RETURNS:
+            True if the given aff check is within the bounds of the given
+            lower and upper affection limits, False otherwise.
+            If low is greater than high, False is returned.
+        """
+        return affection._betweenAff(aff_low, aff_check, aff_high)
+
+
     def mas_compareAff(aff_1, aff_2):
         """
         Runs compareTo logic on the given affection states

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1162,6 +1162,18 @@ label ch30_end:
 
 # label for things that may reset after a certain amount of time/conditions
 label ch30_reset:
+    
+    python:
+        # start by building event lists if they have not been built already
+        if not mas_events_built:
+            mas_rebuildEventLists()
+
+        # check if you've seen everything
+        if len(mas_rev_unseen) == 0:
+            # you've seen everything?! here, higher session limit
+            # NOTE: 1000 is arbitrary. Basically, endless monika topics
+            # I think we'll deal with this better once we hve a sleeping sprite
+            random_seen_limit = 1000
 
     if not persistent._mas_pm_has_rpy:
         # setup the docking station to handle the detection

--- a/Monika After Story/game/script-compliments.rpy
+++ b/Monika After Story/game/script-compliments.rpy
@@ -46,11 +46,17 @@ label mas_compliments_start:
         # Unlock any compliments that need to be unlocked
         Event.checkConditionals(mas_compliments.compliment_database)
 
+        # filter comps
+        filtered_comps = Event.filterEvents(
+            mas_compliments.compliment_database,
+            unlocked=True,
+            aff=mas_curr_affection
+        )
+
         # build menu list
         compliments_menu_items = [
             (mas_compliments.compliment_database[k].prompt, k, not seen_event(k), False)
-            for k in mas_compliments.compliment_database
-            if mas_compliments.compliment_database[k].unlocked
+            for k in filtered_comps
         ]
 
         # also sort this list
@@ -361,9 +367,8 @@ init 5 python:
             persistent._mas_compliments_database,
             eventlabel="mas_compliment_thanks",
             prompt="... Thanks for being there for me!",
-            unlocked=False,
-            conditional="mas_curr_affection == store.mas_affection.ENAMORED",
-            action=EV_ACT_UNLOCK
+            unlocked=True,
+            aff_range=(mas_aff.ENAMORED, None)
         ),
         eventdb=store.mas_compliments.compliment_database
     )

--- a/Monika After Story/game/script-compliments.rpy
+++ b/Monika After Story/game/script-compliments.rpy
@@ -44,7 +44,7 @@ label mas_compliments_start:
         import store.mas_compliments as mas_compliments
 
         # Unlock any compliments that need to be unlocked
-        Event.checkConditionals(mas_compliments.compliment_database)
+#        Event.checkConditionals(mas_compliments.compliment_database)
 
         # filter comps
         filtered_comps = Event.filterEvents(

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -61,7 +61,8 @@ init 5 python:
                 prompt="Can you show me the floating islands?",
                 pool=True,
                 unlocked=False,
-                rules={"no unlock": None}
+                rules={"no unlock": None},
+                aff_range=(mas_aff.ENAMORED, None)
             )
         )
 

--- a/Monika After Story/game/script-moods.rpy
+++ b/Monika After Story/game/script-moods.rpy
@@ -83,11 +83,17 @@ label mas_mood_start:
     python:
         import store.mas_moods as mas_moods
 
+        # filter the moods first
+        filtered_moods = Event.filterEvents(
+            mas_moods.mood_db,
+            unlocked=True,
+            aff=mas_curr_affection
+        )
+
         # build menu list
         mood_menu_items = [
             (mas_moods.mood_db[k].prompt, k, False, False)
-            for k in mas_moods.mood_db
-            if mas_moods.mood_db[k].unlocked
+            for k in filtered_moods
         ]
 
         # also sort this list

--- a/Monika After Story/game/script-stories.rpy
+++ b/Monika After Story/game/script-stories.rpy
@@ -49,12 +49,14 @@ label mas_stories_start(scary=False):
         if scary:
             stories = renpy.store.Event.filterEvents(
                 mas_stories.story_database,
-                category=(True,[mas_stories.TYPE_SCARY])
+                category=(True,[mas_stories.TYPE_SCARY]),
+                aff=mas_curr_affection
             )
         else:
             stories = renpy.store.Event.filterEvents(
                 mas_stories.story_database,
-                excl_cat=list()
+                excl_cat=list(),
+                aff=mas_curr_affection
             )
 
         # build menu list
@@ -178,7 +180,8 @@ label mas_story_unlock_random_cat(scary=False):
             stories = renpy.store.Event.filterEvents(
                 renpy.store.mas_stories.story_database,
                 unlocked=False,
-                category=(True,[renpy.store.mas_stories.TYPE_SCARY])
+                category=(True,[renpy.store.mas_stories.TYPE_SCARY]),
+                aff=mas_curr_affection
             )
 
             if len(stories) == 0:
@@ -188,7 +191,8 @@ label mas_story_unlock_random_cat(scary=False):
                     renpy.store.mas_stories.story_database,
                     unlocked=True,
                     seen=False,
-                    category=(True,[renpy.store.mas_stories.TYPE_SCARY])
+                    category=(True,[renpy.store.mas_stories.TYPE_SCARY]),
+                    aff=mas_curr_affection
                 )
 
                 if len(stories) == 0:
@@ -198,7 +202,8 @@ label mas_story_unlock_random_cat(scary=False):
                     stories = renpy.store.Event.filterEvents(
                         renpy.store.mas_stories.story_database,
                         unlocked=True,
-                        category=(True,[renpy.store.mas_stories.TYPE_SCARY])
+                        category=(True,[renpy.store.mas_stories.TYPE_SCARY]),
+                        aff=mas_curr_affection
                     )
         else:
             # reset flag so we don't unlock another one
@@ -208,7 +213,8 @@ label mas_story_unlock_random_cat(scary=False):
             stories = renpy.store.Event.filterEvents(
                 renpy.store.mas_stories.story_database,
                 unlocked=False,
-                excl_cat=list()
+                excl_cat=list(),
+                aff=mas_curr_affection
             )
 
             if len(stories) == 0:
@@ -218,7 +224,8 @@ label mas_story_unlock_random_cat(scary=False):
                     renpy.store.mas_stories.story_database,
                     unlocked=True,
                     seen=False,
-                    excl_cat=list()
+                    excl_cat=list(),
+                    aff=mas_curr_affection
                 )
 
                 if len(stories) == 0:
@@ -228,7 +235,8 @@ label mas_story_unlock_random_cat(scary=False):
                     stories = renpy.store.Event.filterEvents(
                         renpy.store.mas_stories.story_database,
                         unlocked=True,
-                        excl_cat=list()
+                        excl_cat=list(),
+                        aff=mas_curr_affection
                     )
 
         # select one story randomly

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -1570,7 +1570,16 @@ label monika_simulated:
 
 init 5 python:
     # only available if moni-affecition normal and above
-    addEvent(Event(persistent.event_database,eventlabel="monika_rain",category=["weather"],prompt="Sounds of rain",random=True))
+    addEvent(
+        Event(
+            persistent.event_database,
+            eventlabel="monika_rain",
+            category=["weather"],
+            prompt="Sounds of rain",
+            random=True,
+            aff_range=(mas_aff.NORMAL, None)
+        )
+    )
 
 label monika_rain:
     m 1hua "I really like the sound of rain~"
@@ -1650,7 +1659,8 @@ init 5 python:
             prompt="Can you stop the rain?",
             pool=True,
             unlocked=False,
-            rules={"no unlock": None}
+            rules={"no unlock": None},
+            aff_range=(mas_aff.NORMAL, None)
         )
     )
 
@@ -1694,7 +1704,8 @@ init 5 python:
             prompt="Can you make it rain?",
             pool=True,
             unlocked=False,
-            rules={"no unlock":None}
+            rules={"no unlock":None},
+            aff_range=(mas_aff.NORMAL, None)
         )
     )
 
@@ -1735,7 +1746,8 @@ init 5 python:
             prompt="Can I hold you?",
             pool=True,
             unlocked=False,
-            rules={"no unlock":None}
+            rules={"no unlock":None},
+            aff_range=(mas_aff.HAPPY, None)
         )
     )
 
@@ -5612,9 +5624,10 @@ init 5 python:
             eventlabel="monika_promisering",
             category=['romance'],
             prompt="Promise Ring",
-            random=True
-            )
+            random=True,
+            aff_range=(mas_aff.HAPPY, None)
         )
+    )
 
 label monika_promisering:
     m 4rksdla "Did you know when two people confess their feelings for each other, they sometimes wear matching rings?"
@@ -8442,7 +8455,8 @@ init 5 python:
             prompt="Can you change your clothes?",
             pool=True,
             unlocked=False,
-            rules={"no unlock": None}
+            rules={"no unlock": None},
+            aff_range=(mas_aff.LOVE, None)
         )
     )
 

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -63,6 +63,9 @@ init -1 python:
     import store.songs as songs
     import store.evhand as evhand
 
+    mas_events_built = False
+    # set to True once we have built events
+
     def remove_seen_labels(pool):
         #
         # Removes seen labels from the given pool
@@ -223,11 +226,15 @@ init -1 python:
 
         ASSUMES:
             evhand.event_database
+            mas_events_built
         """
+        global mas_events_built
+
         # retrieve all randoms
         all_random_topics = Event.filterEvents(
             evhand.event_database,
-            random=True
+            random=True,
+            aff=mas_curr_affection
         )
 
         # split randoms into unseen and sorted seen events
@@ -236,6 +243,7 @@ init -1 python:
         # split seen into regular seen and the most seen events
         seen, mostseen = mas_splitSeenEvents(sorted_seen)
 
+        mas_events_built = True
         return (unseen, seen, mostseen)
 
 
@@ -255,7 +263,8 @@ init -1 python:
         all_seen_topics = Event.filterEvents(
             evhand.event_database,
             random=True,
-            seen=True
+            seen=True,
+            aff=mas_curr_affection
         ).values()
 
         # clean the seen topics from early repeats
@@ -268,6 +277,19 @@ init -1 python:
         return mas_splitSeenEvents(cleaned_seen)
 
 
+    def mas_rebuildEventLists():
+        """
+        Rebuilds the unseen, seen and most seen event lists.
+
+        ASSUMES:
+            mas_rev_unseen - unseen list
+            mas_rev_seen - seen list
+            mas_rev_mostseen - most seen list
+        """
+        global mas_rev_unseen, mas_rev_seen, mas_rev_mostseen
+        mas_rev_unseen, mas_rev_seen, mas_rev_mostseen = mas_buildEventLists()
+
+
     # EXCEPTION CLass incase of bad labels
     class MASTopicLabelException(Exception):
         def __init__(self, msg):
@@ -278,16 +300,13 @@ init -1 python:
 init 11 python:
 
     # sort out the seen / most seen / unseen
-    mas_rev_unseen, mas_rev_seen, mas_rev_mostseen = mas_buildEventLists()
+    mas_rev_unseen = []
+    mas_rev_seen = []
+    mas_rev_mostseen = []
+#    mas_rev_unseen, mas_rev_seen, mas_rev_mostseen = mas_buildEventLists()
 
     # for compatiblity purposes:
 #    monika_random_topics = all_random_topics
-
-    if len(mas_rev_unseen) == 0:
-        # you've seen everything?! here, higher session limit
-        # NOTE: 1000 is arbitrary. Basically, endless monika topics
-        # I think we'll deal with this better once we hve a sleeping sprite
-        random_seen_limit = 1000
 
     #Remove all previously seen random topics.
        #remove_seen_labels(monika_random_topics)

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -294,6 +294,32 @@ label v0_3_1(version=version): # 0.3.1
 
 # non generic updates go here
 
+# 0.8.11
+label v0_8_11(version="v0_8_11"):
+    python:
+        import store.mas_compliments as mas_comp
+        import store.evhand as evhand
+        
+        # change compliements event props
+        thanks_ev = mas_comp.compliment_database.get(
+            "mas_compliment_thanks",
+            None
+        )
+        if thanks_ev:
+            # remove conditional and action
+            thanks_ev.conditional = None
+            thanks_ev.action = None
+
+            # unlock only if you have not seen this
+            if not renpy.seen_label(thanks_ev.eventlabel):
+                thanks_ev.unlocked = True
+
+        # change monika nick name
+        if not persistent._mas_called_moni_a_bad_name:
+            mas_unlockEventLabel("monika_affection_nickname")
+
+    return
+
 # 0.8.10
 label v0_8_10(version="v0_8_10"):
     python:

--- a/Monika After Story/game/updates_topics.rpy
+++ b/Monika After Story/game/updates_topics.rpy
@@ -40,6 +40,7 @@ label vv_updates_topics:
 
         # versions
         # use the v#_#_# notation so we can work with labels
+        vv0_8_11 = "v0_8_11"
         vv0_8_10 = "v0_8_10"
         vv0_8_9 = "v0_8_9"
         vv0_8_8 = "v0_8_8"
@@ -72,6 +73,7 @@ label vv_updates_topics:
         # update this dict accordingly to every new version
         # k:old version number -> v:new version number
         # some version changes skip some numbers because no major updates
+#        updates.version_updates[vv0_8_10] = vv0_8_11
         updates.version_updates[vv0_8_9] = vv0_8_10
         updates.version_updates[vv0_8_8] = vv0_8_9
         updates.version_updates[vv0_8_7] = vv0_8_9


### PR DESCRIPTION
This adds a new `Event` property for affection ranges. Affection ranges are used to determine if an Event is active/visible/selectable according to the affection level. **NOTE:**, this is basically the `MASAffectionRule` but using affection states instead of actual numerical values.

**NOTE:** this is on `content` since it affects Events/topics

# `aff_range`
The `aff_range` property is a tuple of the following format:
* `[0]` - affection state to act as the lower bound (inclusive)
* `[1]` - affection state to act as the upper bound (inclusive)

A tuple item that is None is considered an unbounded limit. An `aff_range` of None means that the Event should be **always** active.

`Event.filterEvents` has been updated to work with the new property. Events can be filtered with affection by passing in an affection level to this function via the `aff` param. This only accepts 1 affection level. Multi-affection filtering is not supported.

`Event` objects now have a `checkAffection` function, which just determines if a given affection state is within range of the event's `aff_range`

`aff_range` is **not** locked in the lock db. This is since adjusting affection availability of events might be pretty common.

# other changes
* moved import affection constants to an earlier init level (-900) so we'll have less issues with `Event` objects using these functions.
* added `mas_betweenAff` which checks if a given affection value is within range of 2 affection bounds
* added affection validation functions in the `mas_affection` store.
* rando events are now built in `ch30_reset` instead of init 11. This is so affection filtering can be applied prior to event list building
* `mas_rebuildEventLists` forces a rebuild of event lists.
* moods are now filtered by affection
* stories are now filtered by affection
* compliments are now filtered by affection

# TESTING
## affection default
1. launch game
2. verify that topics with no `aff_range` property are visible.

## affection filtering
1. launch game and modify an event by giving it an affection range tuple
2. Change your affection so it is outside of the aff range tuple you used.
3. open Repeat/Ask and verify that you cannot see the event you modified.
4. Change your affection so it is inside of the aff range tuple you used
5. repeat step 3 and verify that you can see the event again.
6. Repeat steps 1-5 for the possible tuple variations:
    * (None, aff1) - aff1 and lower
    * (aff1, aff2) - aff1 to aff2, inclusive
    * (aff1, aff1) - aff1 only
    * (aff1, None) - aff1 and higher

## regression
* the following topics have been adjusted to work with the new system:
    * clothes select topic - only available at LOVE+ (still requires more than one outfit)
    * islands event topic - only available at ENAMORED+ (still requires seeing the initial greeting)
    * thanks compliment - first appears at ENAMORED+. After seeing it once, it will be locked until LOVE+ 
        * **NOTE**: we do not change `aff_range` in this compliment. Instead the current programming point logic is used for this. 
        * **NOTE:** this requires an update script to function correctly. You will have to unlock this manually for testing.
    * nickname topic - only available at AFF+ (still requires that you did not call her a bad name once) 
        * **NOTE:** this requires an update script to function correctly, you will have to unlock this manually for testing
    * hold me topic - only available at HAPPY+ (still requires you to like rain)
    * promise ring topic - only available at HAPPY+ (still unlocked as a random topic)
    * rain start topic - only available at NORMAL+ (still requires you to like rain, and it not be raining)
    * rain stop topic - only available at NORMAL+ (still requires you to like rain, and it be raining)
    * rain topic - only available at NORMAL+ (still unlocked as a random topic)

## guardrails
1. modify an event in source code, giving it an `aff_range` that is invalid. (use strings instead of affection states, not using a tuple, etc)
2. launch game
3. verify that the game crashes on start with an Exception that makes some sense.

# Future

Greetings and farewells are currently controlled by `MASAffectionRule`. They will be migrated over to the new property in a separate project.