### PR TITLE
datetime 1900 verification 

### DIFF
--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -39,6 +39,8 @@ init -900 python in mas_ev_data_ver:
 
 
     def _verify_dt(val, allow_none=True):
+        if val is not None and val.year < 1900:
+            return False
         return _verify_item(val, datetime.datetime, allow_none)
 
 


### PR DESCRIPTION
adds 1900 as a required minimum year for datetimes

If an event's datetime property has a year below 1900, the event gets popped and recreated (in accordance with the verification system).

# Testing
1. change an event's `start_date`, `end_date`, `unlock_date`, or `last_seen` to a datetime with year below 1900.
2. Restart game.
3. Verify the date is fixed. (This depends on whatever the default value is for this event). 

* verify that events with datetimes where year >= 1900 are not affected.