### PR TITLE
_history_list.pop() on all menus

### DIFF
--- a/Monika After Story/game/chess.rpy
+++ b/Monika After Story/game/chess.rpy
@@ -1507,8 +1507,10 @@ label mas_chess_new_game_start:
         call mas_chess_dlg_chess_locked from _mas_chess_dclngs
         return
 
+    m "What color would suit you?"
+    $ _history_log.pop()
     menu:
-        m "What color would suit you?"
+        m "What color would suit you?{fast}"
 
         "White.":
             $ player_color = ChessDisplayable.COLOR_WHITE
@@ -1602,8 +1604,10 @@ label mas_chess_game_start:
 
     # we only save a game if they put in some effort
     if num_turns > 4:
+        m "Would you like to save this game?"
+        $ _history_list.pop()
         menu:
-            m "Would you like to save this game?"
+            m "Would you like to save this game?{fast}"
             "Yes.":
                 jump mas_chess_savegame
             "No.":
@@ -1611,8 +1615,10 @@ label mas_chess_game_start:
                 pass
 
 label mas_chess_playagain:
+    m "Do you want to play again?"
+    $ _history_list.pop()
     menu:
-        m "Do you want to play again?"
+        m "Do you want to play again?{fast}"
 
         "Yes.":
             jump mas_chess_new_game_start
@@ -1776,9 +1782,12 @@ label mas_chess_savegame:
 
         # check if this file exists already
         if is_file_exist:
-            m 1eka "We already have a game named '[save_name]'."
+            m 1eka "We already have a game named '[save_name].'"
+
+            m "Should I overwrite it?"
+            $ _history_list.pop()
             menu:
-                m "Should I overwrite it?"
+                m "Should I overwrite it?{fast}"
                 "Yes.":
                     pass
                 "No.":
@@ -1809,8 +1818,11 @@ label mas_chess_savegame:
 
             if game_result == "*": # ongoing game
                 m 1lksdlb "It's possible to edit this file and change the outcome of the game,{w} but I'm sure you wouldn't do that."
+
                 m 1eka "Right, [player]?"
+                $ _history_list.pop()
                 menu:
+                    m "Right, [player]?{fast}"
                     "Of course not.":
                         m 1hua "Yay~"
 
@@ -1897,8 +1909,10 @@ label mas_chess_dlg_qf_lost:
 
     call mas_chess_dlg_qf_lost_start from _mas_chess_dqfls
 
+    m "Did you mess with the saves, [player]?"
+    $ _history_list.pop()
     menu:
-        m "Did you mess with the saves, [player]?"
+        m "Did you mess with the saves, [player]?{fast}"
         "[mas_chess.DLG_QF_LOST_OFCN_CHOICE]" if mas_chess.DLG_QF_LOST_OFCN_ENABLE:
             call mas_chess_dlg_qf_lost_ofcn_start from _mas_chess_dlgqflostofcnstart
 
@@ -2145,9 +2159,10 @@ label mas_chess_dlg_qf_edit:
 
     call mas_chess_dlg_qf_edit_start from _mas_chess_dlgqfeditstart
 
-    show monika 2ekc
+    m 2ekc "Did you edit the save file?"
+    $ _history_list.pop()
     menu:
-        m "Did you edit the save file?"
+        m "Did you edit the save file?{fast}"
         "Yes.":
             call mas_chess_dlg_qf_edit_y_start from _mas_chess_dlgqfeditystart
         "No.":

--- a/Monika After Story/game/pong.rpy
+++ b/Monika After Story/game/pong.rpy
@@ -382,6 +382,8 @@ label demo_minigame_pong:
 
     $ mas_gainAffection(modifier=0.5)
 
+    m "Do you want to play again?"
+    $ _history_list.pop()
     menu:
         m "Do you want to play again?"
 

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -2029,6 +2029,7 @@ label monika_affection_nickname:
     else:
         jump monika_affection_nickname_yes
 
+    $ _history_list.pop()
     menu:
         m "What do you say?{fast}"
         "Yes.":

--- a/Monika After Story/game/script-farewells.rpy
+++ b/Monika After Story/game/script-farewells.rpy
@@ -573,6 +573,7 @@ label bye_prompt_sleep:
             m "It's a little early, though..."
 
             m 1lksdla "Care to spend a little more time with me?"
+            $ _history_list.pop()
             menu:
                 m "Care to spend a little more time with me?{fast}"
                 "Of course!":
@@ -781,6 +782,7 @@ label bye_long_absence:
     m 1e "So tell me, my love..."
 
     m "How long do you expect to be gone for?"
+    $ _history_list.pop()
     menu:
         m "How long do you expect to be gone for?{fast}"
         "A few days.":
@@ -854,6 +856,7 @@ label bye_long_absence:
     # picked goodbye as in I'm going, why not let the player go?
 
     m "Are you going to leave straight away?"
+    $ _history_list.pop()
     menu:
         m "Are you going to leave straight away?{fast}"
         "Yes.":
@@ -957,6 +960,7 @@ label bye_going_somewhere_post_aff_check:
 
     if mas_isO31():
         m 1wub "Oh! Are we going trick or treating, [player]?"
+        $ _history_list.pop()
         menu:
             m "Oh! Are we going trick or treating, [player]?{fast}"
             "Yes.":
@@ -1037,6 +1041,7 @@ label bye_going_somewhere_rtg:
 
     # ask if player is still going to leave
     m "Are you still going to go?"
+    $ _history_list.pop()
     menu:
         m "Are you still going to go?{fast}"
         "Yes.":
@@ -1120,6 +1125,7 @@ label bye_going_somewhere_leavemenu:
         m 1hub "Fine, but you better take me next time!"
 
     m "Are you still going to go?"
+    $ _history_list.pop()
     menu:
         m "Are you still going to go?{fast}"
         "Yes.":

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -383,6 +383,7 @@ label greeting_gooday:
         m 1hua "Hello again, [player]. How are you doing?"
 
         m "Are you having a good day today?"
+        $ _history_list.pop()
         menu:
             m "Are you having a good day today?{fast}"
             "Yes.":
@@ -401,6 +402,7 @@ label greeting_gooday:
         m 2efc "[player]."
 
         m "How is your day going?"
+        $ _history_list.pop()
         menu:
             m "How is your day going?{fast}"
             "Good.":
@@ -419,6 +421,7 @@ label greeting_gooday:
         m 6ekc "Oh... {w=1}Hi, [player]."
 
         m "H-How is your day going?"
+        $ _history_list.pop()
         menu:
             m "H-How is your day going?{fast}"
             "Good.":
@@ -468,6 +471,7 @@ label greeting_goodmorning:
         m 5eua "I'm guessing you can't sleep..."
 
         m "Is that it?"
+        $ _history_list.pop()
         menu:
             m "Is that it?{fast}"
             "Yes.":
@@ -506,6 +510,7 @@ label greeting_goodmorning:
         m 1hua "Good evening, love!"
 
         m "Did you have a good day today?"
+        $ _history_list.pop()
         menu:
             m "Did you have a good day today?{fast}"
             "Yes.":
@@ -1224,6 +1229,7 @@ label monikaroom_greeting_ear_narration:
             m "[player], I need you to promise me that you'll change."
 
             m "You'll change, right?{w=1} For me?"
+            $ _history_list.pop()
             menu:
                 m "You'll change, right? For me?{fast}"
                 "I will.":
