### PR TITLE
Some notif fixes

### DIFF
--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -1856,6 +1856,16 @@ label call_next_event:
 
         $ mas_RaiseShield_dlg()
 
+        $ ev = mas_getEV(event_label)
+
+        if (
+                not store.mas_globals.in_idle_mode
+                and (ev is not None and "skip alert" not in ev.rules)
+                and not (event_label.startswith("greeting_") or event_label.startswith("bye_"))
+            ):
+            #Create a new notif
+            call display_notif(m_name, random.choice(notif_quips), "Topic Alerts")
+
         call expression event_label from _call_expression
         $ persistent.current_monikatopic=0
 

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -1860,7 +1860,7 @@ label call_next_event:
 
         if (
                 not store.mas_globals.in_idle_mode
-                and (ev is not None and "skip alert" not in ev.rules)
+                and ((ev is not None and "skip alert" not in ev.rules) or ev is None)
                 and not (event_label.startswith("greeting_") or event_label.startswith("bye_"))
             ):
             #Create a new notif

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -22,6 +22,9 @@ init -1 python:
     layout.MAS_TT_NOTIF = (
         "Enabling this will let Monika use your system's notifications "
     )
+    layout.MAS_TT_NOTIF_SOUND = (
+        "If enabled, a custom notification sound will play for Monika's notifications "
+    )
     layout.MAS_TT_G_NOTIF = (
         "Enables notifications for the selected group."
     )
@@ -1415,10 +1418,17 @@ screen notif_settings():
 
         vbox:
             style_prefix "check"
-            textbutton _("Use Notifications"):
-                action ToggleField(persistent, "_mas_enable_notifications")
-                selected persistent._mas_enable_notifications
-                hovered tooltip.Action(layout.MAS_TT_NOTIF)
+            hbox:
+                spacing 25
+                textbutton _("Use Notifications"):
+                    action ToggleField(persistent, "_mas_enable_notifications")
+                    selected persistent._mas_enable_notifications
+                    hovered tooltip.Action(layout.MAS_TT_NOTIF)
+
+                textbutton _("Sounds"):
+                    action ToggleField(persistent, "_mas_notification_sounds")
+                    selected persistent._mas_notification_sounds
+                    hovered tooltip.Action(layout.MAS_TT_NOTIF_SOUND)
 
             label _("Alert Filters")
 

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1496,9 +1496,6 @@ label ch30_post_mid_loop_eval:
         if not mas_randchat.waitedLongEnough():
             jump post_pick_random_topic
         else:
-            if not store.mas_globals.in_idle_mode:
-                #Create a new notif
-                call display_notif(m_name, random.choice(notif_quips), "Topic Alerts")
             $ mas_randchat.setWaitingTime()
 
         window auto

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -2439,7 +2439,7 @@ label mas_bookmarks_notifs_intro:
         m 1hub "[player], I have something exciting to tell you!"
         call mas_notification_windowreact
 
-    return "no unlock"
+    return "no_unlock"
 
 label mas_derand:
     m 1eua "You can also let me know of any topics that you don't like me bringing up by pressing the 'x' key during the conversation."

--- a/Monika After Story/game/zz_windowreacts.rpy
+++ b/Monika After Story/game/zz_windowreacts.rpy
@@ -3,6 +3,9 @@
 #Whether Monika can use notifications or not
 default persistent._mas_enable_notifications = False
 
+#Whether notification sounds are enabled or not
+default persistent._mas_notification_sounds = True
+
 #Whether Monika can see your active window or not
 default persistent._mas_windowreacts_windowreacts_enabled = False
 
@@ -258,8 +261,9 @@ label display_notif(title, body, group=None, skip_checks=False):
             or skip_checks
         ):
 
-        #Play the notif sound
-        play sound "mod_assets/sounds/effects/notif.wav"
+        #Play the notif sound if we have that enabled
+        if persistent._mas_notification_sounds:
+            play sound "mod_assets/sounds/effects/notif.wav"
 
         #Now we make the notif
         if (renpy.windows):
@@ -286,7 +290,7 @@ init 5 python:
             persistent._mas_windowreacts_database,
             eventlabel="monika_whatwatching",
             category=['youtube'],
-            rules={"notif-group": "Window Reactions"},
+            rules={"notif-group": "Window Reactions", "skip alert": None},
             show_in_idle=True
         ),
         code="WRS"
@@ -302,6 +306,7 @@ init 5 python:
             persistent._mas_windowreacts_database,
             eventlabel="monika_lookingat",
             category=['rule34', 'monika'],
+            rules={"skip alert": None},
             show_in_idle=True
         ),
         code="WRS"
@@ -336,7 +341,7 @@ init 5 python:
             persistent._mas_windowreacts_database,
             eventlabel="monika_monikamoddev",
             category=['monikamoddev'],
-            rules={"notif-group": "Window Reactions"},
+            rules={"notif-group": "Window Reactions", "skip alert": None},
             show_in_idle=True
         ),
         code="WRS"


### PR DESCRIPTION
#4251 

- Fixes notifs showing when repeat convo disabled
- Added a notification sounds button (Sounds because screenlang and wrapping)
- Fixed the return key on the intro topics
- Added a new rule: `skip alert`, which bypasses the topic alert

This should now give notifs for all pushed events too.