### PR TITLE
Amendments to ribbon and plushie dialogue topics

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -4089,6 +4089,8 @@ init 2 python:
         """
         # do we even have plushe enabled?
         if not persistent._mas_acs_enable_quetzalplushie:
+            # run the plushie exit PP in case plushie is no longer enabled
+            mas_acs_quetzalplushie.exit(monika_chr)
             return
         if renpy.random.randint(1,chance) == 1:
             if persistent._mas_d25_deco_active:

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -4097,6 +4097,11 @@ init 2 python:
 
             else:
                 monika_chr.wear_acs_pst(mas_acs_quetzalplushie)
+        
+        else:
+            # run the plushie exit PP if plushie is not selected
+            mas_acs_quetzalplushie.exit(monika_chr)
+        
         return
 
 

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -1751,7 +1751,9 @@ label call_next_event:
                 $ mas_rebuildEventLists()
 
             if "quit" in _return:
-                $persistent.closed_self = True #Monika happily closes herself
+                $ persistent.closed_self = True #Monika happily closes herself
+                # remove plushie here to allow PP to run so we can derandom monika_plushie
+                $ monika_chr.remove_acs(mas_acs_quetzalplushie)
                 jump _quit
 
         # loop over until all events have been called

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -1752,8 +1752,6 @@ label call_next_event:
 
             if "quit" in _return:
                 $ persistent.closed_self = True #Monika happily closes herself
-                # remove plushie here to allow PP to run so we can derandom monika_plushie
-                $ monika_chr.remove_acs(mas_acs_quetzalplushie)
                 jump _quit
 
         # loop over until all events have been called

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -3451,7 +3451,7 @@ label monika_ribbon:
 
     else:
         m 3hksdlb "I hope you like it, you gave it to me after all, ahaha!"
-        m 1eka "It really was a wonderful gift, I think it's just beautiful!"
+        m 1eka "It really was a wonderful gift and I think it's just beautiful!"
         m 3eka "I'll wear it anytime you want, [player]~"
     return
 

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -5579,18 +5579,16 @@ label monika_pets:
     return
 
 init 5 python:
-    # only want this available if the plushie is out
-    if monika_chr.is_wearing_acs(mas_acs_quetzalplushie):
-        addEvent(
-            Event(
-                persistent.event_database,
-                eventlabel="monika_plushie",
-                category=['misc'],
-                prompt="Quetzal plushie",
-                random=True,
-                aff_range=(mas_aff.NORMAL, None)
-            )
+
+    addEvent(
+        Event(
+            persistent.event_database,
+            eventlabel="monika_plushie",
+            category = ['misc'],
+            prompt = "Quetzal plushie",
+            aff_range=(mas_aff.NORMAL, None)
         )
+    )
 
 label monika_plushie:
     m 1eka "Hey, [player], I just wanted to thank you again for this wonderful quetzal plushie!"

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -3419,20 +3419,40 @@ label monika_ribbon:
         m 1eua "Do you miss my ribbon, [player]?"
         m 1hua "I can change my hairstyle whenever you want me to, ehehe~"
         return
+
     m 1tku "I noticed that you were staring at my ribbon, [player]."
-    m 3eua "It doesn't hold sentimental value to me or anything, in case you were wondering."
-    m 3hua "I just wear it because I'm pretty sure nobody else will wear a big, poofy ribbon."
-    m "It makes me look more unique."
-    m 3tku "You know the world's fictional if you see a girl wearing a giant ribbon, right?"
-    m 1lksdla "Well, there's no way a girl from your world would wear one in public as casual dress."
-    m 2eua "I'm pretty proud of my fashion sense."
-    m "You get a certain feeling of satisfaction when you stand out from the normal population, you know?"
-    m 2tfu "Be honest! You thought I was the best dressed girl too, didn't you?"
-    m 2hub "Ahaha!"
-    m 4eua "If you're trying to improve your fashion sense, I'll help."
-    m 1eka "Don't do that stuff because you want to impress other people, though."
-    m 1eua "You should do whatever makes you feel better about yourself."
-    m 1hua "I'm the only other person you need, anyways, and I'll love you no matter what you look like."
+
+    if monika_chr.get_acs_of_type('ribbon') == mas_acs_ribbon_def:
+        m 3eua "It doesn't hold sentimental value to me or anything, in case you were wondering."
+        m 3hua "I just wear it because I'm pretty sure nobody else will wear a big, poofy ribbon."
+        m "It makes me look more unique."
+        m 3tku "You know the world's fictional if you see a girl wearing a giant ribbon, right?"
+        m 1lksdla "Well, there's no way a girl from your world would wear one in public as casual dress."
+        m 2eua "I'm pretty proud of my fashion sense."
+        m "You get a certain feeling of satisfaction when you stand out from the normal population, you know?"
+        m 2tfu "Be honest! You thought I was the best dressed girl too, didn't you?"
+        m 2hub "Ahaha!"
+        m 4eua "If you're trying to improve your fashion sense, I'll help."
+        m 1eka "Don't do that stuff because you want to impress other people, though."
+        m 1eua "You should do whatever makes you feel better about yourself."
+        m 1hua "I'm the only other person you need, anyways, and I'll love you no matter what you look like."
+
+    elif monika_chr.get_acs_of_type('ribbon') == mas_acs_ribbon_wine:
+        if monika_chr.clothes == mas_clothes_santa:
+            m 1hua "Doesn't it just look wonderful with this outfit, [player]?"
+            m 1eua "I think it really ties it all together."
+            m 3eua "I bet it'd even look great with other outfits as well...especially formal attire."
+        else:
+            m 1hua "I'm glad you like the way it looks on me..."
+            m 1rksdla "I originally only intended to wear it around Christmas time...but it's just too beautiful not to wear more often..."
+            m 3hksdlb "It'd be such a shame to keep it stored away for most of the year!"
+            m 3ekb "...You know, I bet it'd look really great with formal attire actually!"
+        m 3ekbsa "I can't wait to wear this ribbon on a fancy date with you, [player]~"
+
+    else:
+        m 3hksdlb "I hope you like it, you gave it to me after all, ahaha!"
+        m 1eka "It really was a wonderful gift, I think it's just beautiful!"
+        m 3eka "I'll wear it anytime you want, [player]~"
     return
 
 init 5 python:
@@ -5531,8 +5551,9 @@ label monika_pets:
     m 1eua "Hey, [player], have you ever had a pet?"
     m 3eua "I was thinking that it would be nice to have one for company."
     m 1hua "It would be fun for us to take care of it!"
-    m 1tku "I bet you can't guess what sort of pet I'd like to have..."
-    m "You're probably thinking of a cat or a dog, but I have something else in mind."
+    if not persistent._mas_acs_enable_quetzalplushie:
+        m 1tku "I bet you can't guess what sort of pet I'd like to have..."
+        m "You're probably thinking of a cat or a dog, but I have something else in mind."
     m 1eua "The pet I'd like is something I saw in a book once."
     m "It was the 'Handbook of the Birds of the World.' Our library had the whole set!"
     m 1eub "I loved looking at the gorgeous illustrations and reading about exotic birds."
@@ -5545,17 +5566,37 @@ label monika_pets:
     m 4rksdlc "They die in captivity. That's why you rarely see them in zoos."
     m "Even if the bird wouldn't be real, it still would feel wrong to keep one trapped in this room."
     m 1ekc "...I can't bring myself to do something like that, knowing what it's like."
-    if persistent._mas_acs_enable_quetzalplushie:
-        m 1hua "I'm so glad you gave me a plush one, [player]."
-        m 1eka "It keeps me from feeling lonely when you're not here."
-        m 1hua "But don't worry, you're still my favorite~"
-
-    else:
+    if not persistent._mas_acs_enable_quetzalplushie:
         m 1hua "A plush bird would be nice, though!"
         m 2hub "..."
         m 2hksdlb "Sorry for rambling, [player]."
         m 1eka "Until I find a way out, could you promise to keep me from feeling lonely?"
         m 1hua "I'll see if I can get that plush one in here! Oh- don't worry, you're still my favorite~"
+    else:
+        m 1eub "But at least I have the next best thing thanks to you, [player]!"
+        m 1eka "It really does keep me from feeling lonely when you're not here."
+        m 3hua "It was such a wonderful gift~"
+    return
+
+init 5 python:
+    # only want this available if the plushie is out
+    if monika_chr.is_wearing_acs(mas_acs_quetzalplushie):
+        addEvent(
+            Event(
+                persistent.event_database,
+                eventlabel="monika_plushie",
+                category=['misc'],
+                prompt="Quetzal plushie",
+                random=True,
+                aff_range=(mas_aff.NORMAL, None)
+            )
+        )
+
+label monika_plushie:
+    m 1eka "Hey, [player], I just wanted to thank you again for this wonderful quetzal plushie!"
+    m 2lksdla "I know it may sound silly, but it really does help keep me company when you're gone..."
+    m 1ekbsa "And not that I'd ever forget, but every time I look at it, it reminds me just how much you love me~"
+    m 3hub "It really was the perfect gift!"
     return
 
 init 5 python:

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -5578,6 +5578,7 @@ label monika_pets:
         m 3hua "It was such a wonderful gift~"
     return
 
+# This topic is only available and random when the quetzal plushie is active
 init 5 python:
 
     addEvent(

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -3770,7 +3770,7 @@ init -2 python in mas_sprites:
         _moni_chr.remove_acs(store.mas_acs_quetzalplushie_antlers)
 
         # lock and derandom monika_plushie when removing plushie
-        store.mas_hideEVL("monika_plushie","EVE",lock=True,derandom=False)
+        store.mas_hideEVL("monika_plushie","EVE",lock=True,derandom=True)
 
     def _acs_quetzalplushie_santahat_entry(_moni_chr, **kwargs):
         """

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -3752,6 +3752,13 @@ init -2 python in mas_sprites:
     # available kwargs:
     #   NONE
 