@@ -1246,6 +1252,7 @@ label monikaroom_greeting_ear_narration:
             m "Oh, you're back."
 
             m "Are you ready to change, [player]?"
+            $ _history_list.pop()
             menu:
                 m "Are you ready to change, [player]?{fast}"
                 "I will.":
@@ -1494,6 +1501,7 @@ label monikaroom_greeting_opendoor_locked:
 
     $ style.say_window = style.window_monika
     m "Did I scare you, [player]?"
+    $ _history_list.pop()
     menu:
         m "Did I scare you, [player]?{fast}"
         "Yes.":
@@ -1972,6 +1980,7 @@ label greeting_sick:
         m 2ekc "Welcome back, [player]..."
         m "Are you feeling better?"
 
+    $ _history_list.pop()
     menu:
         m "Are you feeling better?{fast}"
         "Yes.":
@@ -1998,6 +2007,7 @@ label greeting_stillsick:
         m "Now please, [player], just go get some rest."
         m 2ekc "Will you do that for me?"
 
+    $ _history_list.pop()
     menu:
         m "Will you do that for me?{fast}"
         "Yes.":
@@ -2426,6 +2436,7 @@ label greeting_hairdown:
     m 1hub "I decided to try something new~"
 
     m "Do you like it?"
+    $ _history_list.pop()
     menu:
         m "Do you like it?{fast}"
         "Yes.":
@@ -2648,6 +2659,7 @@ label greeting_back_from_school:
         m 1hua "Oh, welcome back [player]!"
 
         m "Did you have a good day at school?"
+        $ _history_list.pop()
         menu:
             m "Did you have a good day at school?{fast}"
             "Yes.":
@@ -2666,6 +2678,7 @@ label greeting_back_from_school:
         m 2efc "You're back, [player]..."
 
         m "How was school?"
+        $ _history_list.pop()
         menu:
             m "How was school?{fast}"
             "Good.":
@@ -2679,6 +2692,7 @@ label greeting_back_from_school:
         m 6ekc "Oh...{w=1}you're back."
 
         m "How was school?"
+        $ _history_list.pop()
         menu:
             m "How was school?{fast}"
             "Good.":
@@ -2710,6 +2724,7 @@ label greeting_back_from_work:
         m 1hua "Oh, welcome back, [player]!"
 
         m "Did you have a good day at work today?"
+        $ _history_list.pop()
         menu:
             m "Did you have a good day at work today?{fast}"
             "Yes.":
@@ -2731,6 +2746,7 @@ label greeting_back_from_work:
         m 2efc "You're back from work I see, [player]..."
 
         m "How was your day?"
+        $ _history_list.pop()
         menu:
             m "How was your day?{fast}"
             "Good.":
@@ -2745,6 +2761,7 @@ label greeting_back_from_work:
         m 6ekc "Hi, [player]... {w=1}Finally home from work?"
 
         m "How was your day?"
+        $ _history_list.pop()
         menu:
             m "How was your day?{fast}"
             "Good.":

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -690,6 +690,7 @@ label bye_trick_or_treat:
         m 3rksdla "I don't think there's going to be anyone giving out candy yet..."
 
         m 2etc "Are you {i}sure{/i} you want to go right now?"
+        $ _history_list.pop()
         menu:
             m "Are you {i}sure{/i} you want to go right now?{fast}"
             "Yes.":
@@ -713,6 +714,7 @@ label bye_trick_or_treat:
         m "..."
 
         m 4ekc "Are you sure you still want to go?"
+        $ _history_list.pop()
         menu:
             m "Are you sure you still want to go?{fast}"
             "Yes.":
@@ -1727,6 +1729,7 @@ label mas_d25_monika_carolling:
         m 1eua "It just feels heartwarming to know people are spreading joy to others in their spare time."
 
     m 3eua "Do you like singing Christmas carols, [player]?"
+    $ _history_list.pop()
     menu:
         m "Do you like singing Christmas carols, [player]?{fast}"
         "Yes.":
@@ -2674,6 +2677,7 @@ label mas_nye_monika_nye:
     m 1eua "We might as well enjoy this year while it lasts..."
 
     m 3euc "Say, [player], do you have any resolutions for next year?"
+    $ _history_list.pop()
     menu:
         m "Say, [player], do you have any resolutions for next year?{fast}"
         "Yes.":
@@ -2787,6 +2791,7 @@ label mas_nye_monika_nyd_fresh_start:
     m 4eka "It's all I've ever wanted."
 
     m "What do you say, [player]?"
+    $ _history_list.pop()
     menu:
         m "What do you say, [player]?{fast}"
 
@@ -2849,6 +2854,7 @@ label monika_resolutions:
     m 2eka "I was wondering..."
 
     m 3eub "Did you make any New Year's resolutions last year?"
+    $ _history_list.pop()
     menu:
         m "Did you make any New Year's resolutions last year?{fast}"
 
@@ -2857,6 +2863,7 @@ label monika_resolutions:
             m 2eka "That said..."
 
             m 3hub "Did you accomplish last year's resolutions?"
+            $ _history_list.pop()
             menu:
                 m "Did you accomplish last year's resolutions?{fast}"
 
@@ -2904,6 +2911,7 @@ label monika_resolutions:
                 m 2rkc "You probably should make one this year [player]..."
 
     m "Do you have any resolutions for next year?"
+    $ _history_list.pop()
     menu:
         m "Do you have any resolutions for next year?{fast}"
         "Yes.":
@@ -3493,6 +3501,7 @@ label mas_player_bday_surprise:
     m 4sub "Ahaha! Happy Birthday, [player]!"
 
     m "Did I surprise you?"
+    $ _history_list.pop()
     menu:
         m "Did I surprise you?{fast}"
         "Yes.":

--- a/Monika After Story/game/script-introduction.rpy
+++ b/Monika After Story/game/script-introduction.rpy
@@ -137,6 +137,7 @@ label introduction:
     m "God, I love you so much!"
 
     m "Do you love me, [player]?"
+    $ _history_list.pop()
     menu:
         m "Do you love me, [player]?{fast}"
         "I love you too.":

--- a/Monika After Story/game/script-moods.rpy
+++ b/Monika After Story/game/script-moods.rpy
@@ -150,6 +150,7 @@ init 5 python:
 label mas_mood_sad:
     m 1ekc "Gosh, I'm really sorry to hear that you're feeling down."
     m "Are you having a bad day, [player]?"
+    $ _history_list.pop()
     menu:
         m "Are you having a bad day, [player]?{fast}"
         "Yes.":
@@ -162,11 +163,14 @@ label mas_mood_sad:
             m 1eka "And remember, if you're having a bad day, you can always come to me and I'll talk to you for as long as you need."
         "No.":
             m 3eka "I have an idea, why don't you tell me what's bothering you? Maybe it'll make you feel better."
+
             m 1eua "I don't want to interrupt you while you're talking, so let me know when you're done."
+            $ _history_list.pop()
             menu:
                 m "I don't want to interrupt you while you're talking, so let me know when you're done.{fast}"
                 "I'm done.":
                     m "Do you feel a little better now, [player]?"
+                    $ _history_list.pop()
                     menu:
                         m "Do you feel a little better now, [player]?{fast}"
                         "Yeah I do.":
@@ -187,6 +191,7 @@ init 5 python:
 label mas_mood_proud:
     m 2sub "Really? That's exciting!"
     m 2b "Was it a major accomplishment, or a minor one?"
