### PR TITLE
changes to special day conditions + gift changes

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -3474,7 +3474,7 @@ init -1 python:
             boolean indicating if today is a special day.
         """
         # TODO keep adding special days as we add them
-        return mas_isMonikaBirthday() or mas_isO31() or mas_isD25() or mas_anni.isAnni() or mas_isNYE()
+        return mas_isMonikaBirthday() or mas_isO31() or mas_isD25() or (mas_anni.isAnniAny() and not mas_anni.isAnniWeek()) or mas_isNYE()
 
     def mas_getNextMonikaBirthday():
         today = datetime.date.today()

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -3474,7 +3474,7 @@ init -1 python:
             boolean indicating if today is a special day.
         """
         # TODO keep adding special days as we add them
-        return mas_isMonikaBirthday() or mas_isO31() or mas_isD25() or mas_anni.isAnni()
+        return mas_isMonikaBirthday() or mas_isO31() or mas_isD25() or mas_anni.isAnni() or mas_isNYE()
 
     def mas_getNextMonikaBirthday():
         today = datetime.date.today()

--- a/Monika After Story/game/script-anniversary.rpy
+++ b/Monika After Story/game/script-anniversary.rpy
@@ -105,7 +105,7 @@ init -2 python in mas_anni: #needed to lower this in order to get isAnni() worki
             compare = build_anni(months=6)
 
         elif milestone == 'any':
-            return isAnniWeek() or isAnniOneMonth() or isAnniThreeMonth() or isAnniSixMonth or isAnni()
+            return isAnniWeek() or isAnniOneMonth() or isAnniThreeMonth() or isAnniSixMonth() or isAnni()
 
         if compare is not None:
             return compare.date() == datetime.date.today()

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -2108,10 +2108,15 @@ init 5 python:
     )
 
 label mas_d25_postd25_notimespent:
-    #sanity check
+    #sanity checks
     if persistent._mas_d25_spent_d25:
         return
-        
+    if persistent.sessions is None:
+        return
+    if persistent.sessions['first_session'].date() > mas_d25: #need to make sure people who just started post d25 don't lose aff
+        return
+
+
     if mas_isMoniAff(higher=True):
         $ mas_loseAffection(15, reason="missing Christmas.")
         m 1dkc "...I'm just glad you're finally here..."

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -2111,9 +2111,9 @@ label mas_d25_postd25_notimespent:
     #sanity checks
     if persistent._mas_d25_spent_d25:
         return
-    if persistent.sessions is None:
-        return
-    if persistent.sessions['first_session'].date() > mas_d25: #need to make sure people who just started post d25 don't lose aff
+
+    #need to make sure people who just started post d25 don't lose aff
+    if persistent.sessions is None or persistent.sessions['first_session'].date() > mas_d25:
         return
 
 

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -1126,17 +1126,19 @@ label mas_holiday_d25c_autoload_check:
 
             else:
 
-                # we want to be wearing ponytail hair
-                monika_chr.change_hair(mas_hair_def, False)
+                #We don't want santa outfit on fresh persists, same w/ decorations. No point at this point if past d25 itself.
+                if mas_isD25Outfit():
+                    # we want to be wearing ponytail hair
+                    monika_chr.change_hair(mas_hair_def, False)
 
-                # unlock and wear santa/wine ribbon
-                store.mas_selspr.unlock_acs(mas_acs_ribbon_wine)
-                store.mas_selspr.unlock_clothes(mas_clothes_santa)
-                monika_chr.change_clothes(mas_clothes_santa, False)
-                persistent._mas_d25_seen_santa_costume = True
+                    # unlock and wear santa/wine ribbon
+                    store.mas_selspr.unlock_acs(mas_acs_ribbon_wine)
+                    store.mas_selspr.unlock_clothes(mas_clothes_santa)
+                    monika_chr.change_clothes(mas_clothes_santa, False)
+                    persistent._mas_d25_seen_santa_costume = True
 
-                # mark decorations and outfit as active
-                persistent._mas_d25_deco_active = True
+                    # mark decorations and outfit as active
+                    persistent._mas_d25_deco_active = True
 
     # NOTE: holiday intro is handled with conditional
 

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -5671,7 +5671,7 @@ init 5 python:
             category=['romance'],
             prompt="Promise Ring",
             random=True,
