### PR TITLE
Added new sound mixer for background (rain+) noise

### DIFF
--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -1236,6 +1236,11 @@ screen preferences():
                     bar value FieldValue(persistent, "_mas_randchat_freq",
                     range=6, style="slider")
 
+                    hbox:
+                        label _("Ambient Volume")
+
+                    bar value Preference("mixer amb volume")
+
 
                 vbox:
 

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -319,7 +319,14 @@ init python:
         stop_on_mute=True,
         tight=True
     )
-#    renpy.music.set_volume(songs.getVolume("music"), channel="background")
+
+    # also need another verison of background for concurrency
+    renpy.music.register_channel(
+        "backsound",
+        mixer="amb",
+        loop=False,
+        stop_on_mute=True
+    )
 
     #Define new functions
     def show_dialogue_box():
@@ -1317,7 +1324,7 @@ label ch30_post_mid_loop_eval:
                 show mas_lightning zorder 4
 
             $ pause(0.5)
-            play sound "mod_assets/sounds/amb/thunder.wav"
+            play backsound "mod_assets/sounds/amb/thunder.wav"
         
         # Before a random topic can be displayed, a set waiting time needs to pass.
         # The waiting time is set initially, after a random chatter selection and before a random topic is selected.

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -311,14 +311,15 @@ init python:
     mas_battery_supported = battery.is_supported()
 
     # we need a new music channel for background audio (like rain!)
+    # this uses the amb (ambient) mixer. 
     renpy.music.register_channel(
         "background",
-        mixer="sfx",
+        mixer="amb",
         loop=True,
         stop_on_mute=True,
         tight=True
     )
-    renpy.music.set_volume(songs.getVolume("music"), channel="background")
+#    renpy.music.set_volume(songs.getVolume("music"), channel="background")
 
     #Define new functions
     def show_dialogue_box():


### PR DESCRIPTION
#3901 

We tied the original background audio channel to the sfx mixer and set its volume on startup to the music volume (wtf?).

This gives the background audio channel its own mixer and no longer ties it to music volume.

Also adds another bar for volume adjusting in the settings menu.

**EDIT**
Also added a new channel `backsound` for non-repeating ambient noises.

# Testing
1. Launch game.
2. change weather to rain
3. verify changing the "Ambient volume" settting changes sound of rain
4. Verify changing the "Sound volume" **does not** change sound of rain
5. Verify on a relaunch that the "Ambient volume" setting is saved.