### PR TITLE
event startdate/endate fix

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -380,11 +380,15 @@ python early:
                     # if we are dealing with start/end dates, we need to
                     #   ensure that they are datetimes
                     if name == "start_date" or name == "end_date":
-                        if isinstance(value, datetime.date):
+                        if type(value) is datetime.date:
                             value = datetime.datetime.combine(
                                 value,
                                 datetime.time.min
                             )
+
+                        # nullify bad date types
+                        if type(value) is not datetime.datetime:
+                            value = None
 
                     # otherwise, repack the tuples
                     data_row = list(data_row)

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -302,6 +302,7 @@ label v0_3_1(version=version): # 0.3.1
 label v0_8_13(version="v0_8_13"):
     python:
         pass
+        # TODO: redo start/end dates for all affected events
 
 
     return

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -298,12 +298,78 @@ label v0_3_1(version=version): # 0.3.1
 #   without conditionals and start_date
 #   We will save this for versiojn 0812 or 9
 
-# 0.8.13 ?
+# 0.8.13
 label v0_8_13(version="v0_8_13"):
     python:
-        pass
         # TODO: redo start/end dates for all affected events
 
+        ## start date and end date fixes
+        d25_sp_tm = mas_getEV("mas_d25_spent_time_monika")
+        if d25_sp_tm is not None:
+            if (
+                    d25_sp_tm.start_date.hour != 20
+                    or d25_sp_tm.end_date.hour != 1
+                ):
+                d25_sp_tm.start_date = datetime.datetime.combine(
+                    mas_d25,
+                    datetime.time(hour=20)
+                )
+
+                d25_sp_tim.end_date = datetime.datetime.combine(
+                    mas_d25p,
+                    datetime.time(hour=1)
+                )
+
+                Event._verifyAndSetDatesEV(d25_sp_tm)
+
+        d25_ce = mas_getEV("mas_d25_monika_christmas_eve")
+        if d25_ce is not None:
+            if d25_ce.start_date.hour != 20:
+                d25_ce.start_date = datetime.datetime.combine(
+                    mas_d25e,
+                    datetime.time(hour=20)
+                )
+
+                d25_ce.end_date = mas_d25
+
+                Event._verifyAndSetDatesEV(d25_ce)
+
+        nye_re = mas_getEV("monika_nye_year_review")
+        if nye_re is not None:
+            if (
+                    nye_re.start_date.hour != 19
+                    or nye_re.end_date.hour != 23
+                ):
+                nye_re.start_date = datetime.datetime.combine(
+                    mas_nye,
+                    datetime.time(hour=19)
+                )
+
+                nye_re.end_date = datetime.datetime.combine(
+                    mas_nye,
+                    datetime.time(hour=23)
+                )
+
+                Event._verifyAndSetDatesEV(nye_re)
+
+
+        bday_sp = mas_getEV("mas_bday_spent_time_with")
+        if bday_sp is not None:
+            if (
+                    bday_sp.start_date.hour != 22
+                    or bday_sp.end_date.hour != 23
+                ):
+                bday_sp.start_date = datetime.datetime.combine(
+                    mas_monika_birthday,
+                    datetime.time(hour=22)
+                )
+
+                bday_sp.end_date = datetime.datetime.combine(
+                    mas_monika_birthday,
+                    datetime.time(hour=23, minute=59)
+                )
+
+                Event._verifyAndSetDatesEV(bday_sp)
 
     return
 

--- a/Monika After Story/game/updates_topics.rpy
+++ b/Monika After Story/game/updates_topics.rpy
@@ -103,8 +103,8 @@ label vv_updates_topics:
         # update this dict accordingly to every new version
         # k:old version number -> v:new version number
         # some version changes skip some numbers because no major updates
-#        updates.version_updates[vv0_8_12] = vv0_8_13
-#        updates.version_updates[vv0_8_11] = vv0_8_13
+        updates.version_updates[vv0_8_12] = vv0_8_13
+        updates.version_updates[vv0_8_11] = vv0_8_13
         updates.version_updates[vv0_8_10] = vv0_8_11
         updates.version_updates[vv0_8_9] = vv0_8_10
         updates.version_updates[vv0_8_8] = vv0_8_9


### PR DESCRIPTION
change version in `options.rpy` to trigger the update.

Verify that the following events have valid `start_date`/`end_date`:
* `mas_d25_spent_time_monika`
* `monika_nye_year_review`
* `mas_d25_monika_christmas_eve`
* `mas_bday_spent_time_with`

Valid means:
* if the event has not passed yet, the dates are this year
* if the event has already passed, the dates are next year
* if the event is currently ongoing, the dates would not be changed until the event has triggered. 

If using a persistent from before version 0.8.12, the dates should not be changed at all.