### PR TITLE
Text speed changing

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -4150,6 +4150,7 @@ init 2 python:
             persistent.monika_reload += 1
 
 
+
 # Music
 define audio.t1 = "<loop 22.073>bgm/1.ogg"  #Main theme (title)
 define audio.t2 = "<loop 4.499>bgm/2.ogg"   #Sayori theme

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -1840,18 +1840,24 @@ label call_next_event:
             $ ev.last_seen = datetime.datetime.now()
 
         if _return is not None:
-            if "derandom" in _return:
+            $ ret_items = _return.split("|")
+
+            if "derandom" in ret_items:
                 $ ev.random = False
 
-            if "rebuild_ev" in _return:
+            if "no_unlock" in ret_items:
+                $ ev.unlocked = False
+                $ ev.unlock_date = None
+
+            if "rebuild_ev" in ret_items:
                 $ mas_rebuildEventLists()
 
-            if "idle" in _return:
+            if "idle" in ret_items:
                 $ mas_in_idle_mode = True
                 $ persistent._mas_in_idle_mode = True
                 $ renpy.save_persistent()
 
-            if "quit" in _return:
+            if "quit" in ret_items:
                 $ persistent.closed_self = True #Monika happily closes herself
                 jump _quit
 

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -1242,7 +1242,7 @@ screen preferences():
                     label _("Text Speed")
 
                     #bar value Preference("text speed")
-                    bar value FieldValue(_preferences, "text_cps", range=180, max_is_zero=False, style="slider", offset=20)
+                    bar value FieldValue(_preferences, "text_cps", range=170, max_is_zero=False, style="slider", offset=30)
 
                     label _("Auto-Forward Time")
 

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -467,6 +467,9 @@ init 15 python in mas_affection:
         # change quit messages
         layout.QUIT_NO = mas_layout.QUIT_NO_HAPPY
 
+        # enable text speed
+        store.mas_enableTextSpeed()
+
         # always rebuild randos
         store.mas_idle_mailbox.send_rebuild_msg()
 
@@ -477,6 +480,9 @@ init 15 python in mas_affection:
         """
         # change quit messages
         layout.QUIT_NO = mas_layout.QUIT_NO
+
+        # disable text speed
+        store.mas_disableTextSpeed()
 
         # always rebuild randos
         store.mas_idle_mailbox.send_rebuild_msg()

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -456,6 +456,9 @@ init 15 python in mas_affection:
         # change quit message
         layout.QUIT_NO = mas_layout.QUIT_NO_UPSET
 
+        # disable text speed
+        store.mas_disableTextSpeed()
+
         # always rebuild randos
         store.mas_idle_mailbox.send_rebuild_msg()
 
@@ -468,7 +471,8 @@ init 15 python in mas_affection:
         layout.QUIT_NO = mas_layout.QUIT_NO_HAPPY
 
         # enable text speed
-        store.mas_enableTextSpeed()
+        if persistent._mas_text_speed_enabled:
+            store.mas_enableTextSpeed()
 
         # always rebuild randos
         store.mas_idle_mailbox.send_rebuild_msg()
@@ -480,9 +484,6 @@ init 15 python in mas_affection:
         """
         # change quit messages
         layout.QUIT_NO = mas_layout.QUIT_NO
-
-        # disable text speed
-        store.mas_disableTextSpeed()
 
         # always rebuild randos
         store.mas_idle_mailbox.send_rebuild_msg()

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -456,9 +456,6 @@ init 15 python in mas_affection:
         # change quit message
         layout.QUIT_NO = mas_layout.QUIT_NO_UPSET
 
-        # disable text speed
-        store.mas_disableTextSpeed()
-
         # always rebuild randos
         store.mas_idle_mailbox.send_rebuild_msg()
 