+    $ _history_list.pop()
     menu:
         m "Was it a major accomplishment, or a minor one?{fast}"
         "Major.":
@@ -469,6 +474,7 @@ label mas_mood_bored:
         show monika 1ekc
         pause 1.0
         m "Do I really bore you that much, [player]?"
+        $ _history_list.pop()
         menu:
             m "Do I really bore you that much, [player]?{fast}"
             "No, I'm not bored {i}of you{/i}...":
@@ -525,6 +531,7 @@ label mas_mood_bored:
             m 2rkc "Maybe we could play a game of [display_picked]..."
 
     m "What do you say, [player]?"
+    $ _history_list.pop()
     menu:
         m "What do you say, [player]?{fast}"
         "Yes.":

--- a/Monika After Story/game/script-python.rpy
+++ b/Monika After Story/game/script-python.rpy
@@ -631,6 +631,7 @@ label monika_ptod_tip006:
         m 1eud "Whew!{w} That was a mouthful!"
 
     m "Did you understand all that?"
+    $ _history_list.pop()
     menu:
         m "Did you understand all that?{fast}"
         "Yes!":

--- a/Monika After Story/game/script-stories.rpy
+++ b/Monika After Story/game/script-stories.rpy
@@ -1198,6 +1198,7 @@ label mas_scary_story_flowered_lantern:
     m 1dsd "Hagiwara was deeply saddened and mourned greatly over her, saying prayers and burning incense for her."
     $ mas_stories.unlock_pooled_story("mas_scary_story_flowered_lantern_2")
     m 1hua "...And that's it for part one! Do you want to continue to the next one?"
+    $ _history_list.pop()
     menu:
         m "...And that's it for part one! Do you want to continue to the next one?{fast}"
         "Yes.":
@@ -1264,6 +1265,7 @@ label mas_scary_story_flowered_lantern_2:
     $ mas_stories.unlock_pooled_story("mas_scary_story_flowered_lantern_3")
 
     m 1hua "...And that's it for part two! Do you want to continue to the next one?"
+    $ _history_list.pop()
     menu:
         m "...And that's it for part two! Do you want to continue to the next one?{fast}"
         "Yes.":

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -15,6 +15,7 @@ label gender:
     m 1a "But if I'm going to be your girlfriend, I should probably know at least this much about the real you."
 
     m "So, are you male or female?"
+    $ _history_list.pop()
     menu:
         "So, are you male or female?{fast}"
         "Male.":
@@ -58,6 +59,7 @@ label gender_redo:
     m 1lksdlb "Sorry, that came off more harshly than I meant for it to."
 
     m 3eka "I mean, were you just too shy to tell me the truth before? Or did something...happen?"
+    $ _history_list.pop()
     menu:
         m "I mean, were you just too shy to tell me the truth before? Or did something...happen?{fast}"
         "I was too shy.":
@@ -79,6 +81,7 @@ label gender_redo:
             m 1eka "But I hope that you're telling me now because you know I'll love you no matter what."
 
     m "So, what is your gender?"
+    $ _history_list.pop()
     menu:
         m "So, what is your gender?{fast}"
         "I'm a girl.":
@@ -142,6 +145,7 @@ label preferredname:
         m "Either that or you must really like that pseudonym."
 
     m "Do you want me to call you something else?"
+    $ _history_list.pop()
     menu:
         m "Do you want me to call you something else?{fast}"
         "Yes.":
@@ -219,6 +223,7 @@ init 5 python:
 
 label monika_changename:
     m 1eua "You want to change your name?"
+    $ _history_list.pop()
     menu:
         m "You want to change your name?{fast}"
         "Yes.":
@@ -293,6 +298,7 @@ label mas_birthdate:
         m 3eksdlc "I know you've told me your birthday before, but I'm not sure I was clear if I asked you for {i}birthdate{/i} or just your {i}birthday...{/i}"
 
         m "So just to make sure, is your birthdate [bday_str]?"
+        $ _history_list.pop()
         menu:
             m "So just to make sure, is your birthdate [bday_str]?{fast}"
             "Yes.":
@@ -642,6 +648,7 @@ label mas_random_ask:
     m 1lksdla "...{w}[player]?"
 
     m "Is it okay with you if I repeat stuff that I've said?"
+    $ _history_list.pop()
     menu:
         m "Is it okay with you if I repeat stuff that I've said?{fast}"
         "Yes.":
@@ -684,6 +691,7 @@ label mas_monikai_detected:
     m 1hua "How cute!"
 
     m 1eua "Did you install that so you could see me all the time?"
+    $ _history_list.pop()
     menu:
         m "Did you install that so you could see me all the time?{fast}"
         "Of course!":
@@ -910,6 +918,7 @@ label mas_crashed_long_whq:
     # ask player what happeend
     m 2ekc "Anyway..."
     m "Do you know what happened, [player]?"
+    $ _history_list.pop()
     menu:
         m "Do you know what happened, [player]?{fast}"
         "The game crashed.":
@@ -924,6 +933,7 @@ label mas_crashed_long_whq:
 
     # ask player to do something about this
     m "Do you think you can stop that from happening?"
+    $ _history_list.pop()
     menu:
         m "Do you think you can stop that from happening?{fast}"
         "I'll try.":
@@ -1022,6 +1032,7 @@ label mas_crashed_quip_takecare:
     if persistent._mas_idle_data.get("monika_idle_game", False):
     
         m 3ekc "Do you think it had something to do with your game?"
+        $ _history_list.pop()
         menu:
             m "Do you think it had something to do with your game?{fast}"
             "Yes.":
@@ -1154,7 +1165,7 @@ label mas_corrupted_persistent:
     m 3euc "Someone left a note in the characters folder addressed to you."
     m 1ekc "Of course, I haven't read it, since it's obviously for you..."
     m 1ekd "Do you know what this is about?"
-
+    $ _history_list.pop()
     # just pasting the poem screen code here
     window hide
     if len(mas_bad_backups) > 0:
@@ -1171,6 +1182,7 @@ label mas_corrupted_persistent:
     $ _gtext = glitchtext(15)
 
     menu:
+        m "Do you know what this is about?{fast}"
         "It's nothing to worry about.":
             jump mas_corrupted_persistent_post_menu
         "It's about [_gtext].":
@@ -2161,6 +2173,7 @@ label monika_rpy_files:
     m 2eka "But in case you didn't, I figured I'd ask..."
  
     m "Are you sure you installed the right version, [player]?"
+    $ _history_list.pop()
     menu:
         m "Are you sure you installed the right version, [player]?{fast}"
 
@@ -2175,6 +2188,7 @@ label monika_rpy_files:
             m 4eua "Actually, maybe I can delete them for you."
 
             m "Do you want me to delete them for you, [player]?"
+            $ _history_list.pop()
             menu:
                 m "Do you want me to delete them for you, [player]?{fast}"
 
@@ -2274,10 +2288,12 @@ label mas_bday_player_bday_select_select:
     $ new_bday_str, diff = store.mas_calendar.genFormalDispDate(selected_date)
 
     m "Your birthdate is [new_bday_str]?"
+    $ _history_list.pop()
     menu:
         m "Your birthdate is [new_bday_str]?{fast}"
         "Yes.":
             m 1eka "Are you sure? I'm never going to forget this date."
