### PR TITLE
Added Key-centric history lookup functions and preparations for mhs migration

### DIFF
--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -76,6 +76,8 @@ init -810 python:
     store.mas_history.addMHS(MASHistorySaver(
         "o31",
         datetime.datetime(2018, 11, 2),
+        # change trigger to better date
+#        datetime.datetime(2020, 1, 6),
         {
             "_mas_o31_current_costume": "o31.costume.was_worn",
             "_mas_o31_costume_greeting_seen": "o31.costume.greeting.seen",

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -298,6 +298,14 @@ label v0_3_1(version=version): # 0.3.1
 #   without conditionals and start_date
 #   We will save this for versiojn 0812 or 9
 
+# 0.8.13 ?
+label v0_8_13(version="v0_8_13"):
+    python:
+        pass
+
+
+    return
+
 # 0.8.11
 label v0_8_11(version="v0_8_11"):
     python:

--- a/Monika After Story/game/updates_topics.rpy
+++ b/Monika After Story/game/updates_topics.rpy
@@ -68,6 +68,7 @@ label vv_updates_topics:
 
         # versions
         # use the v#_#_# notation so we can work with labels
+        vv0_8_13 = "v0_8_13"
         vv0_8_12 = "v0_8_12"
         vv0_8_11 = "v0_8_11"
         vv0_8_10 = "v0_8_10"
@@ -102,6 +103,8 @@ label vv_updates_topics:
         # update this dict accordingly to every new version
         # k:old version number -> v:new version number
         # some version changes skip some numbers because no major updates
+#        updates.version_updates[vv0_8_12] = vv0_8_13
+#        updates.version_updates[vv0_8_11] = vv0_8_13
         updates.version_updates[vv0_8_10] = vv0_8_11
         updates.version_updates[vv0_8_9] = vv0_8_10
         updates.version_updates[vv0_8_8] = vv0_8_9

--- a/Monika After Story/game/zz_history.rpy
+++ b/Monika After Story/game/zz_history.rpy
@@ -175,6 +175,25 @@ init -860 python in mas_history:
         return found_data
 
 
+    def verify(key, _verify, years_list):
+        """
+        Internali version of mas_HistVerify
+        """
+        if len(years_list) == 0:
+            years_list = range(2017, datetime.date.today().year+1)
+
+        found_data = lookup_otl(key, years_list)
+        years_found = []
+
+        for year, data_tuple in found_data.iteritems():
+            status, _data = data_tuple
+            
+            if status == L_FOUND and _data == _verify:
+                years_found.append(year)
+
+        return (len(years_found) > 0, years_found)
+
+
     ### archive saving functions: (NOT PUBLIC)
     def _store(value, key, year):
         """
@@ -260,6 +279,20 @@ init -850 python:
         return store.mas_history.lookup(key, year)
 
 
+    def mas_HistLookup_k(year, *keys):
+        """
+        Looks up data in the historical archives
+        NOTE: this accepts keys as string pieces that are put together
+
+        IN:
+            year - year to look up data
+            keys - string pieces of a key to search for
+
+        RETURNS: same as mas_HistLookup
+        """
+        return store.mas_history.lookup(".".join(keys), year)
+
+
     def mas_HistLookup_ot(key, *years):
         """
         Looks up data overtime in the historical archives.
@@ -288,6 +321,19 @@ init -850 python:
         return store.mas_history.lookup_otl(key, years_list)
 
 
+    def mas_HistLookup_otl_k(years_list, *keys):
+        """
+        Looks up data overtime in the historical archives
+
+        IN:
+            years_list - list of years to lookup data
+            *keys - string pieces of a key to search for
+
+        RETURNS: See mas_HistLookup_otl
+        """
+        return store.mas_history.lookup_otl(".".join(keys), years_list)
+
+
     def mas_HistVerify(key, _verify, *years):
         """
         Verifies if data at the given key matches the verification value.
@@ -303,19 +349,23 @@ init -850 python:
             [0]: true/False if we found data that matched the verification
             [1]: list of years that matched the verification
         """
-        if len(years) == 0:
-            years = range(2017, datetime.date.today().year+1)
+        return store.mas_history.verify(key, _verify, years)
 
-        found_data = mas_HistLookup_otl(key, years)
-        years_found = []
 
-        for year, data_tuple in found_data.iteritems():
-            status, _data = data_tuple
-            
-            if status == store.mas_history.L_FOUND and _data == _verify:
-                years_found.append(year)
+    def mas_HistVerify_k(years_list, _verify, *keys):
+        """
+        Verifies if data at the given key matches the verification value.
 
-        return (len(years_found) > 0, years_found)
+        IN:
+            years_list - list of years to look up data (as args)
+                Pass an empty list if you want to lookup all years since
+                2017.
+            _verify - the data we want to match to
+            *keys - string pieces of a key to search for
+
+        RETURNS: see mas_HistVerify
+        """
+        return store.mas_history.verify(".".join(keys), _verify, years_list)
 
 
     ## MASHistorySaver stuff
@@ -467,8 +517,13 @@ init -850 python:
             IN:
                 data_tuple - tuple of the following format:
                     [0]: datetime to set the trigger property
+                    [1]: use_year_before 
+                        - check for existence before loading
             """
             self.setTrigger(data_tuple[0])
+            
+            if len(data_tuple) > 1:
+                self.use_year_before = data_tuple[1]
 
 
         def setTrigger(self, _trigger):
@@ -554,8 +609,10 @@ init -850 python:
 
             RETURNS tuple of the following format:
                 [0]: trigger - the trigger property of this object
+                [1]: use_year_before - the use_year_before property of this obj
+                    NOTE: needed for ease of migrations
             """
-            return (self.trigger,)
+            return (self.trigger, self.use_year_before)
 
 
 init -800 python in mas_history:
@@ -784,6 +841,8 @@ init -810 python:
     store.mas_history.addMHS(MASHistorySaver(
         "922",
         datetime.datetime(2018, 9, 30),
+        # TODO: change trigger to bette rdate
+#        datetime.datetime(2020, 1, 6), 
         {
             "_mas_bday_opened_game": "922.actions.opened_game",
             "_mas_bday_no_time_spent": "922.actions.no_time_spent",


### PR DESCRIPTION
Mainly adds key-centric functions, where you can pass in string keys as args instead of a giant string. Might be useful in the future.

### New funs:
* `mas_HistLookup_k` - key-centric version of `mas_HistLookup` 
* `mas_HistLookup_otl_k` - key-centric version of `mas_HistLookup_otl`
* `mas_HistVerify_k` - key-centric version of `mas_HistVerify`

How to use these functions and how they compare to the non-key versions
```python
mas_HistLookup("922.actions.surprise.found_cake", 2018)
mas_HistLookup_k(2018, "922", "actions", "surprise", "found_cake")

mas_HistLookup_otl("922.actions.surprise.found_cake", [2017, 2018])
mas_HistLookup_otl_k([2017, 2018], "922", "actions", "surprise", "found_cake")

mas_HistVerify("922.actions.surprise.found_cake", True)
mas_HistVerify_k([], True, "922", "actions", "surprise", "found_cake")
```

### MHS
MHS data now saves `use_year_before` property, in anticpation of migration.

# Testing

## new funs
* Verify that the key-centric functions retrieve correct data (you can check them against the non-key centric versions)

## mhs
1. launch game
2. close game
3. relaunch game
4. check `persistent._mas_history_mhs_data`, each entry should be a tuple with a datetime and a bool.

**NOTE:** this is on content because history stuff is used by topics