### PR TITLE
Python intro fix

### DIFF
--- a/Monika After Story/game/script-python.rpy
+++ b/Monika After Story/game/script-python.rpy
@@ -137,7 +137,7 @@ label monika_ptod_tip000:
     m 1lksdlb "I don't know {i}that{/i} much about programming, but I will try my best to explain."
     m 1esa "Let's start with what Python even is."
 
-    $ hideEventLabel("monika_ptod_tip000", depool=True)
+    $ mas_hideEVL("monika_ptod_tip000", "EVE", lock=True)
 
     # enable tip 1
     $ import datetime

--- a/Monika After Story/game/script-python.rpy
+++ b/Monika After Story/game/script-python.rpy
@@ -137,7 +137,7 @@ label monika_ptod_tip000:
     m 1lksdlb "I don't know {i}that{/i} much about programming, but I will try my best to explain."
     m 1esa "Let's start with what Python even is."
 
-    $ mas_hideEVL("monika_ptod_tip000", "EVE", lock=True)
+    $ mas_hideEVL("monika_ptod_tip000", "EVE", lock=True, depool=True)
 
     # enable tip 1
     $ import datetime

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -309,6 +309,9 @@ label v0_9_4(version="v0_9_4"):
         if persistent._mas_greeting_type != store.mas_greetings.TYPE_LONG_ABSENCE:
             # reset the long absensce flag that wasn't reset because of a bug
             persistent._mas_long_absence = False
+
+        if mas_getEV('monika_ptod_tip001').unlocked:
+            mas_hideEVL("monika_ptod_tip000", "EVE", lock=True)
     return 
 
 # 0.9.2

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -310,7 +310,9 @@ label v0_9_4(version="v0_9_4"):
             # reset the long absensce flag that wasn't reset because of a bug
             persistent._mas_long_absence = False
 
+        # need to lock intro to python tips for people that have it unlocked in Repeat Conversations due to a bug
         if mas_getEV('monika_ptod_tip001').unlocked:
+            # check to see if tip 001 is unlocked, since 000 is the only way to unlock 001
             mas_hideEVL("monika_ptod_tip000", "EVE", lock=True)
     return 
 


### PR DESCRIPTION
The `Can you teach me about Python?` (`monika_ptod_tip000`) topic was being depooled but not locked, which just made it show up in `Repeat Conversations`. This locks the topic correctly once it's seen, as well as locks it for people who have already seen it previously.

## Testing

- **update script**: on a persistent that has already seen `monika_ptod_tip000` and thus unlocked `monika_ptod_tip001` use the console to `call v0_9_4` and verify that `Can you teach me about Python?` is now locked and no longer showing up under `Repeat Conversations`.

- **via `Can you teach me about Python?`**: using a fresh persistent, view the `Can you teach me about Python?` topic. You may need to manually unlock the topic. Verify after viewing that the topic is now locked and does not show up in `Repeat Conversations` or `Hey, [m_name]...`