### PR TITLE
Use backup in get aff function

### DIFF
--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -1141,9 +1141,12 @@ init 20 python:
     # getter
     def _mas_getAffection():
         if persistent._mas_affection is not None:
-            return persistent._mas_affection.get("affection", 0)
+            return persistent._mas_affection.get(
+                "affection",
+                persistent._mas_aff_backup
+            )
 
-        return 0
+        return persistent._mas_aff_backup
 
     # numerical affection check
     def mas_isBelowZero():


### PR DESCRIPTION
#3641  (Partial)

Changes `_mas_getAffection()` so it retrieves from the backup instead of returning 0 if not found or somtething bad happened.

Also added get functions and used them in some places

# Testing
1. Note value of `_mas_getAffection()` and `persistent._mas_aff_backup
2. remove "affection" off the `persistent._mas_affection` dict.
3. call `_mas_getAffection()`. verify that its the same value as the backup
4. Set `persistent._mas_affection` to None.
5. Repeat step 3.

* verify the set/gain/lose affection functiosn still work when not given an amount