### PR TITLE
Fix Typo - Going Somewhere when Upset (+Recommendations)

### DIFF
--- a/Monika After Story/game/script-farewells.rpy
+++ b/Monika After Story/game/script-farewells.rpy
@@ -931,7 +931,7 @@ label bye_going_somewhere:
         # otherwise we go
         m 1wud "You really want to bring me along?"
         m 1eka "..."
-        m 1hua "Well, I suposed it can't hurt to join you."
+        m 1hua "Well, I suppose it can't hurt to join you."
         m 2dsc "Just...please."
         m 2rkc "{i}Please{/i} understand what I'm going through."
         m 1dkc "..."


### PR DESCRIPTION
Hey, someone on discord found this one. It might have been seen but just to be safe here!
(let me know if I need to credit them, I can find that)

Farewells -> going to take you somewhere -> upset response
"suposed" to be "suppose"


I am also wondering if what I suggested here #2903 to be added, of adding that to the start of the farewell on the same line. (I don't know if it would possible on this pull request since the typo fix is on enhancement). I am willing to do this change, making a new pull if needed. 
To reactivate seems simple enough with the additional dialogue, and I can put updated starting rules to match the others. 
I'm wondering if moving this one up with the other goodbye farewells should be done too, if there isn't an issue with that (would move it to about line 295, as I can see an extra line in "bye_take_care" right above it that probably isn't needed, which I'd be happy to fix too!).