### PR TITLE
Fixed repeating history text on take you somewhere

### DIFF
--- a/Monika After Story/game/script-farewells.rpy
+++ b/Monika After Story/game/script-farewells.rpy
@@ -998,6 +998,9 @@ label bye_going_somewhere_iowait:
     elif promise.done():
         # i/o thread is done!
         jump bye_going_somewhere_rtg
+    else:
+        #clean up the history list so only one "give me a second..." should show up
+        $ _history_list.pop()
 
     # display menu options
     # 4 seconds seems decent enough for waiting.


### PR DESCRIPTION
The "Give me a second to get ready." line would end up showing up multiple times in the history list. Verify that only one will show up anytime you use it (try with a fresh persist too).