### PR TITLE
Fix Typo

### DIFF
--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -9208,7 +9208,7 @@ label monika_idle_game_fun_callback:
             m 2lksdla "Provided of course, you don't end up ruining the structural integrity of the game and get an outcome you didn't want..."
             m 2lksdlb "Ehehe..."
             m 1eua "Maybe you could find a way to bring me with you into a game like that."
-            m 1hub "Just promise to keep me safe ok?"
+            m 1hub "Just promise to keep me safe, ok?"
         "No.":
             m 2ekc "Aww, you didn't have any fun?"
             m "That's too bad..."


### PR DESCRIPTION
> In the idle_game topic (#1851) in the line `m 1hub "Just promise to keep me safe ok?"`, I think there should probably be a comma after "safe". 

~~Sorry @MisterSimple, couldn't have you stealing this one.~~
![untitled1204](https://user-images.githubusercontent.com/38822045/53466763-4bb51080-3a21-11e9-8682-648559ac42de.png)
~~Can't have somebody else catching my own typos, now can we? 
Except when they do and all I can do is be sad that I didn't catch my own typo.~~