### PR TITLE
Smooth zoom

### DIFF
--- a/Monika After Story/game/dev/dev_zoom_transition.rpy
+++ b/Monika After Story/game/dev/dev_zoom_transition.rpy
@@ -13,12 +13,7 @@ init 5 python:
 
 label dev_mas_max_zoom:
     m 1esa "Testing transition"
-    call monika_zoom_transition(new_zoom=2.1)
-    # call expression "monika_zoom_transition" pass (new_zoom=2.1)
-    #$ renpy.call_in_new_context("monika_zoom_transition", new_zoom=2.1)
-    #pause 3.0
-    # $ renpy.call("monika_zoom_transition",new_zoom=2.1)
-    #jump dev_transition_test_max
+    call monika_zoom_transition(new_zoom=20)
     m 1esd "Finished transition"
     return
 
@@ -36,18 +31,6 @@ init 5 python:
 
 label dev_mas_min_zoom:
     m 1esa "Testing transition"
-    call monika_zoom_transition(new_zoom=1.1)
-    # call expression "monika_zoom_transition" pass (new_zoom=1.1)
-    #$ renpy.call_in_new_context("monika_zoom_transition", new_zoom=1.1)
-    # $ renpy.restart_interaction()
-    #pause 3.0
-    # $ renpy.call("monika_zoom_transition",new_zoom=1.1)
-    #jump dev_transition_test_min
+    call monika_zoom_transition(new_zoom=0)
     m 1esd "Finished transition"
     return
-
-label dev_transition_test_min:
-    call monika_zoom_transition(new_zoom=1.1)
-
-label dev_transition_test_max:
-    call monika_zoom_transition(new_zoom=2.1)

--- a/Monika After Story/game/dev/dev_zoom_transition.rpy
+++ b/Monika After Story/game/dev/dev_zoom_transition.rpy
@@ -1,0 +1,53 @@
+# test zoom transitions
+init 5 python:
+    addEvent(
+        Event(
+            persistent.event_database,
+            eventlabel="dev_mas_max_zoom",
+            category=["dev"],
+            prompt="TEST TRANSITION MAX ZOOM",
+            pool=True,
+            unlocked=True
+        )
+    )
+
+label dev_mas_max_zoom:
+    m 1esa "Testing transition"
+    call monika_zoom_transition(new_zoom=2.1)
+    # call expression "monika_zoom_transition" pass (new_zoom=2.1)
+    #$ renpy.call_in_new_context("monika_zoom_transition", new_zoom=2.1)
+    #pause 3.0
+    # $ renpy.call("monika_zoom_transition",new_zoom=2.1)
+    #jump dev_transition_test_max
+    m 1esd "Finished transition"
+    return
+
+init 5 python:
+    addEvent(
+        Event(
+            persistent.event_database,
+            eventlabel="dev_mas_min_zoom",
+            category=["dev"],
+            prompt="TEST TRANSITION MIN ZOOM",
+            pool=True,
+            unlocked=True
+        )
+    )
+
+label dev_mas_min_zoom:
+    m 1esa "Testing transition"
+    call monika_zoom_transition(new_zoom=1.1)
+    # call expression "monika_zoom_transition" pass (new_zoom=1.1)
+    #$ renpy.call_in_new_context("monika_zoom_transition", new_zoom=1.1)
+    # $ renpy.restart_interaction()
+    #pause 3.0
+    # $ renpy.call("monika_zoom_transition",new_zoom=1.1)
+    #jump dev_transition_test_min
+    m 1esd "Finished transition"
+    return
+
+label dev_transition_test_min:
+    call monika_zoom_transition(new_zoom=1.1)
+
+label dev_transition_test_max:
+    call monika_zoom_transition(new_zoom=2.1)

--- a/Monika After Story/game/special-effects.rpy
+++ b/Monika After Story/game/special-effects.rpy
@@ -175,10 +175,12 @@ label monika_kissing_motion(transition=5.0, duration=2.0, hide_ui=True):
 # Used to transition from any valid zoom value to another valid
 # zoom valid zoom value in a smooth way
 # IN:
-#     new_zoom - the new zoom level to move to
+#     new_zoom - the new zoom value to move to
 #     transition - the time in seconds used to transition to the new zoom level
 #         (Default: 5.0)
-label monika_zoom_transition(new_zoom,transition=3.0):
+label monika_zoom_value_transition(new_zoom,transition=3.0):
+    if new_zoom == mas_sprites.value_zoom:
+        return
     # Sanity checks
     if new_zoom > 2.1:
         $ new_zoom = 2.1
