### PR TITLE
No rest

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1294,8 +1294,8 @@ label mas_ch30_select_unseen:
         if not persistent._mas_enable_random_repeats:
             # no repeats means we should push randomlimit if appropriate,
             # otherwise stay slient
-#            if not seen_random_limit:
-#                $ pushEvent("random_limit_reached")
+            if not seen_random_limit:
+                $ pushEvent("random_limit_reached")
 
             jump post_pick_random_topic
 

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1012,7 +1012,6 @@ label ch30_post_restartevent_check:
             #Reset the idlexp total if monika has had at least 6 hours of rest
             if away_experience_time.total_seconds() >= times.REST_TIME:
                 persistent.idlexp_total=0
-                persistent.random_seen = 0
 
                 #Grant good exp for closing the game correctly.
                 mas_gainAffection()

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1256,29 +1256,29 @@ label ch30_post_mid_loop_eval:
             jump post_pick_random_topic
 
         # Pick a random Monika topic
-        if persistent.random_seen < random_seen_limit:
-            label pick_random_topic:
+#        if persistent.random_seen < random_seen_limit:
+        label pick_random_topic:
 
-                # check if we have repeats enabled
-                if not persistent._mas_enable_random_repeats:
-                    jump mas_ch30_select_unseen
+            # check if we have repeats enabled
+            if not persistent._mas_enable_random_repeats:
+                jump mas_ch30_select_unseen
 
-                # randomize selection
-                $ chance = random.randint(1, 100)
+            # randomize selection
+            $ chance = random.randint(1, 100)
 
-                if chance <= store.mas_topics.UNSEEN:
-                    # unseen topic shoud be selected
-                    jump mas_ch30_select_unseen
+            if chance <= store.mas_topics.UNSEEN:
+                # unseen topic shoud be selected
+                jump mas_ch30_select_unseen
 
-                elif chance <= store.mas_topics.SEEN:
-                    # seen topic should be seelcted
-                    jump mas_ch30_select_seen
+            elif chance <= store.mas_topics.SEEN:
+                # seen topic should be seelcted
+                jump mas_ch30_select_seen
 
-                # most seen topic should be selected
-                jump mas_ch30_select_mostseen
+            # most seen topic should be selected
+            jump mas_ch30_select_mostseen
 
-        elif not seen_random_limit:
-            $pushEvent('random_limit_reached')
+#        elif not seen_random_limit:
+#            $pushEvent('random_limit_reached')
 
 label post_pick_random_topic:
 
@@ -1295,8 +1295,8 @@ label mas_ch30_select_unseen:
         if not persistent._mas_enable_random_repeats:
             # no repeats means we should push randomlimit if appropriate,
             # otherwise stay slient
-            if not seen_random_limit:
-                $ pushEvent("random_limit_reached")
+#            if not seen_random_limit:
+#                $ pushEvent("random_limit_reached")
 
             jump post_pick_random_topic
 

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -601,7 +601,7 @@ label unlock_piano:
     $persistent.game_unlocks['piano']=True
     return
 
-# NOTE: this has been disabled
+# NOTE: this has beenpartially disabled
 label random_limit_reached:
     $seen_random_limit=True
     python:

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -601,6 +601,7 @@ label unlock_piano:
     $persistent.game_unlocks['piano']=True
     return
 
+# NOTE: this has been disabled
 label random_limit_reached:
     $seen_random_limit=True
     python:

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -121,7 +121,7 @@ init -1 python:
                 return
 
             pushEvent(sel_ev.eventlabel)
-            persistent.random_seen += 1
+#            persistent.random_seen += 1
 
 
     def mas_insertSort(sort_list, item, key):


### PR DESCRIPTION
#3715

Removes random limit for topics.

# Testing

## random limit 
1. set `random_seen_limit` to 1
2. set random frequency to often
3. ensure repeat topics is enabled (if this was not already enabled, you might need to do a restart)
4. Verify that more than 1 random topic gets shown

## seen all dialogue
1. set random freqency to often
2. disable repeeat topics (might need to restart to take effect)
3. set `mas_rev_unseen` to an empty list
4. Verify the "would you like me to repeat topics" dialogue gets shown