### PR TITLE
Made intro set session data

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -2210,6 +2210,8 @@ python early:
 
 # special store that contains powerful (see damaging) functions
 init -1 python in _mas_root:
+    import store
+    import datetime
 
     # redefine this because I can't get access to global functions, also
     # i dont care to find out how
@@ -2325,6 +2327,21 @@ init -1 python in _mas_root:
 
         # affection
         renpy.game.persistent._mas_affection["affection"] = 0
+
+
+    def initialSessionData():
+        """
+        Completely resets session data to usable initial values.
+        NOTE: these are not the defaults, but rather what they would be set to
+        on a first load.
+        """
+        store.persistent.sessions = {
+            "last_session_end": None,
+            "current_session_start": datetime.datetime.now(),
+            "total_playtime": datetime.timedelta(seconds=0),
+            "total_sessions": 1,
+            "first_session": datetime.datetime.now()
+        }
 
 
 init -999 python:

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -612,6 +612,9 @@ label ch30_main:
     # now we out of intro
     $ mas_in_intro_flow = False
 
+    # set session data to startup values
+    $ store._mas_root.initialSessionData()
+
     # lastly, rebuild Event lists for new people if not built yet
     if not mas_events_built:
         $ mas_rebuildEventLists()


### PR DESCRIPTION
#3489 

Adds a new `mas_root` function for setting initial session data.

That function will only be called in the introduction. (end of `ch30_main`)

# Testing.
1. Launch a fresh game
2. Open console and check `persistent.sessions`. Note the value for `first_session`
3. Close the game any time before the introduction dialogue ends. (this can be main menu, via the scare, before main menu, etc)
4. Relaunch game. Check `persistent.sessions` and verify that its the still the same value as before.
5. Finish introduction and reach spaceroom idle. 
6. Check `persistent.sessions` and verify that `first_session` (as well as the other values) are different than before.