@@ -202,7 +204,55 @@ label monika_zoom_transition(new_zoom,transition=3.0):
 
     # calculate and store the differences between new and old values
     $ _mas_zoom_diff = _mas_new_zoom - _mas_old_zoom
-    $ _mas_zoom_level_diff = new_zoom - _mas_old_zoom_value
+    $ _mas_zoom_value_diff = new_zoom - _mas_old_zoom_value
+    $ _mas_zoom_y_diff = _mas_new_y - _mas_old_y
+    # do the transition and pause so it force waits for the transition to end
+    show monika at mas_smooth_transition
+    pause transition
+    return
+
+# Zoom Transition label #2
+# Used to transition from any valid zoom value to another valid
+# zoom valid zoom value in a smooth way
+# IN:
+#     new_zoom - the new zoom level to move to
+#     transition - the time in seconds used to transition to the new zoom level
+#         (Default: 5.0)
+label monika_zoom_transition(new_zoom,transition=3.0):
+    # Sanity checks
+    if new_zoom == mas_sprites.zoom_level:
+        return
+    if new_zoom > 20:
+        $ new_zoom = 20
+    elif new_zoom < 0:
+        $ new_zoom = 0
+    # store the time the transition will take
+    $ _mas_transition_time = transition
+
+    # store the old values
+    $ _mas_old_zoom = mas_sprites.zoom_level
+    $ _mas_old_zoom_value = mas_sprites.value_zoom
+    $ _mas_old_y = mas_sprites.adjust_y
+
+    # calculate and store the new values
+    if new_zoom > mas_sprites.default_zoom_level:
+        $ _mas_new_y = mas_sprites.default_y + (
+            (new_zoom - mas_sprites.default_zoom_level) * mas_sprites.y_step
+        )
+        $ _mas_new_zoom_value = mas_sprites.default_value_zoom + (
+            (new_zoom - mas_sprites.default_zoom_level) * mas_sprites.zoom_step
+        )
+    else:
+        $ _mas_new_y = mas_sprites.default_y
+        if new_zoom == mas_sprites.default_zoom_level:
+            $ _mas_new_zoom_value = mas_sprites.default_value_zoom
+        else:
+            $ _mas_new_zoom_value = mas_sprites.default_value_zoom - (
+                (mas_sprites.default_zoom_level - new_zoom) * mas_sprites.zoom_step
+            )
+    # calculate and store the differences between new and old values
+    $ _mas_zoom_diff = new_zoom - _mas_old_zoom
+    $ _mas_zoom_value_diff = _mas_new_zoom_value - _mas_old_zoom_value
     $ _mas_zoom_y_diff = _mas_new_y - _mas_old_y
     # do the transition and pause so it force waits for the transition to end
     show monika at mas_smooth_transition
@@ -219,8 +269,8 @@ init python:
             _mas_old_zoom - containing the old zoom
             _mas_old_zoom_value - containing the old zoom value
             _mas_old_y - containing the old y value