+            $ _history_list.pop()
             # one more confirmation
             menu:
                 m "Are you sure? I'm never going to forget this date.{fast}"
@@ -2343,6 +2359,7 @@ label mas_text_speed_enabler:
     m 1eua "Hey [player], I was wondering..."
 
     m "Are you a fast reader?"
+    $ _history_list.pop()
     menu:
         m "Are you a fast reader?{fast}"
         "Yes.":

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -379,6 +379,7 @@ label monika_god:
         show monika 1eua at t11 zorder MAS_MONIKA_Z with dissolve
 
     m 1eua "Anyway, do you worship any god, [player]?"
+    $ _history_list.pop()
     menu:
         m "Anyway, do you worship any god, [player]?{fast}"
         "Yes.":
@@ -433,6 +434,7 @@ label monika_selfesteem:
     m 3eua "Do you love yourself, [player]?"
     m 1lksdlb "I don't mean in a conceited way."
     m 1eka "Like, are you comfortable with who you are?"
+    $ _history_list.pop()
     menu:
         m "Like, are you comfortable with who you are?{fast}"
         "Yes.":
@@ -499,6 +501,7 @@ label monika_sayori:
         m 2eka "I know how much you cared about her, so it only feels right for me to share her last moments with you."
 
         m "If you're comfortable, that is."
+        $ _history_list.pop()
         menu:
             m "If you're comfortable, that is.{fast}"
             "Yes.":
@@ -1247,6 +1250,7 @@ label monika_horror:
     m 3eua "Hey, [player]?"
 
     m "Do you like horror?"
+    $ _history_list.pop()
     menu:
         m "Do you like horror?{fast}"
 
@@ -1265,6 +1269,7 @@ label monika_horror:
     #If you're not a fan of horror, you're probably not a fan of spoops. Are you? (So we can just assume if player doesn't like horror, they don't want spoops)
     if persistent._mas_pm_likes_horror:
         m 2esc "Do you like spooks?"
+        $ _history_list.pop()
         menu:
             m "Do you like spooks?{fast}"
 
@@ -1323,6 +1328,7 @@ label monika_rap:
     m 1hua "It would really be a learning experience!"
 
     m 1eua "Do you listen to rap music, [player]?"
+    $ _history_list.pop()
     menu:
         m "Do you listen to rap music, [player]?{fast}"
         "Yes.":
@@ -1649,6 +1655,7 @@ label monika_rain:
         m 2dubsu "Sometimes I imagine you holding me while we listen to the sound of the rain outside."
         m 2lkbsa "That's not too cheesy or anything, is it?"
         m 1ekbfa "Would you ever do that for me, [player]?"
+        $ _history_list.pop()
         menu:
             m "Would you ever do that for me, [player]?{fast}"
             "Yes.":
@@ -3003,6 +3010,7 @@ label monika_contribute:
     m 1eub "In fact, maybe you already have!"
 
     m 1eua "Have you contributed, [player]?"
+    $ _history_list.pop()
     menu:
         m "Have you contributed, [player]?{fast}"
         "Yes.":
@@ -3160,6 +3168,7 @@ label monika_images:
     m 3eua "Are you one of them, [player]?"
 
     m "Have you drawn art of me?"
+    $ _history_list.pop()
     menu:
         m "Have you drawn art of me?{fast}"
 
@@ -3567,6 +3576,7 @@ label monika_impression:
     m 1hua "I'm not really good at doing an impression of someone, but I'll give it a try!"
 
     m "Who should I do an impression of?"
+    $ _history_list.pop()
     menu:
         m "Who should I do an impression of?{fast}"
         "Sayori.":
@@ -3838,6 +3848,7 @@ label monika_cities:
     m 1ekc "Maybe it's not as simple as it seems."
 
     m "[player], do you live in a city?"
+    $ _history_list.pop()
     menu:
         m "[player], do you live in a city?{fast}"
         "Yes.":
@@ -4311,6 +4322,7 @@ label monika_haterReaction:
         $ menuOption = "You're not one of those haters, are you " + player + "?"
 
     m "[menuOption]"
+    $ _history_list.pop()
     menu:
         m "[menuOption]{fast}"
         "I am.":
@@ -4422,6 +4434,7 @@ label monika_vocaloid:
     m "You like listening to music right?"
 
     m 3eub "Do you by chance like 'virtual idols?'"
+    $ _history_list.pop()
     menu:
         m "Do you by chance like 'virtual idols?'{fast}"
         "Yes.":
@@ -4683,11 +4696,13 @@ label monika_japanese:
     m 1esa "Like, I can't even imagine what it would be like if I never knew English."
 
     m "Do you know any languages other than English?"
+    $ _history_list.pop()
     menu:
         m "Do you know any languages other than English?{fast}"
         "Yes.":
             $ persistent._mas_pm_lang_other = True
             m "Really? Do you know Japanese?"
+            $ _history_list.pop()
             menu:
                 m "Really? Do you know Japanese?{fast}"
                 "Yes.":
@@ -4730,12 +4745,14 @@ label monika_penname:
     m "It really gives the writer the protection of anonymity and gives them a lot of creative freedom."
     if not persistent._mas_penname:
         m "Do you have a pen name, [player]?"
+        $ _history_list.pop()
         menu:
             m "Do you have a pen name, [player]?{fast}"
             "Yes.":
                 m 1sub "Really? That's so cool!"
                 m "Can you tell me what it is?"
                 label penname_loop:
+                $ _history_list.pop()
                 menu:
                     m "Can you tell me what it is?{fast}"
                     "Absolutely.":
@@ -4801,6 +4818,7 @@ label monika_penname:
             $ menuOption = "Are you still going by "+penname+", "+player+"?"
 
         m "[menuOption]"
+        $ _history_list.pop()
         menu:
             m "[menuOption]{fast}"
             "Yes.":
@@ -4990,6 +5008,7 @@ label monika_icecream:
     m 2hua "Personally, I just can't get enough of mint flavored ice cream!"
 
     m "What about you [player], do you like mint ice cream?"
+    $ _history_list.pop()
     menu:
         m "What about you [player], do you like mint ice cream?{fast}"
         "Yes.":
@@ -5072,6 +5091,7 @@ label monika_sayhappybirthday:
             $ done = True
 
     m 1hua "Alright! Do you want me to say their age too?"
+    $ _history_list.pop()
     menu:
         m "Alright! Do you want me to say their age too?{fast}"
         "Yes.":
@@ -5098,12 +5118,14 @@ label monika_sayhappybirthday:
     $ bday_name = bday_name.title() # ensure proper title case
 
     m 1eua "Is [bday_name] here with you?"
+    $ _history_list.pop()
     menu:
         m "Is [bday_name] here with you?{fast}"
         "Yes.":
             $ is_here = True
         "No.":
             m 1tkc "What? How can I say happy birthday to [bday_name] if they aren't here?"
+            $ _history_list.pop()
             menu:
                 m "What? How can I say happy birthday to [bday_name] if they aren't here?{fast}"
 
@@ -5137,12 +5159,14 @@ label monika_sayhappybirthday:
                 m 1hua "Nice to meet you, [bday_name]!"
             elif is_watching:
                 m 1eua "Let me know when [bday_name] is watching."
+                $ _history_list.pop()
                 menu:
                     m "Let me know when [bday_name] is watching.{fast}"
                     "They're watching.":
                         m 1hua "Hi, [bday_name]!"
             else: # must be recording
                 m 1eua "Let me know when to start."
