### PR TITLE
added infinite loop checks at suspected issue spots

### DIFF
--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -1231,6 +1231,9 @@ label monika_outfit:
         m 5hub "We're not that far into our relationship yet. Ahaha!"
     return
 
+# random infinite loop check
+python:
+    renpy.not_infinite_loop(60)
 
 default persistent._mas_pm_likes_horror = None
 default persistent._mas_pm_likes_spoops = False
@@ -1341,6 +1344,9 @@ label monika_rap:
             m 1ekc "Oh... Well I can understand that, rap music isn't everyone's taste."
             m 3hua "But if you ever do decide to give it a try, I'm sure we can find an artist or two that we both like!"
     return "derandom"
+
+python:
+    renpy.not_infinite_loop(60)
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_wine",category=['club members'],prompt="Yuri's wine",random=True))

--- a/Monika After Story/game/zz_extrasmenu.rpy
+++ b/Monika After Story/game/zz_extrasmenu.rpy
@@ -115,6 +115,7 @@ label mas_extra_menu_close:
 
 label mas_idle_loop:
     pause 10.0
+    $ renpy.not_infinite_loop(60)
     jump mas_idle_loop
 
 default persistent._mas_opened_extra_menu = False


### PR DESCRIPTION
#3977 
#3979 

Adds `not_infinite_loop` calls at certain spots.

# Testing
No real way to test if this works besides end-user testing.
For this, just make sure no crashes in the following places:
* opening the extras menu, in standard idle and idle mode
* startup