-            _mas_zoom_diff - containing the difference between the old and new zoom
-            _mas_zoom_level_diff - containing the difference between the old and new zoom levels
+            _mas_zoom_diff - containing the difference between the old and new zoom levels
+            _mas_zoom_value_diff - containing the difference between the old and new zoom values
             _mas_zoom_y_diff - containing the difference between the old and new y values
         """
         # check if the transition time is lower than the elapsed time
@@ -228,7 +278,7 @@ init python:
             # do some calcs
             step = st / _mas_transition_time
             mas_sprites.zoom_level = _mas_old_zoom + (step * _mas_zoom_diff)
-            mas_sprites.value_zoom = _mas_old_zoom_value + (step * _mas_zoom_level_diff)
+            mas_sprites.value_zoom = _mas_old_zoom_value + (step * _mas_zoom_value_diff)
             mas_sprites.adjust_y = int(_mas_old_y + (step * _mas_zoom_y_diff))
             if mas_sprites.adjust_y < mas_sprites.default_y:
                 mas_sprites.adjust_y = mas_sprites.default_y

--- a/Monika After Story/game/special-effects.rpy
+++ b/Monika After Story/game/special-effects.rpy
@@ -113,14 +113,6 @@ transform fade_in(time=1.0):
     alpha 0.0
     ease time alpha 1.0
 
-init python:
-    def zoom_smoothly(trans, st, at):
-        if trans.y < _mas_current_kiss_y:
-            trans.y = 50
-        if trans.zoom < _mas_current_kiss_zoom:
-            trans.zoom = 50
-        return 0
-
 # kissing animation transform
 transform mas_kissing(_zoom, _y,time=2.0):
     i11
@@ -149,7 +141,7 @@ label monika_kissing_motion(transition=5.0, duration=2.0, hide_ui=True):
     $ _mas_kiss_zoom = 4.9 / mas_sprites.value_zoom
     $ _mas_kiss_y = 2060 - ( 1700  * (mas_sprites.value_zoom - 1.1))
     $ _mas_kiss_y2 = -1320 + (1700 * (mas_sprites.value_zoom - 1.1))
-    # 380 #correct value for max
+
     # start the kiss animation
     show monika 6dubfd at mas_kissing(_mas_kiss_zoom,int(_mas_kiss_y),transition)
     # wait until we're done with the animation
@@ -178,3 +170,81 @@ label monika_kissing_motion(transition=5.0, duration=2.0, hide_ui=True):
         $ HKBShowButtons()
     window auto
     return
+
+# Zoom Transition label
+# Used to transition from any valid zoom value to another valid
+# zoom valid zoom value in a smooth way
+# IN:
+#     new_zoom - the new zoom level to move to
+#     transition - the time in seconds used to transition to the new zoom level
+#         (Default: 5.0)
+label monika_zoom_transition(new_zoom,transition=3.0):
+    # Sanity checks
+    if new_zoom > 2.1:
+        $ new_zoom = 2.1
+    elif new_zoom < 1.1:
+        $ new_zoom = 1.1
+    # store the time the transition will take
+    $ _mas_transition_time = transition
+
+    # store the old values
+    $ _mas_old_zoom = mas_sprites.zoom_level
+    $ _mas_old_zoom_value = mas_sprites.value_zoom
+    $ _mas_old_y = mas_sprites.adjust_y
+
+    # calculate and store the new values
+    $ _mas_new_zoom = ((new_zoom - mas_sprites.default_value_zoom) / mas_sprites.zoom_step ) + mas_sprites.default_zoom_level
+    if _mas_new_zoom > mas_sprites.default_value_zoom:
+        $ _mas_new_y = mas_sprites.default_y + ((_mas_new_zoom-mas_sprites.default_zoom_level) * mas_sprites.y_step)
+    else:
+        $ _mas_new_y = mas_sprites.default_y
+    $ _mas_new_zoom = ((new_zoom - mas_sprites.default_value_zoom) / mas_sprites.zoom_step ) + mas_sprites.default_zoom_level
+
+    # calculate and store the differences between new and old values
+    $ _mas_zoom_diff = _mas_new_zoom - _mas_old_zoom
+    $ _mas_zoom_level_diff = new_zoom - _mas_old_zoom_value
+    $ _mas_zoom_y_diff = _mas_new_y - _mas_old_y
+    # do the transition and pause so it force waits for the transition to end
+    show monika at mas_smooth_transition
+    pause transition
+    return
+
+init python:
+    def zoom_smoothly(trans, st, at):
+        """
+        Transition function used in mas_smooth_transition
+        takes the standard parameters on functions used on transforms
+        see https://www.renpy.org/doc/html/atl.html#function-statement
+        ASSUMES:
+            _mas_old_zoom - containing the old zoom
+            _mas_old_zoom_value - containing the old zoom value
+            _mas_old_y - containing the old y value
+            _mas_zoom_diff - containing the difference between the old and new zoom
+            _mas_zoom_level_diff - containing the difference between the old and new zoom levels
+            _mas_zoom_y_diff - containing the difference between the old and new y values
+        """
+        # check if the transition time is lower than the elapsed time
+        if _mas_transition_time > st:
+            # do some calcs
+            step = st / _mas_transition_time
+            mas_sprites.zoom_level = _mas_old_zoom + (step * _mas_zoom_diff)
+            mas_sprites.value_zoom = _mas_old_zoom_value + (step * _mas_zoom_level_diff)
+            mas_sprites.adjust_y = int(_mas_old_y + (step * _mas_zoom_y_diff))
+            if mas_sprites.adjust_y < mas_sprites.default_y:
+                mas_sprites.adjust_y = mas_sprites.default_y
+
+            renpy.restart_interaction()
+            # to be called as soon as possible we return 0
+            return 0.1
+        else:
+            # get the zoom level and call adjust zoom to be sure it works
+            mas_sprites.zoom_level = int(round(mas_sprites.zoom_level))
+            mas_sprites.adjust_zoom()
+            renpy.restart_interaction()
+            # we return None to be able to move to the next statement
+            return None
+
+# zoom transition animation transform
+transform mas_smooth_transition:
+    i11 # this one may not be needed but I keep it just in case
+    function zoom_smoothly

--- a/Monika After Story/game/special-effects.rpy
+++ b/Monika After Story/game/special-effects.rpy
@@ -177,7 +177,7 @@ label monika_kissing_motion(transition=5.0, duration=2.0, hide_ui=True):
 # IN:
 #     new_zoom - the new zoom value to move to
 #     transition - the time in seconds used to transition to the new zoom level
-#         (Default: 5.0)
+#         (Default: 3.0)
 label monika_zoom_value_transition(new_zoom,transition=3.0):
     if new_zoom == mas_sprites.value_zoom:
         return
@@ -217,8 +217,8 @@ label monika_zoom_value_transition(new_zoom,transition=3.0):
 # IN:
 #     new_zoom - the new zoom level to move to
 #     transition - the time in seconds used to transition to the new zoom level
-#         (Default: 5.0)
-label monika_zoom_transition(new_zoom,transition=3.0):
+#         (Default: 3.0)
+label monika_zoom_fixed_duration_transition(new_zoom,transition=3.0):
     # Sanity checks
     if new_zoom == mas_sprites.zoom_level:
         return
@@ -257,6 +257,59 @@ label monika_zoom_transition(new_zoom,transition=3.0):
     # do the transition and pause so it force waits for the transition to end
     show monika at mas_smooth_transition
     pause transition
+    return
+
+# Zoom Transition label #3
+# Used to transition from any valid zoom value to another valid
+# zoom valid zoom value in a smooth way
+# IN:
+#     new_zoom - the new zoom level to move to
+#     transition - the time in seconds used to transition from the maximum to the
+#         minimum zoom level, this works in a way that the time used in the
+#         transition is lower the nearer the current zoom level is to the
+#         new zoom level (Default: 3.0)
+label monika_zoom_transition(new_zoom,transition=3.0):
+    # Sanity checks
+    if new_zoom == mas_sprites.zoom_level:
+        return
+    if new_zoom > 20:
+        $ new_zoom = 20
+    elif new_zoom < 0:
+        $ new_zoom = 0
+
+    # store the old values
+    $ _mas_old_zoom = mas_sprites.zoom_level
+    $ _mas_old_zoom_value = mas_sprites.value_zoom
+    $ _mas_old_y = mas_sprites.adjust_y
+
+    # calculate and store the new values
+    if new_zoom > mas_sprites.default_zoom_level:
+        $ _mas_new_y = mas_sprites.default_y + (
+            (new_zoom - mas_sprites.default_zoom_level) * mas_sprites.y_step
+        )
+        $ _mas_new_zoom_value = mas_sprites.default_value_zoom + (
+            (new_zoom - mas_sprites.default_zoom_level) * mas_sprites.zoom_step
+        )
+    else:
+        $ _mas_new_y = mas_sprites.default_y
+        if new_zoom == mas_sprites.default_zoom_level:
+            $ _mas_new_zoom_value = mas_sprites.default_value_zoom
+        else:
+            $ _mas_new_zoom_value = mas_sprites.default_value_zoom - (
+                (mas_sprites.default_zoom_level - new_zoom) * mas_sprites.zoom_step
+            )
+
+    # calculate and store the differences between new and old values
+    $ _mas_zoom_diff = new_zoom - _mas_old_zoom
+    $ _mas_zoom_value_diff = _mas_new_zoom_value - _mas_old_zoom_value
+    $ _mas_zoom_y_diff = _mas_new_y - _mas_old_y
+
+    # store the time the transition will take
+    $ _mas_transition_time = abs(_mas_zoom_value_diff) * transition
+
+    # do the transition and pause so it force waits for the transition to end
+    show monika at mas_smooth_transition
+    pause _mas_transition_time
     return
 
 init python:


### PR DESCRIPTION
This adds a transform, a function that works with said transform and 3 labels that encapsulate both, in different ways. The labels are used to transition from one zoom level to another easily.

The labels accept 2 parameters:
   - `new_zoom` a required param that specifies the new zoom level or value to move to, which one depends on the label that is used(see the docs for each one).
   - `transition` the time in seconds that it'll take to move to the new_zoom, defaults to 3. This one is used different based on the label(see the docs), in two of them is used to determine the exact time it'll take to finish the transition time and in the other one it's used to determine the time that it takes to move from max to min or min to max which then it's used to define a "transition speed" which remains constant, meaning that the transition will end as soon as possible based on the calculated speed.
  


## Testing

I added some dev topics that trigger the transition to max or min zoom levels, test that those work from any zoom level you already are. Change the zoom levels that these topics transition to check that it can move to any zoom level you want.