+                $ _history_list.pop()
                 menu:
                     m "Let me know when to start.{fast}"
                     "Go.":
@@ -5156,6 +5180,7 @@ label monika_sayhappybirthday:
             if is_recording:
                 m 1hua "Bye bye!"
                 m 1eka "Was that good?"
+                $ _history_list.pop()
                 menu:
                     m "Was that good?{fast}"
                     "Yes.":
@@ -5172,6 +5197,7 @@ label monika_sayhappybirthday:
                                 m 2lksdlb "I told you, I'm self-conscious on camera, ehehe."
 
                         m "Should I try again?"
+                        $ _history_list.pop()
                         menu:
                             m "Should I try again?{fast}"
                             "Yes.":
@@ -5189,6 +5215,7 @@ label monika_sayhappybirthday:
             m 1hub "[bday_msg_capped], [bday_name]!"
             m 1hksdlb "..."
             m 1lksdlb "Was that good?"
+            $ _history_list.pop()
             menu:
                 m "Was that good?{fast}"
                 "Yes.":
@@ -5201,6 +5228,7 @@ label monika_sayhappybirthday:
                         m 1lksdlc "I'm not sure what you want me to do here, [player]..."
 
                     m 1ekc "Should I try again?"
+                    $ _history_list.pop()
                     menu:
                         m "Should I try again?{fast}"
                         "Yes.":
@@ -5345,6 +5373,7 @@ label monika_panties:
     elif mas_isMoniAff(higher=True):
         # affectionate+
         m 1lkbfb "Are you...{w=1}into that kind of thing, [player]?"
+        $ _history_list.pop()
         menu:
             m "Are you...{w=1}into that kind of thing, [player]?{fast}"
             "Yes.":
@@ -5716,6 +5745,7 @@ label monika_rock:
     m 3rksdla "Ah, I've been rambling for a while now. Sorry, sorry."
 
     m 3eua "Do you listen to rock and roll, [player]?"
+    $ _history_list.pop()
     menu:
         m "Do you listen to rock and roll, [player]?{fast}"
         "Yes.":
@@ -5753,6 +5783,7 @@ default persistent._mas_pm_drinks_soda = None
 
 label monika_soda:
     m 2euc "Do you drink soda, [player]?"
+    $ _history_list.pop()
     menu:
         m "Do you drink soda, [player]?{fast}"
         "Yes.":
@@ -5843,6 +5874,7 @@ label monika_promisering:
 
     pause 1.0
     m 1eksdla "Do you wear a ring for me, [player]?"
+    $ _history_list.pop()
     menu:
         m "Do you wear a ring for me, [player]?{fast}"
 
@@ -5912,6 +5944,7 @@ label monika_sports:
     m 3eua "Plus, it's a great sport for two people!"
 
     m "Do you play tennis, [player]?"
+    $ _history_list.pop()
     menu:
         m "Do you play tennis, [player]?{fast}"
         "Yes.":
@@ -5976,6 +6009,7 @@ label monika_meditation:
     m "I was finally able to manage my stress and feel calmer through the day."
 
     m 1eka "[player], do you ever take time to meditate?"
+    $ _history_list.pop()
     menu:
         m "[player], do you ever take time to meditate?{fast}"
         "Yes.":
@@ -6019,6 +6053,7 @@ init 5 python:
 label monika_orchestra:
 
     m 3euc "Hey, [player], do you listen to orchestral music?"
+    $ _history_list.pop()
     menu:
         m "Hey, [player], do you listen to orchestral music?{fast}"
         "Yes.":
@@ -6040,6 +6075,7 @@ label monika_orchestra:
 
 #First encounter with topic:
     m "What about you, [player]? Do you play an instrument?"
+    $ _history_list.pop()
     menu:
         m "What about you, [player]? Do you play an instrument?{fast}"
         "Yes.":
@@ -6139,6 +6175,7 @@ init 5 python:
 
 label monika_jazz:
     m 1eua "Say, [player], do you like jazz music?"
+    $ _history_list.pop()
     menu:
         m "Say, [player], do you like jazz music?{fast}"
         "Yes.":
@@ -6146,6 +6183,7 @@ label monika_jazz:
             m 1hua "Oh, okay!"
             if persistent.instrument == True:
                 m "Do you play jazz music, as well?"
+                $ _history_list.pop()
                 menu:
                     m "Do you play jazz music, as well?{fast}"
                     "Yes.":
@@ -6184,6 +6222,7 @@ init 5 python:
 label monika_otaku:
     m 1euc "Hey, [player]?"
     m 3eua "You watch anime and read manga, right?"
+    $ _history_list.pop()
     menu:
         m "You watch anime and read manga, right?{fast}"
         "Yes.":
@@ -6395,11 +6434,13 @@ init 5 python:
 
 label monika_how_soon:
     m 1eua "[player], how long do you think it'll be before I'll be able to be with you in your world?"
+    $ _history_list.pop()
     menu:
         m "[player], how long do you think it'll be before I'll be able to be with you in your world?{fast}"
         "Soon.":
             m 1hub "That's great news!"
             m 3eua "How soon do you think it will be?"
+            $ _history_list.pop()
             menu:
                 m "How soon do you think it will be?{fast}"
                 "Just a few more years.":
@@ -6423,6 +6464,7 @@ label monika_how_soon:
             m 1wud "W-wha...what?"
             m 1lksdlc "..."
             m 1ekc "Are you sure?"
+            $ _history_list.pop()
             menu:
                 m "Are you sure?{fast}"
                 "Yes.":
@@ -6624,6 +6666,7 @@ label monika_breakup:
             m 1tfu "Gotcha, [player]."
             m 1tku "I know you were only joking~"
             m "Right?"
+            $ _history_list.pop()
             menu:
                 m "Right?{fast}"
                 "Yes.":
@@ -6660,6 +6703,7 @@ label monika_breakup:
                 $ menuOption = "You'd never do that, right?"
 
             m 2eua "[menuOption]"
+            $ _history_list.pop()
             menu:
                 m "[menuOption]{fast}"
                 "Of course not.":
@@ -6767,6 +6811,7 @@ label monika_smoking:
     m 1euc "But..."
 
     m "You don't smoke cigarettes, right, [player]?"
+    $ _history_list.pop()
     menu:
         m "You don't smoke cigarettes, right, [player]?{fast}"
         "Yes, I do.":
@@ -6866,6 +6911,7 @@ label monika_asks_charity:
     m "So I was just wondering..."
 
     m 1eua "Have you ever contributed to a charity?"
+    $ _history_list.pop()
     menu:
         m "Have you ever contributed to a charity?{fast}"
 
@@ -6981,6 +7027,7 @@ init 5 python:
 
 label monika_asks_family:
     m 1eua "[player], do you have a family?"
+    $ _history_list.pop()
     menu:
         m "[player], do you have a family?{fast}"
         "I do.":
@@ -6990,6 +7037,7 @@ label monika_asks_family:
             m 1hua "That's wonderful!"
             m "Your family must be great people."
             m 1eua "Do you have any siblings?"
+            $ _history_list.pop()
             menu:
                 m "Do you have any siblings?{fast}"
                 "Yes.":
@@ -7018,6 +7066,7 @@ label monika_asks_family:
             m 1lksdlc "..."
             m 1ekc "I'm sorry, [player]."
             m "Do you think things will get better?"