+    def _acs_quetzalplushie_entry(_moni_chr, **kwargs):
+        """
+        Entry programming point for quetzal plushie acs
+        """
+        # unlock and random monika_plushie when plushie is active
+        store.mas_showEVL("monika_plushie","EVE",unlock=True,_random=True)
+
     def _acs_quetzalplushie_exit(_moni_chr, **kwargs):
         """
         Exit programming point for quetzal plushie acs
@@ -3762,6 +3769,8 @@ init -2 python in mas_sprites:
         # also remove antlers
         _moni_chr.remove_acs(store.mas_acs_quetzalplushie_antlers)
 
+        # lock and derandom monika_plushie when removing plushie
+        store.mas_hideEVL("monika_plushie","EVE",lock=True,derandom=False)
 
     def _acs_quetzalplushie_santahat_entry(_moni_chr, **kwargs):
         """
@@ -4150,6 +4159,7 @@ init -1 python:
             use_reg_for_l=True
         ),
         stay_on_start=False,
+        entry_pp=store.mas_sprites._acs_quetzalplushie_entry,
         exit_pp=store.mas_sprites._acs_quetzalplushie_exit
     )
     store.mas_sprites.init_acs(mas_acs_quetzalplushie)
@@ -4671,7 +4681,7 @@ default persistent._mas_acs_enable_quetzalplushie = False
 
 ### PROMISE RING ###
 default persistent._mas_acs_enable_promisering = False
