### PR TITLE
Better prompt sorting

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -508,7 +508,7 @@ python early:
             #
             # Special function we use to get a lowercased version of the prompt
             # for sorting purposes
-            return ev.prompt.lower()
+            return renpy.substitute(ev.prompt).lower()
 
 
         @staticmethod


### PR DESCRIPTION
This will use the value of a variable in a prompt instead of the actual string "[var]" when sorting prompts in the menu. This mainly fixes the problem with prompts beginning with [player] appearing at the top of a given category instead of where they should be alphabetically by the player's actual name.