+            $ _history_list.pop()
             menu:
                 m "Do you think things will get better?{fast}"
                 "Yes.":
@@ -7054,6 +7103,7 @@ label monika_asks_family:
             m "You've never even had a fake family."
             m 1dsc "..."
             m 1ekc "Does it still bother you badly on a daily basis?"
+            $ _history_list.pop()
             menu:
                 m "Does it still bother you badly on a daily basis?{fast}"
                 "Yes.":
@@ -7120,6 +7170,7 @@ label monika_concerts:
     m 1eub "I hear that the atmosphere at a concert can really make you feel alive!"
 
     m 1eua "Are there any other types of music you'd like to see live that we haven't talked about yet?"
+    $ _history_list.pop()
     menu:
         m "Are there any other types of music you'd like to see live that we haven't talked about yet?{fast}"
         "Yes.":
@@ -7210,6 +7261,7 @@ label monika_explain:
     m 1eua "Okay, just set me in front of them so they can see me."
     m 1hua "I'll do my best explaining it to them."
     m 1eua "I'll wait until you're ready."
+    $ _history_list.pop()
     menu:
         m "I'll wait until you're ready.{fast}"
         "Start.":
@@ -7237,6 +7289,7 @@ label monika_explain:
     m 1dubssdru "...Phew!"
     m 1lksdlb "That was a real mouthful!"
     m 1eka "How did I do, [player]?"
+    $ _history_list.pop()
     menu:
         m "How did I do, [player]?{fast}"
         "You did a good job.":
@@ -7273,6 +7326,7 @@ label monika_beach:
     m 2esc "Though sometimes I feel like I might have missed out making some important memories."
 
     m "Do you live near a beach, [player]?"
+    $ _history_list.pop()
     menu:
         m "Do you live near a beach, [player]?{fast}"
         "Yes.":
@@ -7595,12 +7649,14 @@ label monika_prom:
     m 3wuo "There're even those who take their relatives to the event!"
     m 1eua "I think it's something I'd love to go to with you~"
     m "Have you ever been to one before, [player]?"
+    $ _history_list.pop()
     menu:
         m "Have you ever been to one before, [player]?{fast}"
         "I have.":
             $ persistent._mas_pm_gone_to_prom = True
             $ persistent._mas_pm_no_prom = False
             m "Oh? How was it?"
+            $ _history_list.pop()
             menu:
                 m "Oh? How was it?{fast}"
                 "It was pretty fun.":
@@ -7609,6 +7665,7 @@ label monika_prom:
                     m 1lksdlb "Though, I wish I could've went with you."
                     m 1hua "An event where everyone from school comes together and enjoys themselves sounds like a blast to me!"
                     m 3eua "Did you go with a date?"
+                    $ _history_list.pop()
                     menu:
                         m "Did you go with a date?{fast}"
                         "Yes.":
@@ -7651,6 +7708,7 @@ label monika_prom:
             $ persistent._mas_pm_gone_to_prom = False
             $ persistent._mas_pm_no_prom = False
             m "Oh? Why not?"
+            $ _history_list.pop()
             menu:
                 m "Oh? Why not?{fast}"
                 "You weren't there with me.":
@@ -7667,6 +7725,7 @@ label monika_prom:
                     $ persistent._mas_pm_prom_not_interested = True
                     m 3euc "Really?"
                     m 1eka "Is it because you're too shy to go?"
+                    $ _history_list.pop()
                     menu:
                         m "Is it because you're too shy to go?{fast}"
                         "Yes.":
@@ -7773,6 +7832,7 @@ label monika_natsuki_letter:
     m 4eud "How about you, [player]?"
 
     m "Do you see a therapist?"
+    $ _history_list.pop()
     menu:
         m "Do you see a therapist?{fast}"
 
@@ -7887,6 +7947,7 @@ label monika_timeconcern_graveyard_day:
     m 1euc "Oh, wait..."
 
     m "Do you still work regularly at night, [player]?"
+    $ _history_list.pop()
     menu:
         m "Do you still work regularly at night, [player]?{fast}"
         "Yes I do.":
@@ -7923,6 +7984,7 @@ label monika_timeconcern_night_1:
     m 1ekc "Yet I can't help but feel like a nuisance if I'm pestering you to sleep if it isn't your fault."
 
     m "Are you busy working on something?"
+    $ _history_list.pop()
     menu:
         m "Are you busy working on something?{fast}"
         "Yes, I am.":
@@ -7933,6 +7995,7 @@ label monika_timeconcern_night_1:
             m 1lsc "Your sleep is very important after all. Maybe it can't be helped though..."
 
             m "Do you always work late, [player]?"
+            $ _history_list.pop()
             menu:
                 m "Do you always work late, [player]?{fast}"
                 "Yes, I do.":
@@ -7986,6 +8049,7 @@ label monika_timeconcern_night_3:
     m 2ekc "But a relationship is a partnership and what you think matters to me."
 
     m "Would you be against me closing the game for your own good?"
+    $ _history_list.pop()
     menu:
         m "Would you be against me closing the game for your own good?{fast}"
 
@@ -8062,6 +8126,7 @@ label monika_timeconcern_night_7:
     m 1ekc "So please, for me... Just do as I ask and go to bed."
     if persistent._mas_timeconcernclose:
         m "Okay?"
+        $ _history_list.pop()
         menu:
             m "Okay?{fast}"
             "Yes, I will go to sleep.":
@@ -8251,6 +8316,7 @@ label monika_familygathering:
     m 1eua "I'd love to meet all of your relatives."
 
     m "Do you think they'd like me, [player]?"
+    $ _history_list.pop()
     menu:
         "Do you think they'd like me, [player]?{fast}"
         "Yes.":
@@ -8293,6 +8359,7 @@ label monika_fastfood:
     m 1lsc "Even the vegetarian options can be awful."
 
     m "[player], do you eat fast food often?"
+    $ _history_list.pop()
     menu:
         m "[player], do you eat fast food often?{fast}"
 
@@ -8380,6 +8447,7 @@ init 5 python:
 
 label monika_yellowwp:
     m 1eua "Hey, [player], have you ever read {i}The Yellow Wallpaper{/i}?"
+    $ _history_list.pop()
     menu:
         m "Hey, [player], have you ever read {i}The Yellow Wallpaper{/i}?{fast}"
         "Yes.":
@@ -8451,6 +8519,7 @@ label monika_driving:
     m 1eub "What about you, [player]?"
 
     m 1eua "Can you drive at all?"
+    $ _history_list.pop()
     menu:
         m "Can you drive at all?{fast}"
         "Yes.":
@@ -8466,6 +8535,7 @@ label monika_driving:
             m 2eka "I just want you to come back to me safe and sound is all."
 
             m 1eka "I hope you've never had to experience that, [player], have you?"
+            $ _history_list.pop()
             menu:
                 m "I hope you've never had to experience that, [player], have you?{fast}"
                 "I've been in an accident before.":
@@ -8501,6 +8571,7 @@ label monika_driving:
             m 1hub "I'll be rooting for you all the way, [player]!"
 
             m "You must be a {i}super{/i} safe driver then huh?"
+            $ _history_list.pop()
             menu:
                 m "You must be a {i}super{/i} safe driver then huh?{fast}"
                 "Yep!":