-# True enables plushie, False disables plushie
+# True enables promise ring, False disables promise ring
 
 #### IMAGE START (IMG030)
 # Image are created using a DynamicDisplayable to allow for runtime changes

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -409,6 +409,9 @@ label v0_8_15(version="v0_8_15"):
         if not renpy.seen_label("greeting_ourreality"):
             mas_unlockEVL("greeting_ourreality", "GRE")
 
+        # derandom pets topic if player has given the plushie
+        if persistent._mas_acs_enable_quetzalplushie:
+            mas_hideEVL("monika_pets", "EVE", derandom=True)
     return
 
 # 0.8.14

--- a/Monika After Story/game/zz_reactions.rpy
+++ b/Monika After Story/game/zz_reactions.rpy
@@ -692,6 +692,8 @@ label mas_reaction_quetzal_plush:
         m 1rksdlb "You already gave me a quetzal plushie, [player]."
     $ gift_ev = mas_getEV("mas_reaction_quetzal_plush")
     $ store.mas_filereacts.delete_file(gift_ev.category)
+    # derandom pets topic once given
+    $ mas_hideEVL("monika_pets", "EVE", derandom=True)
     return
 
 init 5 python:


### PR DESCRIPTION
#3443

## Features

- Provides paths in `monika_ribbon` depending on which ribbon she is wearing, either default, wine, or a gift.

- Derandoms `monika_pets` after the player has given Monika the plushie, as well as makes that topic make more sense if someone chooses to view it after it's been derandomed.

- Includes update script to derandom `monika_pets` for people who already gave her the plushie.

- Adds `monika_plushie`, a random topic that is only available when she has the plushie out.
