### PR TITLE
Always clear just reacted

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1787,6 +1787,11 @@ label ch30_reset:
         if not mas_isD25Season():
             persistent._mas_d25_deco_active = False
 
+    ## reactions fix
+    python:
+        if persistent._mas_filereacts_just_reacted:
+            queueEvent("mas_reaction_end")
+
     ## certain things may need to be reset if we took monika out
     # NOTE: this should be at the end of this label, much of this code might
     # undo stuff from above


### PR DESCRIPTION
#3886 

If `persistent._mas_filereacts_just_reacted` is True, then this will queue the event to reset the reaction state.

# Testing
1. launch game.
2. Set `persistent._mas_filereacts_just_reacted` to True
3. Restart game
4. Verify that its now false