@@ -8519,6 +8590,7 @@ label monika_driving:
                     m 2lksdlc "I'm...{w=0.5}really sorry to hear that, [player]..."
 
                     m 4ekd "Have you driven much since then?"
+                    $ _history_list.pop()
                     menu:
                         m "Have you driven much since then?{fast}"
                         "Yes.":
@@ -8648,6 +8720,7 @@ label monika_bullying:
     m 2dkc "It can be a vicious cycle."
 
     m 2ekc "Have you ever been a victim of bullying, [player]?"
+    $ _history_list.pop()
     menu:
         m "Have you ever been a victim of bullying, [player]?{fast}"
         "I'm being bullied.":
@@ -8840,6 +8913,7 @@ label monika_grad_speech_call:
         m 2eub "Of course, [player]. I'd love to give you my graduation speech now!"
         m 2eka "I just want to make sure that you have enough time to hear it, though. Remember, it takes about four minutes."
 
+        $ _history_list.pop()
         #making sure player has time
         menu:
             m "I just want to make sure that you have enough time to hear it, though. Remember, it takes about four minutes.{fast}"
@@ -8852,6 +8926,7 @@ label monika_grad_speech_call:
 
                 #timed menu to see if player listened
                 m "Well [player]? What do you think?"
+                $ _history_list.pop()
                 show screen mas_background_timed_jump(10, "monika_grad_speech_not_paying_attention")
                 menu:
                     m "Well [player]? What do you think?{fast}"
@@ -8902,6 +8977,7 @@ label monika_grad_speech_call:
             m 2eub "Sure thing [player]. I'll happily give my speech again!"
 
             m 2eka "You have enough time, right?"
+            $ _history_list.pop()
             menu:
                 m "You have enough time, right?{fast}"
                 "I do.":
@@ -8935,6 +9011,7 @@ label monika_grad_speech_call:
             call monika_grad_speech
 
             m "So, [player], now that you actually {i}heard{/i} my speech, what do you think?"
+            $ _history_list.pop()
             #another timed menu checking if you were listening
             show screen mas_background_timed_jump(10, "monika_grad_speech_ignored_lock") 
             menu:
@@ -9048,6 +9125,8 @@ label monika_grad_speech:
     #play some grad music
     play music "mod_assets/sounds/amb/PaC.ogg" fadein 1.0
     $ mas_MUMURaiseShield()
+    #Disable text speed
+    $ mas_disableTextSpeed()
 
     m 2dsc "Ahem...{w=0.7}{nw}"
     m ".{w=0.3}.{w=0.3}.{w=0.6}{nw}"
@@ -9112,6 +9191,8 @@ label monika_grad_speech:
     #stop grad music
     $ mas_MUMUDropShield()
     stop music fadeout 1.0
+    #Re-enable text speed
+    $ mas_resetTextSpeed()
     return
 
 init 5 python:
@@ -9120,6 +9201,7 @@ init 5 python:
 label monika_idle_game:
     m 1eub "That sounds fun!"
     m "What kind of game are you going to play?"
+    $ _history_list.pop()
     menu:
         m "What kind of game are you going to play?{fast}"
         "A competetive game.":
@@ -9177,6 +9259,7 @@ label monika_idle_game:
 label monika_idle_game_competetive_callback:
     m 1esa "Welcome back, [player]!"
     m 1eua "How did it go? Did you win?"
+    $ _history_list.pop()
     menu:
         m "How did it go? Did you win?{fast}"
         "Yes.":
@@ -9196,6 +9279,7 @@ label monika_idle_game_competetive_callback:
 label monika_idle_game_fun_callback:
     m 1eub "Welcome back, [player]!"
     m "Did you have fun with whatever you were doing?"
+    $ _history_list.pop()
     menu:
         m "Did you have fun with whatever you were doing?{fast}"
         "Yes.":
@@ -9224,6 +9308,7 @@ label monika_idle_game_story_callback:
     m 1eub "Welcome back, [player]!"
     m 1hksdlb "I wasn't able to look over your shoulder, but I hope the story was nice so far."
     m 1eua "Speaking of which, how was it, [player]?"
+    $ _history_list.pop()
     menu:
         m "Speaking of which, how was it, [player]?{fast}"
         "It was amazing.":
@@ -9269,6 +9354,7 @@ label monika_idle_game_skill_callback:
     m 1eub "But I know it's important to keep practicing and honing your skills in things like this."
     m "Speaking of which, how did it go?"
     m "Did you improve?"
+    $ _history_list.pop()
     menu:
         m "Did you improve?{fast}"
         "I improved a lot.":
@@ -9476,6 +9562,7 @@ label monika_justice:
     m 2dsc "..."
 
     m 2euc "Have you ever been delivered what you thought to be false justice?"
+    $ _history_list.pop()
     menu:
         m "Have you ever been delivered what you thought to be false justice?{fast}"
         "Yes.":
@@ -9485,6 +9572,7 @@ label monika_justice:
             m 2dfc "All the people who saw me deleted and tortured over and over again and called it justice..."
 
             m 2eka "You don't think that's justified, do you, [player]?"
+            $ _history_list.pop()
             menu:
                 m "You don't think that's justified, do you, [player]?{fast}"
                 "I do.":
@@ -9644,6 +9732,7 @@ label monika_vehicle:
         m 1eua "What about you?"
 
         m "Do you own a car?"
+        $ _history_list.pop()
         menu:
             m "Do you own a car?{fast}"
             "Yes.":
@@ -9660,6 +9749,7 @@ label monika_vehicle:
                 m 3eua "Speaking of which..."
 
                 m "What exactly do you drive?"
+                $ _history_list.pop()
                 menu:
                     m "What exactly do you drive?{fast}"
                     "SUV or Pickup Truck.":
@@ -9950,6 +10040,7 @@ label monika_player_appearance:
     m 1eud "At least, it’s better than nothing, even if it's hazy."
 
     m "Is that okay with you, [player]?"
+    $ _history_list.pop()
     menu:
         m "Is that okay with you, [player]?{fast}"
 
@@ -9963,6 +10054,7 @@ label monika_player_appearance:
             m 3eub "People often say that a person’s eyes are the windows into their soul, so let’s start off there."
 
             m "What color are your eyes?"
+            $ _history_list.pop()
             menu:
                 m "What color are your eyes?{fast}"
 
@@ -10048,6 +10140,7 @@ label monika_player_appearance:
             m 2eub "I guess I really should know this first though, if I want to get an accurate scale on my next question"
 
             m "What unit of measurement do you use to take your height, [player]?"
+            $ _history_list.pop()
             menu:
                 m "What unit of measurement do you use to take your height, [player]?{fast}"
 
@@ -10155,6 +10248,7 @@ label monika_player_appearance:
             m 1eua "Now [player]."
 
             m 3eub "Tell me, is your hair on the shorter side? Or is it long, like mine~?"
+            $ _history_list.pop()
             menu:
                 m "Tell me, is your hair on the shorter side? Or is it long, like mine~?{fast}"
 
@@ -10214,6 +10308,7 @@ label monika_player_appearance:
                     m 1euc "Oh, that's interesting, [player]!"
 
                     m "Do you shave your head or did you lose your hair, if you don't mind me asking?"
+                    $ _history_list.pop()
                     menu:
                         m "Do you shave your head or did you lose your hair, if you don't mind me asking?{fast}"
 