-            aff_range=(mas_aff.HAPPY, None)
+            aff_range=(mas_aff.ENAMORED, None)
         )
     )
 

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -6347,6 +6347,36 @@ image monika 1dkbltpa = DynamicDisplayable(
     tears="pooled"
 )
 
+image monika 1dkbltpb = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="closedsad",
+    nose="def",
+    mouth="big",
+    head="b",
+    left="1l",
+    right="1r",
+    arms="steepling",
+    blush="lines",
+    tears="pooled"
+)
+
+image monika 1dkbltuu = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="closedsad",
+    nose="def",
+    mouth="smug",
+    head="b",
+    left="1l",
+    right="1r",
+    arms="steepling",
+    blush="lines",
+    tears="up"
+)
+
 image monika 1skbltpa = DynamicDisplayable(
     mas_drawmonika,
     character=monika_chr,
@@ -6360,6 +6390,21 @@ image monika 1skbltpa = DynamicDisplayable(
     arms="steepling",
     blush="lines",
     tears="pooled"
+)
+
+image monika 1skbltda = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="sparkle",
+    nose="def",
+    mouth="smile",
+    head="b",
+    left="1l",
+    right="1r",
+    arms="steepling",
+    blush="lines",
+    tears="dried"
 )
 
 image monika 1skbla = DynamicDisplayable(
@@ -6555,6 +6600,21 @@ image monika 1ekbfb = DynamicDisplayable(
     right="1r",
     arms="steepling",
     blush="full"
+)
+
+image monika 1ekbltua = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="normal",
+    nose="def",
+    mouth="smile",
+    head="b",
+    left="1l",
+    right="1r",
+    arms="steepling",
+    blush="lines",
+    tears="up"
 )
 
 image monika 1dktub = DynamicDisplayable(
@@ -9801,6 +9861,21 @@ image monika 3hkbltpa = DynamicDisplayable(
     tears="pooled"
 )
 
+image monika 3hkbltub = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="closedhappy",
+    nose="def",
+    mouth="big",
+    head="h",
+    left="2l",
+    right="1r",
+    arms="restleftpointright",
+    blush="lines",
+    tears="up"
+)
+
 image monika 3dkbltpa = DynamicDisplayable(
     mas_drawmonika,
     character=monika_chr,
@@ -10441,6 +10516,20 @@ image monika 3subfb = DynamicDisplayable(
     blush="full"
 )
 
+image monika 3skbltda = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="knit",
+    eyes="sparkle",
+    nose="def",
+    mouth="smile",
+    head="b",
+    left="2l",
+    right="2r",
+    arms="restleftpointright",
+    blush="lines",
+    tears="dried"
+)
 
 image monika 3hubfa = DynamicDisplayable(
     mas_drawmonika,

--- a/Monika After Story/game/zz_reactions.rpy
+++ b/Monika After Story/game/zz_reactions.rpy
@@ -704,7 +704,7 @@ label mas_reaction_promisering:
             $ mas_gainAffection(modifier=5, bypass=True)
             $ monika_chr.wear_acs_pst(mas_acs_promisering)
             $ persistent._mas_acs_enable_promisering = True
-            if persistent._mas_pm_tried_gift_ring:
+            if not persistent._mas_pm_tried_gift_ring:
                 m 1wud "Is that...a..."
                 m "..."
                 m 1wka "I..."

--- a/Monika After Story/game/zz_reactions.rpy
+++ b/Monika After Story/game/zz_reactions.rpy
@@ -695,7 +695,7 @@ label mas_reaction_quetzal_plush:
 init 5 python:
     addReaction("mas_reaction_promisering", "promisering", is_good=True)
 
-default persistent._mas_pm_tried_gift_ring = False
+default persistent._mas_tried_gift_ring = False
 label mas_reaction_promisering:
     if not persistent._mas_acs_enable_promisering:
         # only available if enam+
@@ -704,7 +704,7 @@ label mas_reaction_promisering:
             $ mas_gainAffection(modifier=5, bypass=True)
             $ monika_chr.wear_acs_pst(mas_acs_promisering)
             $ persistent._mas_acs_enable_promisering = True
-            if not persistent._mas_pm_tried_gift_ring:
+            if not persistent._mas_tried_gift_ring:
                 m 1wud "Is that...a..."
                 m "..."
                 m 1wka "I..."
@@ -745,7 +745,7 @@ label mas_reaction_promisering:
                 m 3skbltda "It's just this is one of the happiest days of my life."
                 m 1skbltda "I love you so much, [player]~"
         else:  
-            if not persistent._mas_pm_tried_gift_ring:
+            if not persistent._mas_tried_gift_ring:
                 if mas_isMoniNormal(higher=True):
                     m 1wud "[player]...is that a ring?"
                     m 2rksdlb "That's such a sweet gesture, and I really appreciate it..."
@@ -766,7 +766,7 @@ label mas_reaction_promisering:
                     m "While I appreciate the thought...{w}I can't accept it right now."
                     m 2ekc "Sorry, [player]."
 
-                $ persistent._mas_pm_tried_gift_ring = True
+                $ persistent._mas_tried_gift_ring = True
             else:
                 m 2rsc "Oh...the ring..."
                 m 2rkc "I'm sorry, but I still can't accept this yet..."
@@ -777,7 +777,6 @@ label mas_reaction_promisering:
     else:
         m 1rksdlb "[player]..."
         m 1rusdlb "You already gave me a ring!"
-    
 
     $ gift_ev = mas_getEV("mas_reaction_promisering")
     $ store.mas_filereacts.delete_file(gift_ev.category)

--- a/Monika After Story/game/zz_reactions.rpy
+++ b/Monika After Story/game/zz_reactions.rpy
@@ -693,62 +693,92 @@ label mas_reaction_quetzal_plush:
     return
 
 init 5 python:
-    # only available after 6 months or if it's her birthday, may as well add valentine later
-    # TODO add dialogue for gift rejection in case the conditions below are not met
-    if mas_anni.pastSixMonths() or mas_isMonikaBirthday():
-        addReaction("mas_reaction_promisering", "promisering", is_good=True)
+    addReaction("mas_reaction_promisering", "promisering", is_good=True)
 
+default persistent._mas_pm_tried_gift_ring = False
 label mas_reaction_promisering:
     if not persistent._mas_acs_enable_promisering:
-        $ mas_receivedGift("mas_reaction_promisering")
+        # only available if enam+
         if mas_isMoniEnamored(higher=True):
+            $ mas_receivedGift("mas_reaction_promisering")
             $ mas_gainAffection(modifier=5, bypass=True)
             $ monika_chr.wear_acs_pst(mas_acs_promisering)
             $ persistent._mas_acs_enable_promisering = True
-            m 1wud "Is that...a..."
-            m "..."
-            m 1wka "I..."
-            m 1wkbltpa "I'm sorry, [player], I just..."
-            m 1dkbltpa "You might not have even meant much by it, but..."
-            m "Just in case this is a promise from you..."
-            m 3lkbltpa "Know that I’ll cherish it."
-            m 3dkbltpa "Always."
-            m 1skbltpa "This makes me so happy!"
-            if mas_isSpecialDay():
-                #TODO maybe go more in detail for this
-                m "Even more that you gave it to me on this special day..."
-            m 1dkbltpa "Aha, sorry for crying, [player]..."
-            m 1skbla "I’m just really, really happy right now."
-            m 1dkbla "Thank you."
-            m "I love you, [player]."
-            m "More than anything else in this fleeting world."
-        elif mas_isMoniNormal(higher=True):
-            $ persistent._mas_acs_enable_promisering = True
-            $ mas_gainAffection(modifier=3, bypass=True)
-            $ monika_chr.wear_acs_pst(mas_acs_promisering)
-            m 1wud "Oh... What is this, [player]?"
-            m "Is that...a ring?"
-            m 1sub " I can’t believe it, [player]!"
-            m 1hua "This...{w}means a lot to me."
-            m 3hub "This makes me so happy!"
-            m 3eub "Seriously, thank you so much for this, [player]!"
-        else:
-            $ mas_gainAffection(bypass=True)
-            m 1wud "Is that a ring?"
-            m "That's very..."
-            m "Unexpected."
-            if mas_isMoniDis(lower=True):
-                m 2rkc "I appreciate the thought...{w} But I can't accept it."
-                m 2ekc "Sorry, [player]."
-                $ persistent._mas_acs_enable_promisering = False
+            if persistent._mas_pm_tried_gift_ring:
+                m 1wud "Is that...a..."
+                m "..."
+                m 1wka "I..."
+                m 1wkbltpa "I'm sorry, [player], I just..."
+                m 1dkbltpa "...I'm so happy...{w=0.5}You just gave me your promise..."
+                m "Your promise that we'll be for each other,{w=0.1} and no one else...{w=0.3}forever..."
+                m 3lkbltpa "Know that I’ll cherish it."
+                m 3dkbltpa "Always."
+                m 1skbltpa "This makes me so happy!"
+
+                if mas_anni.isAnniOneMonth():
+                    m "Even more that you gave it to me on our one month anniversary..."
+                    m 1ekbltua "You must really love me..."
+                elif mas_anni.isAnniThreeMonth():
+                    m "Even more that you gave it to me on our three month anniversary..."
+                    m 1ekbltua "You must really love me..."
+                elif mas_anni.isAnniSixMonth():
+                    m "Even more that you gave it to me on our six month anniversary..."
+                    m 1ekbltua "You must really love me..."
+                elif mas_anni.isAnni():
+                    m "Even more that you gave it to me on our anniversary..."
+                    m 1ekbltua "You must really love me..."
+                elif mas_isSpecialDay():
+                    m "Even more that you gave it to me on this special day..."
+
+                m 1dkbltpb "Aha, sorry for crying, [player]..."
+                m 1skbltda "I’m just really, really happy right now."
+                m 1dkbla "Thank you."
+                m "I love you, [player]."
+                m "More than anything else in this fleeting world."
             else:
-                $ monika_chr.wear_acs_pst(mas_acs_promisering)
-                $ persistent._mas_acs_enable_promisering = True
-                m 3hua "I'm happily surprised by this, [player]."
-                m "Thanks."
+                m 1sua "Oh...it's the ring!"
+                m 3hub "Thank you so much, [player]!"
+                m 1skbla "I know now that you really do love me and want to be with me forever..."
+                m 1skbltpa "So I'll gladly accept this ring as a symbol of that promise."
+                m 1dkbltuu "..."
+                m 3hkbltub "Aha, sorry, [player], I didn't mean to cry..."
+                m 3skbltda "It's just this is one of the happiest days of my life."
+                m 1skbltda "I love you so much, [player]~"
+        else:  
+            if not persistent._mas_pm_tried_gift_ring:
+                if mas_isMoniNormal(higher=True):
+                    m 1wud "[player]...is that a ring?"
+                    m 2rksdlb "That's such a sweet gesture, and I really appreciate it..."
+                    m 2ekc "But I want you to be sure before you give me this..."
+                    m 3ekd "This is more than a gift, it's a promise, and I want to make sure you truly mean it before I can accept it."
+                    m 2ekd "So, please, just wait until we're a little further into our relationship, [player], and then I'll glady accept this ring."
+
+                elif mas_isMoniUpset():
+                    m 1wud "Is that a ring?"
+                    m 2rsc "That's very..."
+                    m 2esc "Unexpected."
+                    m 2ekd "But I can't accept it right now, [player]."
+                    m 2ekc "Maybe when we get further in our relationship."
+
+                else:
+                    m 2wud "Is that a ring?"
+                    m 2rsc "That's...unexpected."
+                    m "While I appreciate the thought...{w}I can't accept it right now."
+                    m 2ekc "Sorry, [player]."
+
+                $ persistent._mas_pm_tried_gift_ring = True
+            else:
+                m 2rsc "Oh...the ring..."
+                m 2rkc "I'm sorry, but I still can't accept this yet..."
+                m 2ekc "I need to be completely sure when I accept this that it means forever..."
+                m 2ekd "That you really are everything I hope you are."
+                m 2dsd "When I know that, I will happily accept your ring, [player]."
+            $ persistent._mas_acs_enable_promisering = False
     else:
         m 1rksdlb "[player]..."
         m 1rusdlb "You already gave me a ring!"
+    
+
     $ gift_ev = mas_getEV("mas_reaction_promisering")
     $ store.mas_filereacts.delete_file(gift_ev.category)
     return
@@ -1106,19 +1136,9 @@ label mas_reaction_candycane:
     $ persistent._mas_filereacts_reacted_map.pop(gift_ev.category,None)
     return
 
-# ribbon logic specific
-# this one stores the last date object when a ribbon was gifted
-# defaults to None and is used to prevent players from giving more than 3
-# ribbons per special day
-default persistent._mas_last_gifted_ribbon_date = None
-
-# stores the number of ribbons given in this day, it resets once the last gifted
-# ribbon date changes
-default persistent._mas_current_gifted_ribbons = 0
-
+#Ribbon stuffs
 init 5 python:
-    if mas_isSpecialDay():
-        addReaction("mas_reaction_blackribbon", "blackribbon", is_good=True)
+    addReaction("mas_reaction_blackribbon", "blackribbon", is_good=True)
 
 label mas_reaction_blackribbon:
     $ _mas_new_ribbon_color = "black"
@@ -1127,8 +1147,7 @@ label mas_reaction_blackribbon:
     return
 
 init 5 python:
-    if mas_isSpecialDay():
-        addReaction("mas_reaction_blueribbon", "blueribbon", is_good=True)
+    addReaction("mas_reaction_blueribbon", "blueribbon", is_good=True)
 
 label mas_reaction_blueribbon:
     $ _mas_new_ribbon_color = "blue"
@@ -1137,8 +1156,7 @@ label mas_reaction_blueribbon:
     return
 
 init 5 python:
-    if mas_isSpecialDay():
-        addReaction("mas_reaction_darkpurpleribbon", "darkpurpleribbon", is_good=True)
+    addReaction("mas_reaction_darkpurpleribbon", "darkpurpleribbon", is_good=True)
 
 label mas_reaction_darkpurpleribbon:
     $ _mas_new_ribbon_color = "dark purple"
@@ -1147,8 +1165,7 @@ label mas_reaction_darkpurpleribbon:
     return
 
 init 5 python:
-    if mas_isSpecialDay():
-        addReaction("mas_reaction_grayribbon", "grayribbon", is_good=True)
+    addReaction("mas_reaction_grayribbon", "grayribbon", is_good=True)
 
 label mas_reaction_grayribbon:
     $ _mas_new_ribbon_color = "gray"
@@ -1157,8 +1174,7 @@ label mas_reaction_grayribbon:
     return
 
 init 5 python:
-    if mas_isSpecialDay():
-        addReaction("mas_reaction_greenribbon", "greenribbon", is_good=True)
+    addReaction("mas_reaction_greenribbon", "greenribbon", is_good=True)
 
 label mas_reaction_greenribbon:
     $ _mas_new_ribbon_color = "green"
@@ -1167,8 +1183,7 @@ label mas_reaction_greenribbon:
     return
 
 init 5 python:
-    if mas_isSpecialDay():
-        addReaction("mas_reaction_lightpurpleribbon", "lightpurpleribbon", is_good=True)
+    addReaction("mas_reaction_lightpurpleribbon", "lightpurpleribbon", is_good=True)
 
 label mas_reaction_lightpurpleribbon:
     $ _mas_new_ribbon_color = "light purple"
@@ -1177,8 +1192,7 @@ label mas_reaction_lightpurpleribbon:
     return
 
 init 5 python:
-    if mas_isSpecialDay():
-        addReaction("mas_reaction_peachribbon", "peachribbon", is_good=True)
+    addReaction("mas_reaction_peachribbon", "peachribbon", is_good=True)
 
 label mas_reaction_peachribbon:
     $ _mas_new_ribbon_color = "peach"
@@ -1187,8 +1201,7 @@ label mas_reaction_peachribbon:
     return
 
 init 5 python:
-    if mas_isSpecialDay():
-        addReaction("mas_reaction_pinkribbon", "pinkribbon", is_good=True)
+    addReaction("mas_reaction_pinkribbon", "pinkribbon", is_good=True)
 
 label mas_reaction_pinkribbon:
     $ _mas_new_ribbon_color = "pink"
@@ -1197,8 +1210,7 @@ label mas_reaction_pinkribbon:
     return
 
 init 5 python:
-    if mas_isSpecialDay():
-        addReaction("mas_reaction_redribbon", "redribbon", is_good=True)
+    addReaction("mas_reaction_redribbon", "redribbon", is_good=True)
 
 label mas_reaction_redribbon:
     $ _mas_new_ribbon_color = "red"
@@ -1207,8 +1219,7 @@ label mas_reaction_redribbon:
     return
 
 init 5 python:
-    if mas_isSpecialDay():
-        addReaction("mas_reaction_tealribbon", "tealribbon", is_good=True)
+    addReaction("mas_reaction_tealribbon", "tealribbon", is_good=True)
 
 label mas_reaction_tealribbon:
     $ _mas_new_ribbon_color = "teal"
@@ -1217,8 +1228,7 @@ label mas_reaction_tealribbon:
     return
 
 init 5 python:
-    if mas_isSpecialDay():
-        addReaction("mas_reaction_yellowribbon", "yellowribbon", is_good=True)
+    addReaction("mas_reaction_yellowribbon", "yellowribbon", is_good=True)
 
 label mas_reaction_yellowribbon:
     $ _mas_new_ribbon_color = "yellow"
@@ -1226,24 +1236,16 @@ label mas_reaction_yellowribbon:
     call _mas_reaction_ribbon_helper("mas_reaction_yellowribbon")
     return
 
-label _mas_reaction_ribbon_helper(label):
-    $ _today = datetime.date.today()
-    # should we reset?
-    if persistent._mas_last_gifted_ribbon_date != _today:
-        $ persistent._mas_current_gifted_ribbons = 0
-        $ persistent._mas_last_gifted_ribbon_date = _today
+#specific to this, since we need to verify if the player actually gave a ribbon.
+default persistent._mas_current_gifted_ribbons = 0
 
-    # check how many ribbons we got today, if we received 3 we decline the gift
-    if persistent._mas_current_gifted_ribbons > 2:
-        call mas_reaction_no_more_ribbons
-    # otherwise we check if we already have that one
-    elif store.mas_selspr.get_sel_acs(_mas_gifted_ribbon_acs).unlocked:
+label _mas_reaction_ribbon_helper(label):
+    #if we already have that ribbon
+    if store.mas_selspr.get_sel_acs(_mas_gifted_ribbon_acs).unlocked:
         call mas_reaction_old_ribbon
     else:
         # since we don't have it we can accept it
         call mas_reaction_new_ribbon
-        # add it to our counter
-        $ persistent._mas_current_gifted_ribbons += 1
         #unlock the ribbon selector
         $ store.mas_unlockEVL("monika_ribbon_select", "EVE")
     # normal gift processing
@@ -1256,7 +1258,12 @@ label _mas_reaction_ribbon_helper(label):
 
 label mas_reaction_new_ribbon:
     if persistent._mas_current_gifted_ribbons == 0:
-        $ mas_gainAffection(15, bypass=True)
+
+        if mas_isSpecialDay():
+            $ mas_gainAffection(15, bypass=True)
+        else:
+            $ mas_gainAffection()
+
         m 1suo "A new ribbon!"
         m 3hub "...And it's [_mas_new_ribbon_color]!"
 
@@ -1287,7 +1294,11 @@ label mas_reaction_new_ribbon:
         m 3hua "Thanks again~"
 
     else:
-        $ mas_gainAffection(10, bypass=True)
+        if mas_isSpecialDay():
+            $ mas_gainAffection(10, bypass=True)
+        else:
+            $ mas_gainAffection()
+
         m 1suo "Another ribbon!"
         m 3hub "...And this time it's [_mas_new_ribbon_color]!"
 
@@ -1306,10 +1317,4 @@ label mas_reaction_new_ribbon:
 label mas_reaction_old_ribbon:
     m 1rksdlb "[player]..."
     m 1rusdlb "You already gave me a [_mas_new_ribbon_color] ribbon!"
-    return
-
-label mas_reaction_no_more_ribbons:
-    m 1rksdla "[player]..."
-    m 1eksdla "You've already given me so many ribbons today!"
-    m 3eka "Let's save that one for another occasion, alright?"
     return


### PR DESCRIPTION
Promisering is now available at enamored+, ribbons are an always thing, however affection gained from them is different if on a special day. This also has new dlg for these bits too/amended dlg to existing bits.

Regarding special day:
the addition of monthly anniversaries (ie. the first year monthlies, 1mo, 3mo, 6mo. [not 1week]) and also NYE.

Other fixes include a sanity check on the notimespent for d25, as it'd still trigger if you started MAS within the 7 day period that notimespent would be pushed. (Note: this needs to be fixed for subsequent years as the event doesn't push itself). As well, issue on fresh persists post d25 is that Monika would be all dressed up in santa outfit, even though she doesn't wear it post d25 normally (returns to uni after this). Added condition for these so that they'll only happen for the Santa outfit period.