### PR TITLE
Fix first sesh reset on revisit to main menu

### DIFF
--- a/Monika After Story/game/script.rpy
+++ b/Monika After Story/game/script.rpy
@@ -34,7 +34,7 @@ label start:
             $ mas_startup_song()
         else:
             stop music
-        jump ch30_loop
+        jump ch30_preloop
     jump ch30_main
 
 label endgame(pause_length=4.0):

--- a/Monika After Story/game/script.rpy
+++ b/Monika After Story/game/script.rpy
@@ -28,6 +28,13 @@ label start:
     $ config.allow_skipping = True
 
     #Jump to the space room.
+    if persistent.autoload:
+        #Stop the title screen music
+        if persistent.current_track:
+            $ mas_startup_song()
+        else:
+            stop music
+        jump ch30_loop
     jump ch30_main
 
 label endgame(pause_length=4.0):


### PR DESCRIPTION
If a player managed to revisit the main menu, they'd see ~~that all~~ the intro again and then have their first session reset. This skips right over intro and leads directly to the `ch30_loop` label.

## Testing:
Have an up-to-date update folder, but a `config.version` which mismatches. Upon updating, it should say MAS is up-to-date, and proceed takes you to the main menu. Verify that intro is skipped and `persistent.sessions` is still intact.