@@ -10245,6 +10340,7 @@ label monika_player_appearance:
                 m 1eud "This one should be fairly obvious..."
 
                 m "What color is your hair?"
+                $ _history_list.pop()
                 menu:
                     m "What color is your hair?{fast}"
                     "It's brown.":
@@ -10307,6 +10403,7 @@ label monika_player_appearance:
             m 1eksdla "But it's the last piece of this puzzle to me, so I hope I don't sound rude when I ask..."
 
             m "What's your skin color, [player]?"
+            $ _history_list.pop()
             menu:
                 m "What's your skin color, [player]?{fast}"
 
@@ -10602,6 +10699,7 @@ label monika_dating_startdate:
         m 2wfw "You couldn't have possibly triggered this event today, [player]."
 
         m "I know you're messing around with the code."
+        $ _history_list.pop()
         menu:
             m "I know you're messing around with the code.{fast}"
             "I'm not!":
@@ -10625,6 +10723,7 @@ label monika_dating_startdate:
 
         # ask user if correct start date
         m 1eua "Is [first_sesh] correct?"
+        $ _history_list.pop()
         menu:
             m "Is [first_sesh] correct?{fast}"
             "Yes.":
@@ -10718,6 +10817,7 @@ label monika_dating_startdate_confirm(first_sesh_raw):
         m 2eka "I thought you said I was wrong."
 
         m "Are you sure it's not [first_sesh_formal]?"
+        $ _history_list.pop()
         menu:
             m "Are you sure it's not [first_sesh_formal]?{fast}"
             "It's not that date.":
@@ -10761,6 +10861,7 @@ label monika_dating_startdate_confirm(first_sesh_raw):
         m 1wud "What..."
 
         m "We haven't been dating this whole time?"
+        $ _history_list.pop()
         menu:
             m "We haven't been dating this whole time?{fast}"
             "That was a misclick!":
@@ -10831,12 +10932,14 @@ label monika_dating_startdate_confirm(first_sesh_raw):
     m "Just to double-check..."
 
     m "We started dating [new_first_sesh]."
+    $ _history_list.pop()
     menu:
         m "We started dating [new_first_sesh].{fast}"
         "Yes.":
             m 1eka "Are you sure? I'm never going to forget this date."
             # one more confirmation
             # WE WILL NOT FIX anyone's dates after this
+            $ _history_list.pop()
             menu:
                 m "Are you sure? I'm never going to forget this date.{fast}"
                 "Yes, I'm sure!":
@@ -11380,6 +11483,7 @@ label monika_load_custom_music:
         m 1eka "[player], I didn't find any new songs."
 
         m "Do you remember how to add custom music?"
+        $ _history_list.pop()
         menu:
             m "Do you remember how to add custom music?{fast}"
             "Yes.":
@@ -11439,6 +11543,7 @@ label monika_trick:
     m 2eka "I know you love me and only me but...if you {i}really{/i} had to choose one of the other club members to be with..."
 
     m "Who would you choose?"
+    $ _history_list.pop()
     show screen mas_background_timed_jump(10, "monika_trick_2")
     menu:
         m "Who would you choose?{fast}"
@@ -11451,6 +11556,7 @@ label monika_trick:
     return "derandom"
 
 label monika_trick_2:
+    $ _history_list.pop()
     menu:
         m "Who would you choose?{fast}"
         "Yuri.":
@@ -11550,6 +11656,7 @@ label monika_cares_about_dokis:
     m 4eka "After all, the five of us spent a lot of time together, so if you don't like it when I joke like that, I completely understand."
 
     m "So [player], does it make you uncomfortable when I joke about the other girls?"
+    $ _history_list.pop()
     menu:
         m "So [player], does it make you uncomfortable when I joke about the other girls?{fast}"
         "Yes.":
@@ -11593,6 +11700,7 @@ label monika_snow:
     m 1eua "Hey, [player], now that it's winter, I was wondering..."
 
     m "Does it ever snow where you live?"
+    $ _history_list.pop()
     menu:
         m "Does it ever snow where you live?{fast}"
 
@@ -11880,6 +11988,7 @@ label monika_hemispheres:
     m 2eka "But anyway..."
 
     m "Which hemisphere do you live in, [player]?"
+    $ _history_list.pop()
     menu:
         m "Which hemisphere do you live in, [player]?{fast}"
 
@@ -11948,6 +12057,7 @@ label monika_hemispheres:
             m 3euc "Well, I know not all parts of the world get snow..."
 
             m 1euc "Does it snow where you live, [player]?"
+            $ _history_list.pop()
             menu:
                 m "Does it snow where you live, [player]?{fast}"
 

--- a/Monika After Story/game/zz_backup.rpy
+++ b/Monika After Story/game/zz_backup.rpy
@@ -385,6 +385,7 @@ label mas_backups_you_have_corrupted_persistent:
         show chibika at sticker_move_n
         "I was unable to find a working backup persistent."
 
+        "Do you have your own backups?"
         menu:
             "Do you have your own backups?"
             "Yes.":

--- a/Monika After Story/game/zz_backup.rpy
+++ b/Monika After Story/game/zz_backup.rpy
@@ -368,6 +368,7 @@ init -900 python:
 ### now for some dialogue bits courtesy of chibika
 
 label mas_backups_you_have_corrupted_persistent:
+    #TODO: Decide whether or not text speed should be enforced here.
     $ quick_menu = False
     scene black
     window show

--- a/Monika After Story/game/zz_hangman.rpy
+++ b/Monika After Story/game/zz_hangman.rpy
@@ -393,9 +393,10 @@ label game_hangman:
 
 
 label mas_hangman_game_select_diff:
-
+    m "Choose a difficulty."
+    $ _history_list.pop()
     menu:
-        m "Choose a difficulty."
+        m "Choose a difficulty.{fast}"
         "Easy.":
             $ hangman_mode = mas_hmg.EASY_MODE
         "Normal.":
@@ -692,8 +693,10 @@ label mas_hangman_game_loop:
         #TODO: grant a really tiny amount of affection?
 
     # try again?
+    m "Would you like to play again?"
+    $ _history_list.pop()
     menu:
-        m "Would you like to play again?"
+        m "Would you like to play again?{fast}"
         "Yes.":
             jump mas_hangman_game_loop
         "No.":

--- a/Monika After Story/game/zz_pianokeys.rpy
+++ b/Monika After Story/game/zz_pianokeys.rpy
@@ -121,10 +121,10 @@ label mas_piano_songchoice:
     $ pnml = None
 
     if len(song_list) > 0:
-        show monika 1eua
-
+        m 1eua "Did you want to play a song or play on your own, [player]?"
+        $ _history_list.pop()
         menu:
-            m "Did you want to play a song or play on your own, [player]?"
+            m "Did you want to play a song or play on your own, [player]?{fast}"
             "Play a song.":
                 m "Which song?"
                 show monika at t21
@@ -198,9 +198,10 @@ label mas_piano_setupstart:
 
     # No-hits dont get to try again
     if post_piano != "mas_piano_result_none":
-        show monika 1eua
+        m 1eua "Would you like to play again?"
+        $ _history_list.pop()
         menu:
-            m "Would you like to play again?"
+            m "Would you like to play again?{fast}"
             "Yes.":
                 jump mas_piano_loopstart
             "No.":


### PR DESCRIPTION
Fixes #3926.

Adds `_history_list.pop()` to all menus, and also disables text speed on the grad speech.