### PR TITLE
Data migration framework

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -140,12 +140,11 @@ python early:
             "unlock_date":11,
             "shown_count":12,
             "diary_entry":13,
-#            "rules":14,
-            "last_seen":15,
-            "years":16,
-            "sensitive":17,
-            "aff_range":18,
-            "show_in_idle":19,
+            "last_seen":14,
+            "years":15,
+            "sensitive":16,
+            "aff_range":17,
+            "show_in_idle":18,
         }
 
         # name constants
@@ -289,7 +288,6 @@ python early:
                 unlock_date,
                 0, # shown_count
                 diary_entry,
-                None, # rules, #NOTE: this is no longer stored in persistent
                 last_seen,
                 years,
                 sensitive,

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -147,15 +147,11 @@ init -895 python in mas_ev_data_ver:
         11: MASCurriedVerify(_verify_dt, True), # unlock_date
         12: MASCurriedVerify(_verify_int, False), # shown_count
         13: MASCurriedVerify(_verify_str, True), # diary_entry
-
-        # NOTE: Rules are no longer saved in persistent (0.8.15+)
-#        14: MASCurriedVerify(_verify_dict, False), # rules
-
-        15: MASCurriedVerify(_verify_dt, True), # last_seen
-        16: MASCurriedVerify(_verify_tuli, True), # years
-        17: MASCurriedVerify(_verify_bool, True), # sensitive
-        18: MASCurriedVerify(_verify_tuli_aff, True), # aff_range
-        19: MASCurriedVerify(_verify_bool, True), # show_in_idle
+        14: MASCurriedVerify(_verify_dt, True), # last_seen
+        15: MASCurriedVerify(_verify_tuli, True), # years
+        16: MASCurriedVerify(_verify_bool, True), # sensitive
+        17: MASCurriedVerify(_verify_tuli_aff, True), # aff_range
+        18: MASCurriedVerify(_verify_bool, True), # show_in_idle
     }
 
 
@@ -205,13 +201,17 @@ init -895 python in mas_ev_data_ver:
 
 
     # verify some databases
-    verify_event_data(store.persistent.event_database)
-    verify_event_data(store.persistent._mas_compliments_database)
-    verify_event_data(store.persistent.farewell_database)
-    verify_event_data(store.persistent.greeting_database)
-    verify_event_data(store.persistent._mas_mood_database)
-    verify_event_data(store.persistent._mas_story_database)
-    verify_event_data(store.persistent._mas_apology_database)
+    for _dm_db in store._mas_dm_dm.per_dbs:
+        verify_event_data(_dm_db)
+
+    _dm_db = None
+#    verify_event_data(store.persistent.event_database)
+#    verify_event_data(store.persistent._mas_compliments_database)
+#    verify_event_data(store.persistent.farewell_database)
+#    verify_event_data(store.persistent.greeting_database)
+#    verify_event_data(store.persistent._mas_mood_database)
+#    verify_event_data(store.persistent._mas_story_database)
+#    verify_event_data(store.persistent._mas_apology_database)
 
 
 init -500 python:
@@ -235,7 +235,6 @@ init -500 python:
         True, # unlock_date
         True, # shown_count
         False, # diary_entry
-        False, # rules
         True, # last_seen
         False, # years
         False, # sensitive

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -83,7 +83,9 @@ init python:
 
 
     def mas_transferTopic(old_topicID, new_topicID, per_eventDB):
-        """
+        """DEPREACTED
+        NOTE: This can cause data corruption. DO NOT USE.
+
         Transfers a topic's data from the old topic ID to the new one int he
         given database as well as the lock database.
 
@@ -786,12 +788,18 @@ label v0_8_1(version="v0_8_1"):
             writ_4.action = EV_ACT_POOL
 
         # writing tip 3
-        mas_transferTopic(
-            "monika_write",
-            "monika_writingtip3",
-            persistent.event_database
-        )
+        # transfer specific ev data
+        writ_3_old = persistent.event_database.get("monika_write", None)
+
+        if writ_3_old is not None:
+            persistent.event_database.pop("monika_write")
+
         writ_3 = evhand.event_database.get("monika_writingtip3", None)