@@ -484,6 +481,9 @@ init 15 python in mas_affection:
         """
         # change quit messages
         layout.QUIT_NO = mas_layout.QUIT_NO
+
+        # disable text speed
+        store.mas_disableTextSpeed()
 
         # always rebuild randos
         store.mas_idle_mailbox.send_rebuild_msg()

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -559,7 +559,10 @@ init python:
         if config.developer and not ignoredev:
             mas_enableTextSpeed()
 
-        elif mas_isMoniHappy(higher=True):
+        elif (
+                mas_isMoniHappy(higher=True)
+                and persistent._mas_text_speed_enabled
+            ):
             mas_enableTextSpeed()
 
         else:

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -35,6 +35,9 @@ init -1 python in mas_globals:
     # NOTE: set to True during o31, and also during sayori easter egg
     # TODO: need to this
 
+    text_speed_enabled = False
+    # set to True if text speed is enabled
+
 
 init 970 python:
     import store.mas_filereacts as mas_filereacts
@@ -528,6 +531,48 @@ init python:
         mas_idle_mailbox.get_idle_cb()
 
 
+    def mas_enableTextSpeed():
+        """
+        Enables text speed
+        """
+        style.say_dialogue = style.normal
+        store.mas_globals.text_speed_enabled = True
+
+
+    def mas_disableTextSpeed():
+        """
+        Disables text speed
+        """
+        style.say_dialogue = style.default_monika
+        store.mas_globals.text_speed_enabled = False
+
+
+    def mas_resetTextSpeed(ignoredev=False):
+        """
+        Sets text speed to the appropriate one depending on global settings
+
+        Rules:
+        1 - developer always gets text speed (unless ignoredev is True)
+        2 - text speed enabled if affection above happy
+        3 - text speed disabled otherwise
+        """
+        if config.developer and not ignoredev:
+            mas_enableTextSpeed()
+
+        elif mas_isMoniHappy(higher=True):
+            mas_enableTextSpeed()
+
+        else:
+            mas_disableTextSpeed()
+
+
+    def mas_isTextSpeedEnabled():
+        """
+        Returns true if text speed is enabled
+        """
+        return store.mas_globals.text_speed_enabled
+
+
 # IN:
 #   start_bg - the background image we want to start with. Use this for
 #       special greetings. None uses the default spaceroom images.
@@ -825,8 +870,8 @@ label ch30_autoload:
     $ m.what_args["slow_abortable"] = config.developer
     $ import store.evhand as evhand
     if not config.developer:
-        $ style.say_dialogue = style.default_monika
         $ config.allow_skipping = False
+    $ mas_resetTextSpeed()
     $ quick_menu = True
     $ startup_check = True #Flag for checking events at game startup
     $ mas_skip_visuals = False

--- a/Monika After Story/game/script-easter-eggs.rpy
+++ b/Monika After Story/game/script-easter-eggs.rpy
@@ -215,10 +215,7 @@ label natsuki_name_scare_hungry:
     hide n_cg1bs
     hide monika_body_glitch1
 
-    if config.developer:
-        $ style.say_dialogue = style.normal
-    else:
-        $ style.say_dialogue = style.default_monika
+    $ mas_resetTextSpeed()
 
     # cleanup
     python:

--- a/Monika After Story/game/script-stories.rpy
+++ b/Monika After Story/game/script-stories.rpy
@@ -544,7 +544,7 @@ label mas_scary_story_hunter:
         $ style.say_dialogue = style.edited
         y "{cps=*2}I'll get you too.{/cps}{nw}"
         hide yuri
-        $ style.say_dialogue = style.default_monika
+        $ mas_resetTextSpeed()
         show monika 1eua at i11 zorder MAS_MONIKA_Z
     hide emptydesk
     call mas_scary_story_cleanup
@@ -614,7 +614,7 @@ label .clean:
     hide natsuki
     $ pause(1.5)
     hide black
-    $ style.say_dialogue = style.default_monika
+    $ mas_resetTextSpeed()
     show monika 1eua at i11 zorder MAS_MONIKA_Z
 
 label .end:
@@ -707,7 +707,7 @@ label mas_scary_story_mujina:
         m 2tub "The salesman responded, 'Oh, you mean...{w=2}{b}like this?{/b}'{nw}"
         show mujina zorder 75 at otei_appear(a=1.0,time=0.25)
         play sound "sfx/glitch1.ogg"
-        $ style.say_dialogue = style.default_monika
+        $ mas_resetTextSpeed()
         $ pause(0.4)
         stop sound
         hide mujina

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -2281,3 +2281,69 @@ label mas_bday_player_bday_select_select:
     $ persistent._mas_player_bday = selected_date
     $ renpy.save_persistent()
     jump birthdate_set
+
+
+# Enables the text speed setting
+init 5 python:
+    addEvent(
+        Event(
+            persistent.event_database,
+            eventlabel="mas_text_speed_enabler",
+            random=True,
+            aff_range=(mas_aff.HAPPY, None)
+        )
+    )
+
+default persistent._mas_text_speed_enabled = False
+# text speed should be enabled when happy+, but disabled if dipping below
+#   upset. (and reenabled on happy+)
+
+default persistent._mas_pm_is_fast_reader = None
+# True if fast reader, False if not
+
+label mas_text_speed_enabler:
+    m 1eua "Hey [player], I was wondering..."
+    menu:
+        m "Are you a fast reader?"
+        "Yes.":
+            $ persistent._mas_pm_is_fast_reader = True
+            $ persistent._mas_text_speed_enabled = True
+
+            m 1wub "Really? That's impressive."
+            m 1kua "I guess you do a lot of reading in your spare time."
+            m 1eua "In that case..."
+
+        "No.":
+            $ persistent._mas_pm_is_fast_reader = False
+            $ persistent._mas_text_speed_enabled = True
+
+            m 1eud "Oh, that's alright."
+            m "Regardless..."
+
+    if not persistent._mas_pm_is_fast_reader:
+        # this sets the current speed to slowest possible.
+        $ preferences.text_cps = 20
+
+    m 6dsa ".{w=1}.{w=1}.{w=1}{nw}"
+
+    $ mas_enableTextSpeed()
+
+    if persistent._mas_pm_is_fast_reader:
+        m 4eua "There!"
+
+    m 4eua "I've enabled the text speed setting!"
+
+    m 1hka "I was only controlling it earlier so I could make sure you read {i}every single{/i} word I say to you."
+    m 1eka "But now that we've been together for a bit, I can trust that you're not just going to skip through my text without reading it."
+
+    if persistent._mas_pm_is_fast_reader:
+        m 1tuu "But I wonder if you can keep up."
+        m 3tuu "{cps=*2}I can talk pretty fast, you know...{/cps}{nw}"
+        $ _history_list.pop()
+        m 3hua"Ahaha~"
+
+    else:
+        m 3hua "And I'm sure that you'll get faster at reading the longer we spend time togther."
+        m "So feel free to change the text speed when you feel comfortable doing so."
+
+    return "derandom|no_unlock"

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -2336,7 +2336,7 @@ label mas_text_speed_enabler:
     m 1eka "But now that we've been together for a bit, I can trust that you're not just going to skip through my text without reading it."
 
     if persistent._mas_pm_is_fast_reader:
-        m 1tuu "...I wonder if you can keep up."
+        m 1tuu "However,{w} I wonder if you can keep up."
         m 3tuu "{cps=*2}I can talk pretty fast, you know...{/cps}{nw}"
         $ _history_list.pop()
         m 3hua "Ahaha~"

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -2295,8 +2295,7 @@ init 5 python:
     )
 
 default persistent._mas_text_speed_enabled = False
-# text speed should be enabled when happy+, but disabled if dipping below
-#   upset. (and reenabled on happy+)
+# text speed should be enabled only when happy+
 
 default persistent._mas_pm_is_fast_reader = None
 # True if fast reader, False if not

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -2336,7 +2336,7 @@ label mas_text_speed_enabler:
     m 1eka "But now that we've been together for a bit, I can trust that you're not just going to skip through my text without reading it."
 
     if persistent._mas_pm_is_fast_reader:
-        m 1tuu "But I wonder if you can keep up."
+        m 1tuu "...I wonder if you can keep up."
         m 3tuu "{cps=*2}I can talk pretty fast, you know...{/cps}{nw}"
         $ _history_list.pop()
         m 3hua "Ahaha~"

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -2320,8 +2320,8 @@ label mas_text_speed_enabler:
             m "Regardless..."
 
     if not persistent._mas_pm_is_fast_reader:
-        # this sets the current speed to slowest possible.
-        $ preferences.text_cps = 20
+        # this sets the current speed to default monika's speed
+        $ preferences.text_cps = 30
 
     m 6dsa ".{w=1}.{w=1}.{w=1}{nw}"
 
@@ -2346,3 +2346,5 @@ label mas_text_speed_enabler:
         m "So feel free to change the text speed when you feel comfortable doing so."
 
     return "derandom|no_unlock"
+
+

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -2340,7 +2340,7 @@ label mas_text_speed_enabler:
         m 1tuu "But I wonder if you can keep up."
         m 3tuu "{cps=*2}I can talk pretty fast, you know...{/cps}{nw}"
         $ _history_list.pop()
-        m 3hua"Ahaha~"
+        m 3hua "Ahaha~"
 
     else:
         m 3hua "And I'm sure that you'll get faster at reading the longer we spend time togther."

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -3867,6 +3867,19 @@ image monika 1huu = DynamicDisplayable(
     arms="steepling"
 )
 
+image monika 1tua = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="up",
+    eyes="smug",
+    nose="def",
+    mouth="smile",
+    head="k",
+    left="1l",
+    right="1r",
+    arms="steepling"
+)
+
 image monika 1tub = DynamicDisplayable(
     mas_drawmonika,
     character=monika_chr,
@@ -3874,6 +3887,19 @@ image monika 1tub = DynamicDisplayable(
     eyes="smug",
     nose="def",
     mouth="big",
+    head="k",
+    left="1l",
+    right="1r",
+    arms="steepling"
+)
+
+image monika 1tuu = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="up",
+    eyes="smug",
+    nose="def",
+    mouth="smug",
     head="k",
     left="1l",
     right="1r",
@@ -8354,6 +8380,19 @@ image monika 3hub = DynamicDisplayable(
     arms="restleftpointright"
 )
 
+image monika 3tua = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="up",
+    eyes="smug",
+    nose="def",
+    mouth="smile",
+    head="k",
+    left="2l",
+    right="1r",
+    arms="restleftpointright"
+)
+
 image monika 3tub = DynamicDisplayable(
     mas_drawmonika,
     character=monika_chr,
@@ -8361,6 +8400,19 @@ image monika 3tub = DynamicDisplayable(
     eyes="smug",
     nose="def",
     mouth="big",
+    head="k",
+    left="2l",
+    right="1r",
+    arms="restleftpointright"
+)
+
+image monika 3tuu = DynamicDisplayable(
+    mas_drawmonika,
+    character=monika_chr,
+    eyebrows="up",
+    eyes="smug",
+    nose="def",
+    mouth="smug",
     head="k",
     left="2l",
     right="1r",

--- a/Monika After Story/game/zz_hangman.rpy
+++ b/Monika After Story/game/zz_hangman.rpy
@@ -579,10 +579,7 @@ label mas_hangman_game_loop:
                 hide window_sayori
                 hide hm_s
                 show monika 1 zorder MAS_MONIKA_Z at hangman_monika_i
-                if config.developer:
-                    $ style.say_dialogue = style.normal
-                else:
-                    $ style.say_dialogue = style.default_monika
+                $ mas_resetTextSpeed()
                 $ is_window_sayori_visible = False
 
                 # enable disabled songs and esc

--- a/Monika After Story/game/zz_history.rpy
+++ b/Monika After Story/game/zz_history.rpy
@@ -704,6 +704,7 @@ init -810 python:
             "_mas_pm_driving_can_drive": "pm.lifestyle.can_drive",
             "_mas_pm_driving_learning": "pm.lifestyle.learning_to_drive",
             "_mas_pm_driving_post_accident": "pm.lifestyle.driving_post_accident",
+            "_mas_pm_is_fast_reader": "pm.lifestyle.reads_fast",
 
             # lifestyle / ring
             "_mas_pm_wearsRing": "pm.lifestyle.ring.wears_one",


### PR DESCRIPTION
#2247 

This adds some functions that allow for changing text speed as well as an event to enable it.

# Key Features

## text speed general
* text speed only enabled when happy+

## text speed functions
* `mas_enableTextSpeed` - enables text speed 
* `mas_disableTextSpeed` - disables text speed
* `mas_resetTextSpeed` - enables/disables text speed according to global vars (developer / affection / text speed enabled var). This should be used when you want to revert from changing the `say_dialogue` or disabling text speed.
    * this takes 1 optional arg, which when True, ignores `config.developer` settings
* `mas_isTextSpeedEnabled` - returns True if text speed is _currently_ enabled. This does not mean whether or not persistent flag is set.

## vars
* `mas_globals.text_speed_enabled` - True if text speed is currently enabled, False otherwise
* `persistent._mas_text_speed_enabled` - True if text speed can be changed (aka after Monika allows it), False otherwise.
* `_mas_pm_is_fast_reader` - True if player is a fast reader, False if not. 

## New event return item
* `no_unlock`. If this is returned, the Event's unlocked property gets set to False and `unlock_date` to 
None

## New fast reader topic
* short random topic that appears when happy+
* asks user if they are a fast reader
* **always enables text speed, regardless of answer**
* if user answers No, `text_cps` is set to slowest possible (30)
* this event derandoms, locks itself after 
   * aka it can only be shown once

## other notes
* `config.developer` takes precedence regarding text speed. When that var is True, text speed is always enabled (except for when `mas_disableTextSpeed` or `say_dialogue` is explicitly changed.
* changed the loweset possible text speed setting to 30 instead of 20

## technical
Monika's text speed is governed by the `default_monika` style, which is set to 30 cps. By changing that to the regular `normal` style, we can enable the text speed slider.

All the enable/disable/reset functions just swap out the style for the `say_dialogue`

# TESTING

## Text speed topic
1. open console and run `mas_disableTextSpeed`, then `pushEvent("mas_text_speed_enabler")`
2. open + close talk menu to trigger topic
3. verify that when clicking no or yes, text speed is enabled. 
    * when clicking no, text speed should be set to slowest possible
4. verify that the topic is no longer random/unlocked when it ends.

## startup adjustments
* Verify that text speed is only enabled when happy+ (and after the text speed topic is run).
2 ways to test this:
** Remove Devflag **
1. set `persistent._mas_text_speed_enabled` and affection to desired values.
2. Close game and Remove the defflag.rpy + rpyc file
3. restart game and verify speed

** Via reset text speed function **
1. set `persistent._mas_text_speed_enabled` and affection to desired values
2. run `mas_resetTextSpeed(True)`
3. verify speed
