### PR TITLE
changed updater server urls to s3

### DIFF
--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -1,8 +1,15 @@
 # enabling unstable mode
 default persistent._mas_unstable_mode = False
 default persistent._mas_can_update = True
-define mas_updater.regular = "http://updates.monikaafterstory.com/updates.json"
-define mas_updater.unstable = "http://unstable.monikaafterstory.com/updates.json"
+
+# legacy. These will be redirected to the s3 links after 090
+#define mas_updater.regular = "http://updates.monikaafterstory.com/updates.json"
+#define mas_updater.unstable = "http://unstable.monikaafterstory.com/updates.json"
+
+# new s3 links
+define mas_updater.regular = "http://s3-us-west-2.amazonaws.com/monika-after-story/updates/updates.json"
+define mas_updater.unstable = "http://s3-us-west-2.amazonaws.com/monika-after-story/unstable/updates.json"
+
 define mas_updater.force = False
 define mas_updater.timeout = 10 # timeout default
 
@@ -377,6 +384,49 @@ init -1 python:
                 self._state = self.STATE_CHECKING
 
 
+        @staticmethod
+        def _handleRedirect(new_url):
+            """
+            Attempts to connect to the redircted url
+
+            IN:
+                new_url - the redirect we want to connect to
+
+            Returns read_json if we got a connection, Nnone otherwise
+            """
+            import httplib
+
+            _http, double_slash, url = new_url.partition("//")
+            url, single_slash, req_uri = url.partition("/")
+            read_json = None
+            h_conn = httplib.HTTPConnection(
+                url
+            )
+
+            try:
+                # make connection
+                h_conn.connect()
+
+                # get file we need
+                h_conn.request("GET", single_slash + req_uri)
+                server_response = h_conn.getresponse()
+
+                if server_response.status != 200:
+                    # we dont follow anymore redirects
+                    return None
+
+                read_json = server_response.read()
+
+            except httplib.HTTPException:
+                # we assume a timeout / connection error
+                return None
+
+            finally:
+                h_conn.close()
+
+            return read_json
+
+
         # some function here
         @staticmethod
         def _sendRequest(update_link, thread_result):
@@ -409,13 +459,32 @@ init -1 python:
                 server_response = h_conn.getresponse()
 
                 # check status
-                if server_response.status != 200:
+                if server_response.status == 301:
+                    # redirect, pull the location header and continue
+                    new_url = server_response.getheader("location", None)
+
+                    if new_url is None:
+                        # we have to have the redirect location to continue
+                        thread_result.append(MASUpdaterDisplayable.STATE_NO_OK)
+                        return
+
+                    # otherwise, switch connection to the new url
+                    h_conn.close()
+                    read_json = MASUpdaterDisplayable._handleRedirect(new_url)
+
+                    if read_json is None:
+                        # redirect failed too
+                        thread_result.append(MASUpdaterDisplayable.STATE_NO_OK)
+                        return                   
+
+                elif server_response.status != 200:
                     # didnt get an OK response
                     thread_result.append(MASUpdaterDisplayable.STATE_NO_OK)
                     return
 
-                # good status, lets get the value
-                read_json = server_response.read()
+                else:
+                    # good status, lets get the value
+                    read_json = server_response.read()
 
             except httplib.HTTPException:
                 # we assume a timeout / connection error

--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -7,8 +7,8 @@ default persistent._mas_can_update = True
 #define mas_updater.unstable = "http://unstable.monikaafterstory.com/updates.json"
 
 # new s3 links
-define mas_updater.regular = "http://s3-us-west-2.amazonaws.com/monika-after-story/updates/updates.json"
-define mas_updater.unstable = "http://s3-us-west-2.amazonaws.com/monika-after-story/unstable/updates.json"
+define mas_updater.regular = "http://d2vycydjjutzqv.cloudfront.net/updates.json"
+define mas_updater.unstable = "http://dzfsgufpiee38.cloudfront.net/updates.json"
 
 define mas_updater.force = False
 define mas_updater.timeout = 10 # timeout default


### PR DESCRIPTION
# NOTE
the 301 redirects can no longer be tested. They broke a bunch of people's updates.

#3647 

Since we're switching updater servers to s3, need to do more than just add redirect on server. Need to add support for redirect in the server checking code.

**NOTE:** Next release will have to be served on ec2, but 091+ can be served via s3
I will be removing the redirects off the update server, but only after this pull request is merged.
This is so older versions will be able to update to 090, and then from there on, they can use s3.

This does 2 things:
+ adds 301 (redirect) support to update checking
+ changes updater links to the new ones

# Testing
For both unstable and regular updates:
1. change version to an older one 
2. run check update and update
3. verify update works

For 301 testing:
1. comment out the s3 lines, uncomment the old updater lines
2. change version to older one
2. run check update and update
3. verify update works