+
+        if writ_3_old is not None and writ_3 is not None:
+            writ_3.unlocked = writ_3_old[Event.T_EVENT_NAMES["unlocked"]]
+            writ_3.unlock_date = writ_3_old[Event.T_EVENT_NAMES["unlock_date"]]
+
         if writ_3 and not renpy.seen_label(writ_3.eventlabel):
             writ_3.pool = False
             writ_3.conditional = "seen_event('monika_writingtip2')"
@@ -806,14 +814,26 @@ label v0_8_1(version="v0_8_1"):
             # are migrating
 
             mas_transferTopicSeen(old_t, new_t)
-            mas_transferTopic(old_t, new_t, persistent.event_database)
-            writ_2 = evhand.event_database.get(new_t, None)
-            if writ_2 and not renpy.seen_label(new_t):
-                writ_2.conditional = "seen_event('monika_writingtip1')"
+            old_t_ev = mas_getEV(old_t)
+            new_t_ev = mas_getEV(new_t)
+
+            if old_t_ev is not None and new_t_ev is not None:
+                new_t_ev.unlocked = old_t_ev.unlocked
+                new_t_ev.unlock_date = old_t_ev.unlock_date
+
+            if new_t_ev and not renpy.seen_label(new_t):
+                new_t_ev.conditional = "seen_event('monika_writingtip1')"
+                new_t_ev.pool = False
+                new_t_ev.action = EV_ACT_POOL
 
             # writing tip 1
+            zero_t_d = persistent.event_database.pop(zero_t)
             mas_transferTopicSeen(zero_t, old_t)
-            mas_transferTopic(zero_t, old_t, persistent.event_database)
+            if old_t_ev is not None:
+                old_t_ev.unlocked = zero_t_d[Event.T_EVENT_NAMES["unlocked"]]
+                old_t_ev.unlock_date = zero_t_d[
+                    Event.T_EVENT_NAMES["unlock_date"]
+                ]
 
         ## dropping repeats
         persistent._mas_enable_random_repeats = None

--- a/Monika After Story/game/zz_dm.rpy
+++ b/Monika After Story/game/zz_dm.rpy
@@ -1,6 +1,117 @@
 # data migration module
 
+init -999 python in _mas_dm_dm:
+    import store
+
+    # sets current version of dta migration
+    dm_data_version = 1
+
+    # persistent var is set below
+
+    # persistent databases:
+    per_dbs = [
+        store.persistent.event_database,
+        store.persistent._mas_compliments_database,
+        store.persistent.farewell_database,
+        store.persistent.greeting_database,
+        store.persistent._mas_mood_database,
+        store.persistent._mas_story_database,
+        store.persistent._mas_apology_database
+    ]
+
+    # lock db 
+    lock_db = store.persistent._mas_event_init_lockdb
+
+    ## utility functions
+
+    def rm_idxs(_db, _key, _exp_len, *idxs):
+        """
+        removes indexes off the given key off the given db
+
+        IN:
+            _db - database to remove indexes off of
+            _key - key of the item to remove indexes off of
+            _exp_len - the length the item should have prior to removal.
+                Pass in 0 or less to ignore length checks.
+            *idxs - indexes to remove
+                If nothing is passed, nothing happens.
+        """
+        # sanity check
+        if len(idxs) < 1:
+            return
+
+        # length check
+        ignore_len = _exp_len <= 0
+
+        _data = list(_db[_key])
+
+        if ignore_len or len(_data) == _exp_len:
+            for idx in idxs:
+                _data.pop(idx)
+
+            _db[_key] = tuple(_data)
+
+
+    def rm_idxs_db(_db, _exp_len, *idxs):
+        """
+        Removes indexes off items in the given db
+
+        IN:
+            _db - database to remove indexes off of
+            _exp_len - the length the item should have prior to removal
+                Pass in 0 or less to ignore length checks
+            *idxs - indexes to remove
+                if Nothing is passsed, nothing happens
+        """
+        if len(idxs) < 1:
+            return
+
+        for item in _db:
+            rm_idxs(_db, item, _exp_len, *idxs)
+
+
+    ## migration functions
+
+    def _dm_1_to_2():
+        """
+        Data migration between versions 1 and 2
+
+        GOALS:
+            - remove rules property from events and shrink the tuples.
+        """
+        ### needed vars
+        rules_index = 14
+        curr_len = 20 # number of properties ver 1 events have. 
+
+        ### perform logic
+        for _db in per_dbs:
+            rm_idxs_db(_db, curr_len, rules_index)
+        
+
+        # rules property at index 14
+        # need to modify the lock db as well
+
+    # data migration map maps data migration functions and a version jump:
+    #   key: tuple of the following format:
+    #       [0]: version starting from
+    #       [1]: version updating to
+    #   value: function to run
+    dm_map = {
+
+        # if we dont have a current dm version, we can assume we are using
+        #   the latest one
+        (None, dm_data_version): None,
+    }
+
+
 init -897 python:
