### PR TITLE
Mistle toe event fix

### DIFF
--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -750,7 +750,8 @@ init -875 python in mas_delact:
 #        6: _mas_bday_surprise_party_hint_reset,
 #        7: _mas_bday_spent_time_with_reset,
         8: _mas_d25_holiday_intro_upset_reset,
-        9: _mas_d25_monika_carolling_reset
+        9: _mas_d25_monika_carolling_reset,
+        10: _mas_d25_monika_mistletoe_reset,
     }
 
 

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -1253,7 +1253,7 @@ init -815 python in mas_history:
     # d25 season
     def _d25s_exit_pp(mhs):
         # just add appropriate delayed action IDs
-        _MDA_safeadd(8, 9)
+        _MDA_safeadd(8, 9, 10)
 
 
 # topics
@@ -1792,9 +1792,35 @@ init 5 python:
         )
     )
 
-label mas_d25_monika_mistletoe:
-    $ mas_unlockEVL("mas_d25_monika_mistletoe", "EVE")
+init -876 python in mas_delact:
+    # delayed action to reeset the mistle topic
+    # NOTE: this is to derandom and lock this topic post d25 season.
 
+    def _mas_d25_monika_mistletoe_reset_action(ev):
+        # updates conditional, action, random, unlocked
+        ev.conditional = (
+            "mas_isD25Season() "
+            "and not mas_isD25Post() "
+            "and persistent._mas_d25_in_d25_mode"
+        )
+        ev.action = store.EV_ACT_RANDOM
+        ev.unlocked = False
+        ev.random = False
+        return True
+
+
+    def _mas_d25_monika_mistletoe_reset():
+        # creates delayed action for mistletoe
+        return store.MASDelayedAction.makeWithLabel(
+            10,
+            "mas_d25_monika_mistletoe",
+            "True",
+            _mas_d25_monika_mistletoe_reset_action,
+            store.MAS_FC_INIT
+        )
+
+
+label mas_d25_monika_mistletoe:
     m 1eua "Say, [player]."
     m 1eub "You've heard about the mistletoe tradition, right?"
     m 1tku "When lovers end up underneath it, they're expected to kiss."

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -412,6 +412,13 @@ label v0_9_0(version="v0_9_0"):
         # derandom pets topic if player has given the plushie
         if persistent._mas_acs_enable_quetzalplushie:
             mas_hideEVL("monika_pets", "EVE", derandom=True)
+
+        # reset mistletoe if random'd
+        d25_mis_ev = mas_getEV("mas_d25_monika_mistletoe")
+        if d25_mis_ev is not None:
+            # this will reset later
+            mas_addDelayedAction(10)
+
     return
 
 # 0.8.14


### PR DESCRIPTION
delayd action for mistletoe event so it doesnt show up past d25season

this has been added to the prog point for d25season MHS and update scripts.

# Testing
* if you update to 090, the delayed action should get added and ran. check the ev properties (random/unlocked/action/conditional) for correct values (false/false/"random"/<conditional>)
* you can also force the change by doing ` mas_addDelayedAction(10)`, then relaunching the game.

**NOTE:** Testing the MHS trigger is unneccessary. all it does is add the delayed action, so if the delayed action can be added with the function above, then all is good.