### PR TITLE
History list no longer substututes

### DIFF
--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -1425,7 +1425,7 @@ screen history():
                         if "color" in h.who_args:
                             text_color h.who_args["color"]
 
-                text h.what
+                text h.what.replace("[","[[")
 
         if not _history_list:
             label _("The dialogue history is empty.")


### PR DESCRIPTION
Fixes #4186. History screen now adds the extra `[` to the escape character which stops it from substituting.