### PR TITLE
Updater fixes

### DIFF
--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -2,6 +2,9 @@
 default persistent._mas_unstable_mode = False
 default persistent._mas_can_update = True
 
+# flag used so we know we just updated through the internal updater 
+default persistent._mas_just_updated = False
+
 # legacy. These will be redirected to the s3 links after 090
 #define mas_updater.regular = "http://updates.monikaafterstory.com/updates.json"
 #define mas_updater.unstable = "http://unstable.monikaafterstory.com/updates.json"
@@ -817,18 +820,20 @@ init 10 python:
         the_thread.start()
 
 # Update cleanup flow:
-init python early:
+init -999 python:
 
     def _mas_getBadFiles():
         """
         Searches through the entire mod_assets folder for any file
         with the '.new' extension and returns their paths
+        RETURNS:
+            a list containing the file names, list will be empty if 
+            there was no 'bad' files
         """
         import os
-        
+
         return [
             os.path.join(root, file)
-
             for root, dirs, files in os.walk(os.path.join(config.gamedir,'mod_assets'))
                 for file in files
                     if file.endswith(".new")
@@ -840,12 +845,15 @@ init python early:
         """
         import shutil
         files = _mas_getBadFiles()
-        print(files)
         for file in files:
             shutil.move(file, file[:-4])
 
-    # check if we have files to move
-    mas_cleanBadUpdateFiles()
+    # if we just updated
+    if renpy.game.persistent._mas_just_updated:
+        # check if we have files to move
+        mas_cleanBadUpdateFiles()
+        # reset the flag
+        renpy.game.persistent._mas_just_updated = False
 
 
 
@@ -917,9 +925,11 @@ label update_now:
         if updater_selection > 0:
             # user wishes to update
             $ persistent.closed_self = True # we take updates as self closed
+            $ persistent._mas_just_updated = True #set the just updated flag 
 
-            #Stop background sound
+            #Stop background sound and music
             stop background
+            stop music 
 
             # call quit so we can save important stuff
             call quit

--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -816,6 +816,38 @@ init 10 python:
         )
         the_thread.start()
 
+# Update cleanup flow:
+init python early:
+
+    def _mas_getBadFiles():
+        """
+        Searches through the entire mod_assets folder for any file
+        with the '.new' extension and returns their paths
+        """
+        import os
+        
+        return [
+            os.path.join(root, file)
+
+            for root, dirs, files in os.walk(os.path.join(config.gamedir,'mod_assets'))
+                for file in files
+                    if file.endswith(".new")
+            ]
+    
+    def mas_cleanBadUpdateFiles():
+        """
+        Moves any file with the '.new' extension to the correct file
+        """
+        import shutil
+        files = _mas_getBadFiles()
+        print(files)
+        for file in files:
+            shutil.move(file, file[:-4])
+
+    # check if we have files to move
+    mas_cleanBadUpdateFiles()
+
+
 
 label mas_updater_steam_issue:
 #    show monika at t11

--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -2,7 +2,7 @@
 default persistent._mas_unstable_mode = False
 default persistent._mas_can_update = True
 
-# flag used so we know we just updated through the internal updater 
+# flag used so we know we just updated through the internal updater
 default persistent._mas_just_updated = False
 
 # legacy. These will be redirected to the s3 links after 090
@@ -478,7 +478,7 @@ init -1 python:
                     if read_json is None:
                         # redirect failed too
                         thread_result.append(MASUpdaterDisplayable.STATE_NO_OK)
-                        return                   
+                        return
 
                 elif server_response.status != 200:
                     # didnt get an OK response
@@ -820,14 +820,14 @@ init 10 python:
         the_thread.start()
 
 # Update cleanup flow:
-init -999 python:
+init -894 python:
 
     def _mas_getBadFiles():
         """
         Searches through the entire mod_assets folder for any file
         with the '.new' extension and returns their paths
         RETURNS:
-            a list containing the file names, list will be empty if 
+            a list containing the file names, list will be empty if
             there was no 'bad' files
         """
         import os
@@ -838,7 +838,7 @@ init -999 python:
                 for file in files
                     if file.endswith(".new")
             ]
-    
+
     def mas_cleanBadUpdateFiles():
         """
         Moves any file with the '.new' extension to the correct file
@@ -925,11 +925,11 @@ label update_now:
         if updater_selection > 0:
             # user wishes to update
             $ persistent.closed_self = True # we take updates as self closed
-            $ persistent._mas_just_updated = True #set the just updated flag 
+            $ persistent._mas_just_updated = True #set the just updated flag
 
             #Stop background sound and music
             stop background
-            stop music 
+            stop music
 
             # call quit so we can save important stuff
             call quit


### PR DESCRIPTION
Fixes #4050

With the contents of this pull request we'll now know when we just updated from the updater and on the restart we'll check all the files inside `mod_assets/` in case we have one of those `.new` files and if we do we just move that one to the file it should go. Also we now mute the music before starting the update process just in case the music it's playing and can't be updated.

## Testing
Since we're still not sure how to force trigger the updater issue (might be interesting to try by deliberately opening the file with another program though), what I did was to just duplicate a file and add the `.new` extension at the end. 
Since the check runs only if the `persistent._mas_just_updated` flag is set to true, it must be set to true through the developer console and then restart MAS.
By the time Monika appears on screen the file with the `.new` extension should be gone (it moves to the file with the same name without the `.new` extension).

## Technical 
The check runs at init level -999 to  ensure that we haven't accessed any of the mod files by that time. Originally I planned to run it on `python early` but the persistent flags weren't updated by that time so -999 will do.