### PR TITLE
optimization attempt and an override for the choose renderer label

### DIFF
--- a/Monika After Story/game/options.rpy
+++ b/Monika After Story/game/options.rpy
@@ -154,11 +154,14 @@ define config.has_autosave = False
 define config.autosave_on_quit = False
 define config.autosave_slots = 0
 define config.layers = [ 'master', 'transient', 'screens', 'overlay', 'front' ]
-define config.image_cache_size = 64
-define config.predict_statements = 50
+define config.image_cache_size = 128
+define config.predict_statements = 10
 define config.rollback_enabled = config.developer
 define config.menu_clear_layers = ["front"]
 define config.gl_test_image = "white"
+define config.label_overrides = { 
+    "_choose_renderer": "mas_choose_renderer_override"
+}
 #define config.gl_resize = False
 
 init python:

--- a/Monika After Story/game/splash.rpy
+++ b/Monika After Story/game/splash.rpy
@@ -359,3 +359,4 @@ label quit:
             store.mas_utils.trydel(mas_docking_station._trackPackage("monika"))
 
     return
+

--- a/Monika After Story/game/zz_graphicsmenu.rpy
+++ b/Monika After Story/game/zz_graphicsmenu.rpy
@@ -499,3 +499,7 @@ label mas_gmenu_start:
         jump _quit
 
     return
+
+label mas_choose_renderer_override:
+    # if we do this somehow, just quit immediately.
+    jump _quit


### PR DESCRIPTION
I've added an insta quit label so that if the choose rendere menu appears, the game quits instead and monika thinks its a crash.

also double image cache size and reduced prediction. maybe less prediction means better perf? It looks a little better during mid topic. 

# Testing
I don't know. If you can reproduce the graphics menu appearing randomly, then try that and verify it shuts down instead. If it still appears, then whatever is causing this is not something we can fix.

Otherwise, you can force it to appear by uncommented the line with `choose_renderer` in splash.