### PR TITLE
Player bday fixes

### DIFF
--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1104,6 +1104,10 @@ label i_greeting_monikaroom:
 
     $ has_listened = False
 
+    # need to remove this in case the player quits the special player bday greet before the party and doesn't return until the next day
+    if "mas_player_bday_no_restart" in persistent.event_list:
+        $ persistent.event_list.remove("mas_player_bday_no_restart")
+
     # FALL THROUGH
 label monikaroom_greeting_choice:
     $ _opendoor_text = "...Gently open the door."

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -3584,9 +3584,13 @@ label mas_player_bday_cake:
         else:
             m 6ekbfa "I love you, [player]~"
             call monika_kissing_motion(duration=0.5, initial_exp="6hkbfa", fade_duration=0.5)
-            m 6ekbsa "Let's enjoy your special day~"
+            if mas_isplayer_bday():
+                m 6ekbsa "Let's enjoy your special day~"
     else:
-        m 1ekbfa "I love you, [player]! Let's enjoy your special day~"
+        if mas_isplayer_bday():
+            m 1ekbfa "I love you, [player]! Let's enjoy your special day~"
+        else:
+            m 1ekbfa "I love you, [player]!"
     if "mas_player_bday_no_restart" in persistent.event_list:
         $ persistent.event_list.remove("mas_player_bday_no_restart")
     return
@@ -3645,7 +3649,11 @@ label mas_player_bday_no_restart:
     $ store.mas_player_bday_event.show_player_bday_Visuals()
     $ persistent._mas_player_bday_decor = True
     m 3hub "Happy Birthday, [player]!"
-    m 1eka "I really wanted to surprise you today, but it's getting late and I just couldn't wait any longer."
+    if mas_isplayer_bday():
+        m 1eka "I really wanted to surprise you today, but it's getting late and I just couldn't wait any longer."
+    else:
+        # just in case this isn't seen until after midnight
+        m 1hksdlb "I really wanted to surprise you, but I guess I ran out of time since it's not even your birthday anymore, ahaha!"
     m 3eksdlc "Gosh, I just hope you weren't starting to think I forgot your birthday. I'm really sorry if you did..."
     m 1rksdla "I guess I probably shouldn't have waited so long, ehehe."
     m 1hua "Oh! I made you a cake!"


### PR DESCRIPTION
A problem could arise where the player first loads the mod on their bday after 7 pm and then quits the special greeting before she knows you are there. If the player then did not load the mod again until the next day, `mas_player_bday_no_restart` would still be in the event list and run. This removes this event from the list as soon as the special greeting runs to prevent this from happening.

This also includes some minor consistency issues that could arise if the `mas_player_bday_no_restart` or the birthday party in general runs after the bday has passed.  This is possible if the player leaves the mod open from pre-bday all the way until post-bday without interacting with Monika, or if the party starts just before midnight and finishes after midnight.

## Testing
Open the mod on player bday, for the first time that day, after 7 pm, but click off before selecting from the menu on the special greet. Load the mod again the day after player bday and verify that `mas_player_bday_no_restart` does not run.