+
+    
+    
+
+
+
+    # NOTE: this should be the last thing we do
 
     persistent._mas_dm_data_version = 1
     # this should be updated whenever we do a data version migration

--- a/Monika After Story/game/zz_dm.rpy
+++ b/Monika After Story/game/zz_dm.rpy
@@ -192,10 +192,6 @@ init -999 python in _mas_dm_dm:
     #       [1]: version updating to
     #   value: function to run
     dm_map = {
-
-        # if we dont have a current dm version, we can assume we are using
-        #   the latest one
-        (None, dm_data_version): -1,
         (1, 2): _dm_1_to_2,
         (2, 1): _dm_2_to_1,
     }
@@ -289,6 +285,21 @@ init -999 python in _mas_dm_dm:
 
 
 init -897 python:
+    # if version number is None, we can assume this is a completely fresh game
+    # as version number is not set until init level 10
+    # This means that we should NOT run the data migration scripts
+    # NOTE: this also may mean the user is from 0.3.0, but data is too old by
+    #   that point.
+    if persistent.version_number is None:
+        persistent._mas_dm_data_version = store._mas_dm_dm.dm_data_version
+
+    elif persistent._mas_dm_data_version is None:
+        # if this value is None, but version number is not None, then the user
+        # is coming from a post 0.5.0 install. They should have some data,
+        # but we only want to modify it if contains RULES. 
+        # TODO
+        pass
+
     if persistent._mas_dm_data_version != store._mas_dm_dm.dm_data_version:
         store._mas_dm_dm.run(
             persistent._mas_dm_data_version,

--- a/Monika After Story/game/zz_dm.rpy
+++ b/Monika After Story/game/zz_dm.rpy
@@ -4,8 +4,7 @@ init -999 python in _mas_dm_dm:
     import store
 
     # sets current version of dta migration
-    # TODO: change this to 2 on release
-    dm_data_version = 1
+    dm_data_version = 2
     # this should be updated whenever we do a data version migration
 
     # persistent var is set below

--- a/Monika After Story/game/zz_dm.rpy
+++ b/Monika After Story/game/zz_dm.rpy
@@ -22,7 +22,84 @@ init -999 python in _mas_dm_dm:
     # lock db 
     lock_db = store.persistent._mas_event_init_lockdb
 
+    ## internal utility functions DO NOT USE
+
+    def __add_idxs(_db, _key, _exp_len, idx_d_list):
+        """INTERNAL ONLY
+        adds indexes to the given key to the given db
+        """
+        # length check
+        ignore_len = _exp_len < 0
+
+        _data = list(_db[_key])
+
+        if ignore_len or len(_data) == _exp_len:
+            for idx, idx_data in idx_d_list:
+                _data.insert(idx, idx_data)
+
+            _db[_key] = tuple(_data)
+
+
+    def __rm_idxs(_db, _key, _exp_len, idx_list)
+        """INTERNAL ONLY
+        removes indexes off the given key off the given db
+        """
+        # length check
+        ignore_len = _exp_len <= 0
+
+        _data = list(_db[_key])
+
+        if ignore_len or len(_data) == _exp_len:
+            for idx in idx_list
+                _data.pop(idx)
+
+            _db[_key] = tuple(_data)
+
+
     ## utility functions
+
+    def add_idxs(_db, _key, _exp_len, *idxs_d):
+        """
+        Adds indexes to the given key 
+
+        NOTE: indxs_d is added in reverse order. 
+
+        IN:
+            _db - database to add indexes to
+            _key - key of the item to add indexes to
+            _exp_len - the length the item should have prior to addition
+                Pass in less than 0 to ignore length checks
+            *idxs_d - tuples of the following format:
+                [0]: index to add
+                [1]: data to add at index
+        """
+        if len(idxs_d) < 1:
+            return
+
+        __add_idxs(_db, _key, _exp_len, sorted(idxs_d, reverse=True))
+
+
+    def add_idxs_db(_db, _exp_len, *idxs_d):
+        """
+        Adds indexes to items in the given db
+
+        IN:
+            _db - database to add indexes to
+            _exp_len - the length the item shoudl have prior to additoin
+                Pass in 0 or less to ignore length checks
+            *idxs_d - tuples of the following format:
+                [0]: index to add
+                [1]: data to add at index
+        """
+        # sanity check
+        if len(idxs_d) < 1:
+            return
+
+        idxs_d_rev = sorted(idxs_d, reverse=True)
+
+        for item in _db:
+            __add_idxs(_db, item, _exp_len, idxs_d_rev)
+
 
     def rm_idxs(_db, _key, _exp_len, *idxs):
         """
@@ -40,17 +117,8 @@ init -999 python in _mas_dm_dm:
         if len(idxs) < 1:
             return
 
-        # length check
-        ignore_len = _exp_len <= 0
-
-        _data = list(_db[_key])
-
-        if ignore_len or len(_data) == _exp_len:
-            for idx in idxs:
-                _data.pop(idx)
-
-            _db[_key] = tuple(_data)
-
+        __rm_idxs(_db, _key, _exp_len, sorted(idxs, reverse=True))
+        
 
     def rm_idxs_db(_db, _exp_len, *idxs):
         """
@@ -66,15 +134,17 @@ init -999 python in _mas_dm_dm:
         if len(idxs) < 1:
             return
 
+        idxs_rev = sorted(idxs, reverse=True)
+
         for item in _db:
-            rm_idxs(_db, item, _exp_len, *idxs)
+            __rm_idxs(_db, item, _exp_len, idxs_rev)
 
 
     ## migration functions
 
     def _dm_1_to_2():
         """
-        Data migration between versions 1 and 2
+        Data migration from version 1 to 2
 
         GOALS:
             - remove rules property from events and shrink the tuples.
@@ -84,12 +154,36 @@ init -999 python in _mas_dm_dm:
         curr_len = 20 # number of properties ver 1 events have. 
 
         ### perform logic
+
+        # removes rules proprety at index 14
         for _db in per_dbs:
             rm_idxs_db(_db, curr_len, rules_index)
-        
 
-        # rules property at index 14
-        # need to modify the lock db as well
+        # removes rules proerty in lock db at index 14
+        rm_idxs_db(lock_db, curr_len, rules_index)
+
+
+    def _dm_2_to_1():
+        """
+        Data migration from version 2 to 1
+
+        GOALS:
+            - add rules property to events, expand tuples
+        """
+        ### needed vars
+        rules_index = 14
+        rules_data = {}
+        curr_len = 19 # number of properties ver 1 events have. 
+
+        ### perform logic
+
+        # adds rules property in index 14
+        for _db in per_dbs:
+            add_idxs_db(_db, curr_len, (rules_index, rules_data))
+
+        # adds rules property to lock db index 14
+        add_idxs_db(lock_db, curr_len, (rules_index, rules_data))
+
 
     # data migration map maps data migration functions and a version jump:
     #   key: tuple of the following format:
@@ -101,11 +195,13 @@ init -999 python in _mas_dm_dm:
         # if we dont have a current dm version, we can assume we are using
         #   the latest one
         (None, dm_data_version): None,
+        (1, 2): _dm_1_to_2,
+        (2, 1): _dm_2_to_1,
     }
 
 
 init -897 python:
-
+    pass
     
     
 


### PR DESCRIPTION
# This will be merged after next unstable.

#3547 

One thing that screws us over is dealing with changes to the data structure in an update. This adds a framework for handling data migrating very early in the pipeline.

# Key Features
* complete removal of the `rules` property event
* new data migration system that runs at init level -897

## Data migrating
the file `zz_dm` is where data migration functions should live. A "version" is a number associated with the persistent data. Each time we have a new data "version", the number should be increased.

The algorithm is only run when the version stored is different from the version set in `zz_dm`. The store `_mas_dm_dm` contains all functions related to messing with persistent data as well as the functions for transitioning versions.

The mapping of versions to migration functions is handled via the `dm_map`. The keys of this map should a be a `tuple` of the following format:
* `[0]`: version to update from
* `[1]`: version to update to
The values of this map should be a function. 

Currently the only version migration available is the removal of the rules property.

The system is capable of handling direct version jumps (a, b) as well as stepped version jumps (a, c, d, b). The system can also do reverse migrations (b, a). The alg basically just tries to find the fewest jumps from a to b.

All migration functions written for this MUST be semi-reversible as well as repeatable. This means that:
* the reverse of a migration must undo what a migration does, to the best of its ability (data loss is ok)
* if the migration runs again, it should NOT change data that has already been migrated

**NOTE:** Data migrations from pre-0.9.0 are **not** subject to the above rules. No tech support will be provided for users who update to 0.9.1 and rollback to pre-0.9.0. **A warning similar to this will be placed in the release notes of the next release.**

Data migration functions should also practice offensive programming. If there are any issues, the migration should crash to avoid corrupting more data.

## other
* fixed crash from writing tips update scripts

# Testing
**BACKUP PERSISTENTS BEFORE TESTING**
Version migration **will** change data structure significantly.

All versions from 072 to 090 need to be tested.

## Setup
1. in `zz_dm`, set `dm_data_version` to 2.
2. Either make a persistent for each version from 072 to 090, or download this zip:
[per.zip](https://github.com/Monika-After-Story/MonikaModDev/files/2873234/per.zip)

## For each version
1. Launch game using that versions persistent.
2. Verify that items in `persistent.event_database` have a length of 19.
3. Verify that the rules property is removed from items in `persistent.event_database`. You can check this by looking at the last 7 items in the tuple. Should look something like: `0, None, None, None, False, None, False)`
The actual values may vary. The last 7 properties and expected values are:
- `shown_count`: number of times the event has been shown
- `diary_entry`: this should always be None
- `last_seen`: datetime of when this event was last seen, or None
- `years`: list of years, or None
- `sensitive`: True or False
- `aff_range`: tuple or None
- `show_in_idle`: True or False

The rules property was between `diary_entry` and `last_seen`, so if you see a `dict` or an extra `None` there, then thats bad.

### version notes:
* 072 and earlier do **not** have rules property
* 073-074 have 15 properties to start
* 080-081 have 16 properties to start
* 082-088 have 17 properties to start
* 089-0810 have 18 properties to start
* 0811-0814 have 19 properties to start
* 090 has 20 properties to start. (this is actually treated as data version 1)

## Reversing
Reversing data migrations only works for builds with data versions (090 and future release)
1. Setup a persistent that has data version 2. 
2. In `zz_dm`, set `dm_data_version` to 1.
3. Copy `zz_dm.rpy` to a build of 090. **This is important as the properties in `Event` need to match in order for you to see any changes.**
4. Launch the game using the 090 build with a data version 2 persistent.
5. Verify that items in `persistent.event_database` have a length of 20
6. Verify that a None is added in index 14's place in an item in `persistent.event_database`. This is 2 spots after `shown_count`. 

## Rerunning migrations
1. Setup a persistent that has data formatted in version 2 format but has `persistent._mas_dm_data_version` set to 1.
2. In `zz_dm`, set `dm_data_version` to 2.
3. launch game.
4. Verify that items in `persistent.event_database` still have a length of 19.
5. Verify that nothing was removed from items in `persistent.event_database`
6. Repeat steps 1-5 except:
   * use a persistent that has data formatted in version 1 format but has `persistent._mas_dm_data_version` set to 2.
   * copy `zz_dm.rpy` to a build of 090. Set the `dm_data_version` to 1
   * The length should be 20 and the no additional properties should be added to items in `persistent.event_database` 

