### PR TITLE
data verification system on start

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -377,6 +377,15 @@ python early:
                             self.eventlabel + " not found in eventdb"
                         )
 
+                    # if we are dealing with start/end dates, we need to
+                    #   ensure that they are datetimes
+                    if name == "start_date" or name == "end_date":
+                        if isinstance(value, datetime.date):
+                            value = datetime.datetime.combine(
+                                value,
+                                datetime.time.min
+                            )
+
                     # otherwise, repack the tuples
                     data_row = list(data_row)
                     data_row[attr_loc] = value

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -22,6 +22,41 @@ image monika_waiting_img:
 transform prompt_monika:
     tcommon(950,z=0.8)
 
+
+init -900 python in mas_ev_data_ver:
+    # special store dedicated to verification of Event-based data
+    import datetime
+
+
+    def _verify_bool(val, allow_none=True):
+        return _verify_item(val, bool, allow_none)
+
+
+    def _verify_dict(val, allow_none=True):
+        return _verify_item(val, dict, allow_none)
+
+
+    def _verify_item(val, _type, allow_none=True):
+        """
+        Verifies the given value has the given type/instance
+
+        IN:
+            val - value to verify
+            _type - type to check
+            allow_none - If True, None should be considered good value,
+                false means bad value
+                (Default: True)
+
+        RETURNS: True if the given value has the given type/instance,
+            false otherwise
+        """
+        if val is None:
+            return allow_none
+
+        # otherwise check item
+        return isinstance(val, _type)
+
+
 init -500 python:
     # initalies the locks db
 

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -180,6 +180,9 @@ init -900 python in mas_ev_data_ver:
         IN:
             per_db - persistent database to verify
         """
+        if per_db is None:
+            return
+
         for ev_label in per_db.keys():
             # pull out the data
             ev_line = per_db[ev_label]

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -188,13 +188,11 @@ init -900 python in mas_ev_data_ver:
 
     # verify some databases
     verify_event_data(store.persistent.event_database)
-
-    # TODO: must check if the reports reveal bad shit about these databases
-#    verify_event_data(store.persistent._mas_compliments_database)
-#    verify_event_data(store.persistent.farewell_database)
-#    verify_event_data(store.persistent.greeting_database)
-#    verify_event_data(store.persistent._mas_mood_database)
-#    verify_event_data(store.persistent._mas_story_database)
+    verify_event_data(store.persistent._mas_compliments_database)
+    verify_event_data(store.persistent.farewell_database)
+    verify_event_data(store.persistent.greeting_database)
+    verify_event_data(store.persistent._mas_mood_database)
+    verify_event_data(store.persistent._mas_story_database)
 
 
 init -500 python:

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -26,14 +26,49 @@ transform prompt_monika:
 init -900 python in mas_ev_data_ver:
     # special store dedicated to verification of Event-based data
     import datetime
+    import store
 
-
+    ## verification type functions
+    ## most of these lead into verify_item
     def _verify_bool(val, allow_none=True):
         return _verify_item(val, bool, allow_none)
 
 
     def _verify_dict(val, allow_none=True):
         return _verify_item(val, dict, allow_none)
+
+
+    def _verify_dt(val, allow_none=True):
+        return _verify_item(val, datetime.datetime, allow_none)
+
+
+    def _verify_evact(val, allow_none=True):
+        if val is None:
+            return allow_none
+
+        return val in store.EV_ACTIONS
+
+
+    def _verify_int(val, allow_none=True):
+        return _verify_item(val, int, allow_none)
+
+
+    def _verify_str(val, allow_none=True):
+        return _verify_item(val, str, allow_none)
+
+
+    def _verify_tuli(val, allow_none=True):
+        if val is None:
+            return allow_none
+
+        return isinstance(val, list) or isinstance(val, tuple)
+
+
+    def _verify_tuli_aff(val, allow_none=True):
+        if val is None:
+            return allow_none
+
+        return isinstance(val, tuple) and len(val) == 2
 
 
     def _verify_item(val, _type, allow_none=True):
@@ -55,6 +90,111 @@ init -900 python in mas_ev_data_ver:
 
         # otherwise check item
         return isinstance(val, _type)
+
+
+    class MASCurriedVerify(object):
+        """
+        Allows for currying of a verification function
+        """
+
+        def __init__(self, verifier, allow_none):
+            """
+            Constructor
+
+            IN:
+                verifier - the verification function we want to use
+                allow_none - True if we should pass True for allow_none,
+                    false for False
+            """
+            self.verifier = verifier
+            self.allow_none = allow_none
+
+
+        def __call__(self, value):
+            """
+            Callable override
+
+            IN:
+                value - the value we want to verify
+
+            RETURNS: True if the value passes verification, False otherwise
+            """
+            return self.verifier(value, self.allow_none)
+
+
+    # map data to tuples
+    _verify_map = {
+        0: MASCurriedVerify(_verify_str, False), # eventlabel
+        1: MASCurriedVerify(_verify_str, True), # prompt
+        2: MASCurriedVerify(_verify_str, True), # label
+        # TODO: because of reactions, we cannot verify category yet
+#        3: MASCurriedVerify(_verify_tuli, True), # category
+        4: MASCurriedVerify(_verify_bool, True), # unlocked
+        5: MASCurriedVerify(_verify_bool, True), # random
+        6: MASCurriedVerify(_verify_bool, True), # pool
+        7: MASCurriedVerify(_verify_str, True), # conditional
+        8: MASCurriedVerify(_verify_evact, True), # action
+        9: MASCurriedVerify(_verify_dt, True), # start_date
+        10: MASCurriedVerify(_verify_dt, True), # end_date
+        11: MASCurriedVerify(_verify_dt, True), # unlock_date
+        12: MASCurriedVerify(_verify_int, False), # shown_count
+        13: MASCurriedVerify(_verify_str, True), # diary_entry
+        14: MASCurriedVerify(_verify_dict, False), # rules
+        15: MASCurriedVerify(_verify_dt, True), # last_seen
+        16: MASCurriedVerify(_verify_tuli, True), # years
+        17: MASCurriedVerify(_verify_bool, True), # sensitive
+        18: MASCurriedVerify(_verify_tuli_aff, True) # aff_range
+    }
+
+
+    def _verify_data_line(ev_line):
+        """
+        Verifies event data for a single tuple of data.
+
+        IN:
+            ev_line - single line of data to verify
+
+        RETURNS:
+            True if passed verification, False if not
+        """
+        # we only want to check what exists in this data
+        for index in range(len(ev_line)):
+            # go through verification map and verify
+            verify = _verify_map.get(index, None)
+            if verify is not None and not verify(ev_line[index]):
+                # verification failed! 
+                return False
+
+        return True
+
+
+    def verify_event_data(per_db):
+        """
+        Verifies event data of the given persistent data. Entries that are 
+        invalid are removed. We only check the bits of data that we have, so
+        data lines with smaller sizes are only validated for what they have.
+
+        IN:
+            per_db - persistent database to verify
+        """
+        for ev_label in per_db.keys():
+            # pull out the data
+            ev_line = per_db[ev_label]
+
+            if not _verify_data_line(ev_line):
+                # verification failed! pop this element
+                per_db.pop(ev_label)
+
+
+    # verify some databases
+    verify_event_data(store.persistent.event_database)
+
+    # TODO: must check if the reports reveal bad shit about these databases
+#    verify_event_data(store.persistent._mas_compliments_database)
+#    verify_event_data(store.persistent.farewell_database)
+#    verify_event_data(store.persistent.greeting_database)
+#    verify_event_data(store.persistent._mas_mood_database)
+#    verify_event_data(store.persistent._mas_story_database)
 
 
 init -500 python:

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -54,7 +54,10 @@ init -900 python in mas_ev_data_ver:
 
 
     def _verify_str(val, allow_none=True):
-        return _verify_item(val, str, allow_none)
+        if val is None:
+            return allow_none
+
+        return isinstance(val, str) or isinstance(val, unicode)
 
 
     def _verify_tuli(val, allow_none=True):
@@ -183,6 +186,9 @@ init -900 python in mas_ev_data_ver:
 
             if not _verify_data_line(ev_line):
                 # verification failed! pop this element
+                store.mas_utils.writelog(
+                    "bad data found in {0}\n".format(ev_label)
+                )
                 per_db.pop(ev_label)
 
 

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -1298,9 +1298,9 @@ init -876 python in mas_delact:
             "and persistent._mas_d25_started_upset "
         )
         ev.action = store.EV_ACT_PUSH
-        ev.start_date = store.mas_d25c_start,
+        ev.start_date = store.mas_d25c_start
         ev.end_date = store.mas_d25p
-        store.Event._verifyDatesEV(ev)
+        store.Event._verifyAndSetDatesEV(ev)
         return True
 
 

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -301,17 +301,8 @@ label v0_3_1(version=version): # 0.3.1
 # 0.8.12
 label v0_8_12(version="v0_8_12"):
     python:
-        hiu_ev = store.evhand.event_database.get(
-            "mas_d25_monika_holiday_intro_upset",
-            None
-        )
-
-        if hiu_ev is not None:
-            if isinstance(hiu_ev.start_date, tuple):
-                # tuple start date means this was bad data
-                hiu_ev.start_date = mas_d25c_start
-                hiu_ev.end_date = mas_d25p
-                Event._verifyAndSetDatesEV(ev)
+        pass
+        # NOTHING
 
     return
 

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -298,6 +298,23 @@ label v0_3_1(version=version): # 0.3.1
 #   without conditionals and start_date
 #   We will save this for versiojn 0812 or 9
 
+# 0.8.12
+label v0_8_12(version="v0_8_12"):
+    python:
+        hiu_ev = store.evhand.event_database.get(
+            "mas_d25_monika_holiday_intro_upset",
+            None
+        )
+
+        if hiu_ev is not None:
+            if isinstance(hiu_ev.start_date, tuple):
+                # tuple start date means this was bad data
+                hiu_ev.start_date = mas_d25c_start
+                hiu_ev.end_date = mas_d25p
+                Event._verifyAndSetDatesEV(ev)
+
+    return
+
 # 0.8.11
 label v0_8_11(version="v0_8_11"):
     python:

--- a/Monika After Story/game/updates_topics.rpy
+++ b/Monika After Story/game/updates_topics.rpy
@@ -68,6 +68,7 @@ label vv_updates_topics:
 
         # versions
         # use the v#_#_# notation so we can work with labels
+        vv0_8_12 = "v0_8_12"
         vv0_8_11 = "v0_8_11"
         vv0_8_10 = "v0_8_10"
         vv0_8_9 = "v0_8_9"
@@ -101,6 +102,7 @@ label vv_updates_topics:
         # update this dict accordingly to every new version
         # k:old version number -> v:new version number
         # some version changes skip some numbers because no major updates
+#        updates.version_updates[vv0_8_11] = vv0_8_12
         updates.version_updates[vv0_8_10] = vv0_8_11
         updates.version_updates[vv0_8_9] = vv0_8_10
         updates.version_updates[vv0_8_8] = vv0_8_9


### PR DESCRIPTION
test the data verification system using @kaido1224 's persistent. 

Also make sure that events are not removed incorrectly. Only events with invalid data should be removed.

**NOTE:**, `category` is ignored for now, since we need to change reactions to use filename lists instead of just single filename.

Also, setting the `start_date` or `end_date` of an Event to a `date` will auto convert it to a `datetime`

## short explain

The verification system runs at init level -900 and simply does an `isinstance` check of Event properties. Nones are allowd for most of the properties. Failures are logged to `mas_log` and popped from the respective database.

All checking interacts **directly** with the **persistent database**. 