### PR TITLE
Persistent data cleanup

### DIFF
--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -23,7 +23,9 @@ transform prompt_monika:
     tcommon(950,z=0.8)
 
 
-init -895 python in mas_ev_data_ver:
+init -950 python in mas_ev_data_ver:
+    # must be before -900 so we can use in persistent backup/cleanup
+
     # special store dedicated to verification of Event-based data
     import datetime
     import store

--- a/Monika After Story/game/zz_backup.rpy
+++ b/Monika After Story/game/zz_backup.rpy
@@ -360,8 +360,23 @@ init -900 python:
             mas_utils.writelog("[ERROR]: {0}".format(str(e)))
 
 
+    def __mas__memoryCleanup():
+        """
+        Cleans up persistent data by removing uncessary parts.
+        """
+        # the chosen dict can be completely cleaned
+        persistent._chosen.clear()
+
+        # the seen ever dict must be iterated through
+        from store.mas_ev_data_ver import _verify_str
+        for seen_ever_key in persistent._seen_ever.keys():
+            if not _verify_str(seen_ever_key):
+                persistent._seen_ever.pop(seen_ever_key)
+
+
     # run the backup system if persistents arent screwd
     if not mas_corrupted_per and persistent._mas_moni_chksum is None:
+        __mas__memoryCleanup()
         __mas__memoryBackup()
 
 


### PR DESCRIPTION
#3802 

This clears `_chosen` and cleans `_seen_ever` of non-label things right before persisten tbackup

# Testing
1. Launch game **without these changes**.
2. Note the size of `persistent._chosen` and `persistent._seen_ever`
3. Launch game **with these changes**
4. Verify `_chosen` is len 0 and `_seen_ever` is much smaller.
5. Also check if a label you have seen is still considered seen when using `renpy.seen_label`