### PR TITLE
Persistent data loss fix

### DIFF
--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -202,6 +202,9 @@ init -950 python in mas_ev_data_ver:
                 per_db.pop(ev_label)
 
 
+init -895 python in mas_ev_data_ver:
+    # this MUST happen after the data migrations
+
     # verify some databases
     for _dm_db in store._mas_dm_dm.per_dbs:
         verify_event_data(_dm_db)


### PR DESCRIPTION
The init level of data verification in `event-handler` was changed to -950, which is before when data migration happens (-897). This results in data loss.

# Testing
* verify no more data loss (specifically rando topics).
* use persistent in discord server