### PR TITLE
More Notif Fixes + Idle Transition Fixes

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -3889,8 +3889,8 @@ init 2 python:
         drink_ev.action = None
         persistent._mas_coffee_brew_time = None
         persistent._mas_coffee_cup_done = None
-        removeEventIfExist(brew_ev.eventlabel)
-        removeEventIfExist(drink_ev.eventlabel)
+        mas_rmEVL(brew_ev.eventlabel)
+        mas_rmEVL(drink_ev.eventlabel)
 
 
     def _mas_startupCoffeeLogic():
@@ -3937,7 +3937,7 @@ init 2 python:
                 if brew_ev.conditional is not None and eval(brew_ev.conditional):
                     # even though this in inaccurate, it works for the
                     # immersive purposes, so whatever.
-                    removeEventIfExist(brew_ev.eventlabel)
+                    mas_rmEVL(brew_ev.eventlabel)
                     mas_drinkCoffee(persistent._mas_coffee_brew_time)
 
                     if not still_drink(persistent._mas_coffee_cup_done):
@@ -3957,7 +3957,7 @@ init 2 python:
                 brew_ev.conditional = None
                 brew_ev.action = None
                 persistent._mas_coffee_brew_time = None
-                removeEventIfExist(brew_ev.eventlabel)
+                mas_rmEVL(brew_ev.eventlabel)
 
                 # make sure she has the cup, just in case
                 if not monika_chr.is_wearing_acs(mas_acs_mug):
@@ -4109,8 +4109,8 @@ init 2 python:
         drink_ev.action = None
         persistent._mas_c_hotchoc_brew_time = None
         persistent._mas_c_hotchoc_cup_done = None
-        removeEventIfExist(brew_ev.eventlabel)
-        removeEventIfExist(drink_ev.eventlabel)
+        mas_rmEVL(brew_ev.eventlabel)
+        mas_rmEVL(drink_ev.eventlabel)
 
 
     def _mas_startupHotChocLogic():
@@ -4158,7 +4158,7 @@ init 2 python:
                 if brew_ev.conditional is not None and eval(brew_ev.conditional):
                     # even though this in inaccurate, it works for the
                     # immersive purposes, so whatever.
-                    removeEventIfExist(brew_ev.eventlabel)
+                    mas_rmEVL(brew_ev.eventlabel)
                     mas_drinkHotChoc(persistent._mas_c_hotchoc_brew_time)
 
                     if not still_drink(persistent._mas_c_hotchoc_cup_done):
@@ -4178,7 +4178,7 @@ init 2 python:
                 brew_ev.conditional = None
                 brew_ev.action = None
                 persistent._mas_c_hotchoc_brew_time = None
-                removeEventIfExist(brew_ev.eventlabel)
+                mas_rmEVL(brew_ev.eventlabel)
 
                 # make sure she has the cup, just in case
                 if not monika_chr.is_wearing_acs(mas_acs_hotchoc_mug):

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -1161,9 +1161,9 @@ init python:
     import datetime
 
     def addEvent(
-            event, 
+            event,
             eventdb=None,
-            skipCalendar=False, 
+            skipCalendar=False,
             code="EVE"
         ):
         #
@@ -1861,7 +1861,7 @@ label call_next_event:
         if (
                 not store.mas_globals.in_idle_mode
                 and ((ev is not None and "skip alert" not in ev.rules) or ev is None)
-                and not (event_label.startswith("greeting_") or event_label.startswith("bye_"))
+                and not mas_isRstBlk(event_label)
             ):
             #Create a new notif
             call display_notif(m_name, random.choice(notif_quips), "Topic Alerts")

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -20,7 +20,7 @@ init -1 python:
         "Enable this to let Monika repeat topics that you have already seen."
     )
     layout.MAS_TT_NOTIF = (
-        "Enabling this will let Monika use your system's notifications "
+        "Enabling this will let Monika use your system's notifications and check if MAS is your active window "
     )
     layout.MAS_TT_NOTIF_SOUND = (
         "If enabled, a custom notification sound will play for Monika's notifications "

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -1765,21 +1765,21 @@ init 20 python:
         # If affection level between -15 and -20 and you haven't seen the label before, push this event where Monika mentions she's a little upset with the player.
         # This is an indicator you are heading in a negative direction.
         if curr_affection <= -15 and not seen_event("mas_affection_upsetwarn"):
-            queueEvent("mas_affection_upsetwarn")
+            queueEvent("mas_affection_upsetwarn", notify=True)
 
         # If affection level between 15 and 20 and you haven't seen the label before, push this event where Monika mentions she's really enjoying spending time with you.
         # This is an indicator you are heading in a positive direction.
         elif 15 <= curr_affection and not seen_event("mas_affection_happynotif"):
-            queueEvent("mas_affection_happynotif")
+            queueEvent("mas_affection_happynotif", notify=True)
 
         # If affection level is greater than 100 and you haven't seen the label yet, push this event where Monika will allow you to give her a nick name.
         elif curr_affection >= 100 and not seen_event("monika_affection_nickname"):
-            queueEvent("monika_affection_nickname")
+            queueEvent("monika_affection_nickname", notify=True)
 
         # If affection level is less than -50 and the label hasn't been seen yet, push this event where Monika says she's upset with you and wants you to apologize.
         elif curr_affection <= -50 and not seen_event("mas_affection_apology"):
             if not persistent._mas_disable_sorry:
-                queueEvent("mas_affection_apology")
+                queueEvent("mas_affection_apology", notify=True)
         # If affection level is equal or less than -100 and the label hasn't been seen yet, push this event where Monika says she's upset with you and wants you to apologize.
         elif curr_affection <= -100 and not seen_event("greeting_tears"):
             mas_unlockEVL("greeting_tears", "GRE")

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -758,6 +758,19 @@ label spaceroom(start_bg=None, hide_mask=False, hide_monika=False, dissolve_all=
                 morning_flag = False
                 monika_room = "monika_room"
 
+        ## are we hiding monika
+        if not hide_monika:
+            if force_exp is None:
+#                force_exp = "monika idle"
+                if dissolve_all:
+                    force_exp = store.mas_affection._force_exp()
+
+                else:
+                    force_exp = "monika idle"
+
+            if not renpy.showing(force_exp):
+                renpy.show(force_exp, at_list=[t11], zorder=MAS_MONIKA_Z)
+
         # if we onyl want to dissolve masks, then we dissolve now
         if not dissolve_all and not hide_mask:
             mas_drawSpaceroomMasks(dissolve_masks)
@@ -777,19 +790,6 @@ label spaceroom(start_bg=None, hide_mask=False, hide_monika=False, dissolve_all=
                 )
                 mas_calShowOverlay()
 
-        ## are we hiding monika
-        if not hide_monika:
-            if force_exp is None:
-#                force_exp = "monika idle"
-                if dissolve_all:
-                    force_exp = store.mas_affection._force_exp()
-
-                else:
-                    force_exp = "monika idle"
-
-            if not renpy.showing(force_exp):
-                renpy.show(force_exp, at_list=[t11], zorder=MAS_MONIKA_Z) 
-#            show monika idle at t11 zorder MAS_MONIKA_Z
 
     # vignette
     if store.mas_globals.show_vignette:
@@ -1499,7 +1499,7 @@ label ch30_post_mid_loop_eval:
             $ mas_randchat.setWaitingTime()
 
         window auto
-        
+
 #        python:
 #            if (
 #                    mas_battery_supported

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1545,7 +1545,7 @@ label mas_ch30_select_unseen:
             # no repeats means we should push randomlimit if appropriate,
             # otherwise stay slient
             if not seen_random_limit:
-                $ pushEvent("random_limit_reached", notify=True)
+                $ pushEvent("random_limit_reached")
 
             jump post_pick_random_topic
 

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1066,14 +1066,6 @@ label ch30_autoload:
     if persistent._mas_affection["affection"] <= -115:
         jump mas_affection_finalfarewell_start
 
-    # sanitiziing the event_list from bull shit
-    if len(persistent.event_list) > 0:
-        python:
-            persistent.event_list = [
-                ev_label for ev_label in persistent.event_list
-                if renpy.has_label(ev_label)
-            ]
-
     # set this to None for now
     $ selected_greeting = None
 
@@ -1553,7 +1545,7 @@ label mas_ch30_select_unseen:
             # no repeats means we should push randomlimit if appropriate,
             # otherwise stay slient
             if not seen_random_limit:
-                $ pushEvent("random_limit_reached")
+                $ pushEvent("random_limit_reached", notify=True)
 
             jump post_pick_random_topic
 
@@ -1623,8 +1615,7 @@ label ch30_reset:
             if len(listRpy) == 0 and persistent.current_monikatopic == "monika_rpy_files":
                 $ persistent.current_monikatopic = 0
 
-            while "monika_rpy_files" in persistent.event_list:
-                $ persistent.event_list.remove("monika_rpy_files")
+            $ mas_rmallEVL("monika_rpy_files")
 
         elif len(listRpy) != 0:
             $ queueEvent("monika_rpy_files")
@@ -1838,5 +1829,23 @@ label ch30_reset:
 
     # make sure nothing the player has derandomed is now random
     $ mas_check_player_derand()
+
+    # clean up the event list of baka events
+    python:
+        for index in range(len(persistent.event_list)-1, -1, -1):
+            item = persistent.event_list[index]
+
+            # type check
+            if type(item) != tuple:
+                new_data = (item, False)
+            else:
+                new_data = item
+
+            # label check
+            if renpy.has_label(new_data[0]):
+                persistent.event_list[index] = new_data
+
+            else:
+                persistent.event_list.pop(index)
 
     return

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1105,8 +1105,7 @@ label i_greeting_monikaroom:
     $ has_listened = False
 
     # need to remove this in case the player quits the special player bday greet before the party and doesn't return until the next day
-    if "mas_player_bday_no_restart" in persistent.event_list:
-        $ persistent.event_list.remove("mas_player_bday_no_restart")
+    $ mas_rmallEVL("mas_player_bday_no_restart")
 
     # FALL THROUGH
 label monikaroom_greeting_choice:

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -3590,8 +3590,7 @@ label mas_player_bday_cake:
             m 1ekbfa "I love you, [player]! Let's enjoy your special day~"
         else:
             m 1ekbfa "I love you, [player]!"
-    if "mas_player_bday_no_restart" in persistent.event_list:
-        $ persistent.event_list.remove("mas_player_bday_no_restart")
+    $ mas_rmallEVL("mas_player_bday_no_restart")
     return
 
 # event for if you went on a date pre-bday and return on bday
@@ -3639,7 +3638,7 @@ init 5 python:
     )
 
 label mas_player_bday_no_restart:
-    if "mas_player_bday_ret_on_bday" in persistent.event_list:
+    if mas_findEVL("mas_player_bday_ret_on_bday") >= 0:
         #TODO: priority rules should be set-up here
         return
     m 3rksdla "Well [player], I was hoping to do something a little more fun, but you've been so sweet and haven't left all day long, so..."
@@ -3992,7 +3991,7 @@ init -876 python in mas_delact:
         ev.random = False
         ev.unlocked = False
         store.mas_idle_mailbox.send_rebuild_msg()
-        store.removeEventIfExist(ev.eventlabel)
+        store.mas_rmEVL(ev.eventlabel)
         return True
 
 
@@ -4148,7 +4147,7 @@ init -876 python in mas_delact:
         ev.unlocked = False
         ev.random = False
         store.mas_idle_mailbox.send_rebuild_msg()
-        store.removeEventIfExist(ev.eventlabel)
+        store.mas_rmEVL(ev.eventlabel)
         return True
 
 
@@ -4211,7 +4210,7 @@ init -876 python in mas_delact:
         ev.unlocked = False
         ev.random = False
         store.mas_idle_mailbox.send_rebuild_msg()
-        store.removeEventIfExist(ev.eventlabel)
+        store.mas_rmEVL(ev.eventlabel)
         return True
 
 
@@ -4267,7 +4266,7 @@ init -876 python in mas_delact:
         ev.unlocked = False
         ev.random = False
         store.mas_idle_mailbox.send_rebuild_msg()
-        store.removeEventIfExist(ev.eventlabel)
+        store.mas_rmEVL(ev.eventlabel)
         return True
 
 
@@ -4326,7 +4325,7 @@ init -876 python in mas_delact:
         ev.unlocked = False
         ev.pool = False
         store.mas_idle_mailbox.send_rebuild_msg()
-        store.removeEventIfExist(ev.eventlabel)
+        store.mas_rmEVL(ev.eventlabel)
         return True
 
 
@@ -4747,8 +4746,7 @@ label mas_gone_over_f14_check:
     if checkout_time is not None and checkout_time.date() < mas_f14:
         $ persistent._mas_f14_spent_f14 = True
         $ persistent._mas_f14_gone_over_f14 = True
-        if "mas_f14_no_time_spent" in persistent.event_list:
-            $ persistent.event_list.remove("mas_f14_no_time_spent")
+        $ mas_rmallEVL("mas_f14_no_time_spent")
     return
 
 label greeting_gone_over_f14:

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -619,6 +619,10 @@ label unlock_piano:
 # NOTE: this has beenpartially disabled
 label random_limit_reached:
     $seen_random_limit=True
+
+    #Notif so people don't get stuck here
+    call display_notif(m_name, "Hey [player]...", "Topic Alerts")
+
     python:
         limit_quips = [
             "It seems I'm at a loss on what to say.",
@@ -1295,6 +1299,7 @@ init 5 python:
             persistent.event_database,
             eventlabel="mas_coffee_finished_brewing",
             show_in_idle=True,
+            rules={"skip alert": None}
         )
     )
 
@@ -1352,6 +1357,7 @@ init 5 python:
             persistent.event_database,
             eventlabel="mas_coffee_finished_drinking",
             show_in_idle=True,
+            rules={"skip alert": None}
         )
     )
 
@@ -1424,6 +1430,7 @@ init 5 python:
             persistent.event_database,
             eventlabel="mas_c_hotchoc_finished_brewing",
             show_in_idle=True,
+            rules={"skip alert": None}
         )
     )
 
@@ -1481,6 +1488,7 @@ init 5 python:
             persistent.event_database,
             eventlabel="mas_c_hotchoc_finished_drinking",
             show_in_idle=True,
+            rules={"skip alert": None}
         )
     )
 

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -485,8 +485,7 @@ label birthdate_set:
         m 3hua "We'll just have to celebrate your birthday on March 1st on non-leap years then, [player]."
 
     $ persistent._mas_player_confirmed_bday = True
-    if "calendar_birthdate" in persistent.event_list:
-        $ persistent.event_list.remove("calendar_birthdate")
+    $ mas_rmallEVL("calendar_birthdate")
     return
 
 init 5 python:
@@ -2470,7 +2469,8 @@ label mas_notification_windowreact:
 
     if renpy.windows:
         m 3rksdla "Also, since you're using Windows...I now know how to check what your active window is..."
-        m 1hksdlb "Don't worry though, I know you might not want me constantly watching you, and I respect your privacy."
+        m 3eub "So if I have something to talk about while I'm in the background, I can let you know!"
+        m 3hksdlb "And don't worry, I know you might not want me constantly watching you, and I respect your privacy."
         m 3eua "So I'll only look at what you're doing if you're okay with it."
         m 2eua "If you enable 'Window Reacts' in the settings menu, that'll tell me you're fine with me looking around."
 

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -1302,7 +1302,7 @@ init 5 python:
 
 label mas_coffee_finished_brewing:
 
-    if not store.mas_globals.in_idle_mode:
+    if mas_isFocused() and not store.mas_globals.in_idle_mode:
         m 1esd "Oh, coffee's done."
 
     #moving this here so she uses this line to 'pull her chair back'
@@ -1312,8 +1312,8 @@ label mas_coffee_finished_brewing:
     # this line is here so we dont it looks better when we hide monika
     show emptydesk at i11 zorder 9
 
-    if store.mas_globals.in_idle_mode:
-        # idle pauses 
+    if store.mas_globals.in_idle_mode or not mas_isFocused():
+        # idle pauses
         m 1eua "I'm going to grab some coffee. I'll be right back.{w=1}{nw}"
 
     else:
@@ -1337,7 +1337,7 @@ label mas_coffee_finished_brewing:
     $ renpy.pause(0.5, hard=True)
     call monika_zoom_transition(curr_zoom, 1.0)
 
-    if store.mas_globals.in_idle_mode:
+    if store.mas_globals.in_idle_mode or not mas_isFocused():
         m 1hua "Back!{w=1.5}{nw}"
 
     else:
@@ -1362,7 +1362,7 @@ label mas_coffee_finished_drinking:
     # monika only gets a new cup between 6am and noon
     $ get_new_cup = mas_isCoffeeTime()
 
-    if not store.mas_globals.in_idle_mode:
+    if mas_isFocused() and not store.mas_globals.in_idle_mode:
         m 1esd "Oh, I've finished my coffee."
 
     #moving this here so she uses this line to 'pull her chair back'
@@ -1371,7 +1371,7 @@ label mas_coffee_finished_drinking:
 
     show emptydesk at i11 zorder 9
 
-    if store.mas_globals.in_idle_mode:
+    if store.mas_globals.in_idle_mode or not mas_isFocused():
         if get_new_cup:
             # its currently morning, monika should get another drink
             m 1eua "I'm going to get another cup of coffee. I'll be right back.{w=1}{nw}"
@@ -1407,7 +1407,7 @@ label mas_coffee_finished_drinking:
     $ renpy.pause(0.5, hard=True)
     call monika_zoom_transition(curr_zoom, 1.0)
 
-    if store.mas_globals.in_idle_mode:
+    if store.mas_globals.in_idle_mode or not mas_isFocused():
         m 1hua "Back!{w=1.5}{nw}"
 
     else:
@@ -1431,7 +1431,7 @@ init 5 python:
 
 label mas_c_hotchoc_finished_brewing:
 
-    if not store.mas_globals.in_idle_mode:
+    if mas_isFocused() and not store.mas_globals.in_idle_mode:
         m 1esd "Oh, my hot chocolate is ready."
 
     #moving this here so she uses this line to 'pull her chair back'
@@ -1441,7 +1441,7 @@ label mas_c_hotchoc_finished_brewing:
     # this line is here so we dont it looks better when we hide monika
     show emptydesk at i11 zorder 9
 
-    if store.mas_globals.in_idle_mode:
+    if store.mas_globals.in_idle_mode or not mas_isFocused():
         m 1eua "I'm going to grab some hot chocolate. I'll be right back.{w=1}{nw}"
 
     else:
@@ -1465,7 +1465,7 @@ label mas_c_hotchoc_finished_brewing:
     $ renpy.pause(0.5, hard=True)
     call monika_zoom_transition(curr_zoom, 1.0)
 
-    if store.mas_globals.in_idle_mode:
+    if store.mas_globals.in_idle_mode or not mas_isFocused():
         m 1hua "Back!{w=1.5}{nw}"
 
     else:
@@ -1491,7 +1491,7 @@ label mas_c_hotchoc_finished_drinking:
     # monika only gets a new cup between 6am and noon
     $ get_new_cup = mas_isHotChocTime()
 
-    if not store.mas_globals.in_idle_mode:
+    if mas_isFocused() and not store.mas_globals.in_idle_mode:
         m 1esd "Oh, I've finished my hot chocolate."
 
     #moving this here so she uses this line to 'pull her chair back'
@@ -1500,7 +1500,7 @@ label mas_c_hotchoc_finished_drinking:
 
     show emptydesk at i11 zorder 9
 
-    if store.mas_globals.in_idle_mode:
+    if store.mas_globals.in_idle_mode or not mas_isFocused():
         if get_new_cup:
             # its currently morning, monika should get another drink
             m 1eua "I'm going to get another cup of hot chocolate. I'll be right back.{w=1}{nw}"
@@ -1537,7 +1537,7 @@ label mas_c_hotchoc_finished_drinking:
     $ renpy.pause(0.5, hard=True)
     call monika_zoom_transition(curr_zoom, 1.0)
 
-    if store.mas_globals.in_idle_mode:
+    if store.mas_globals.in_idle_mode or not mas_isFocused():
         m 1hua "Back!{w=1.5}{nw}"
 
     else:

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -120,7 +120,7 @@ init -1 python:
             if persistent._mas_sensitive_mode and sel_ev.sensitive:
                 return
 
-            pushEvent(sel_ev.eventlabel)
+            pushEvent(sel_ev.eventlabel, notify=True)
 #            persistent.random_seen += 1
 
 
@@ -349,12 +349,12 @@ init python:
             # need to make sure we don't allow any events that start with monika_ that don't have a prompt
             and ev.prompt != ev.eventlabel
         ):
-            if "mas_topic_derandom" not in persistent.event_list:
+            if mas_findEVL("mas_topic_derandom") < 0:
                 persistent.flagged_monikatopic = ev.eventlabel
                 pushEvent('mas_topic_derandom',True)
                 renpy.notify(__("Topic flagged for removal."))
             else:
-                persistent.event_list.remove("mas_topic_derandom")
+                mas_rmEVL("mas_topic_derandom")
                 renpy.notify(__("Topic flag removed."))
 
     def mas_bookmark_topic(ev_label=None):

--- a/Monika After Story/game/sprite-chart-20.rpy
+++ b/Monika After Story/game/sprite-chart-20.rpy
@@ -15,7 +15,7 @@ image monika 1cua:
             choice:
                 7
         "monika 1dua_static"
-        0.05
+        0.06
         repeat
 
 image monika 1efb:
@@ -29,7 +29,7 @@ image monika 1efb:
             choice:
                 7
         "monika 1dfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 1efc:
@@ -43,7 +43,7 @@ image monika 1efc:
             choice:
                 7
         "monika 1dfc_static"
-        0.05
+        0.06
         repeat
 
 image monika 1efd:
@@ -57,7 +57,7 @@ image monika 1efd:
             choice:
                 7
         "monika 1dfd_static"
-        0.05
+        0.06
         repeat
 
 image monika 1efo:
@@ -71,7 +71,7 @@ image monika 1efo:
             choice:
                 7
         "monika 1dfo_static"
-        0.05
+        0.06
         repeat
 
 image monika 1efp:
@@ -85,7 +85,7 @@ image monika 1efp:
             choice:
                 7
         "monika 1dfp_static"
-        0.05
+        0.06
         repeat
 
 image monika 1eft:
@@ -99,7 +99,7 @@ image monika 1eft:
             choice:
                 7
         "monika 1dft_static"
-        0.05
+        0.06
         repeat
 
 image monika 1eftsu:
@@ -113,7 +113,7 @@ image monika 1eftsu:
             choice:
                 7
         "monika 1dftsu_static"
-        0.05
+        0.06
         repeat
 
 image monika 1efu:
@@ -127,7 +127,7 @@ image monika 1efu:
             choice:
                 7
         "monika 1dfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 1efw:
@@ -141,7 +141,7 @@ image monika 1efw:
             choice:
                 7
         "monika 1dfw_static"
-        0.05
+        0.06
         repeat
 
 image monika 1efx:
@@ -155,7 +155,7 @@ image monika 1efx:
             choice:
                 7
         "monika 1dfx_static"
-        0.05
+        0.06
         repeat
 
 image monika 1eka:
@@ -169,7 +169,7 @@ image monika 1eka:
             choice:
                 7
         "monika 1dka_static"
-        0.05
+        0.06
         repeat
 
 image monika 1ekb:
@@ -183,7 +183,7 @@ image monika 1ekb:
             choice:
                 7
         "monika 1dkb_static"
-        0.05
+        0.06
         repeat
 
 image monika 1ekbfa:
@@ -197,7 +197,7 @@ image monika 1ekbfa:
             choice:
                 7
         "monika 1dkbfa_static"
-        0.05
+        0.06
         repeat
 
 image monika 1ekbfb:
@@ -211,7 +211,7 @@ image monika 1ekbfb:
             choice:
                 7
         "monika 1dkbfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 1ekbfu:
@@ -225,7 +225,7 @@ image monika 1ekbfu:
             choice:
                 7
         "monika 1dkbfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 1ekbla:
@@ -239,7 +239,7 @@ image monika 1ekbla:
             choice:
                 7
         "monika 1dkbla_static"
-        0.05
+        0.06
         repeat
 
 image monika 1ekbltua:
@@ -253,7 +253,7 @@ image monika 1ekbltua:
             choice:
                 7
         "monika 1dkbltua_static"
-        0.05
+        0.06
         repeat
 
 image monika 1ekbsa:
@@ -267,7 +267,7 @@ image monika 1ekbsa:
             choice:
                 7
         "monika 1dkbsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 1ekbsu:
@@ -281,7 +281,7 @@ image monika 1ekbsu:
             choice:
                 7
         "monika 1dkbsu_static"
-        0.05
+        0.06
         repeat
 
 image monika 1ekc:
@@ -295,7 +295,7 @@ image monika 1ekc:
             choice:
                 7
         "monika 1dkc_static"
-        0.05
+        0.06
         repeat
 
 image monika 1ekd:
@@ -309,7 +309,7 @@ image monika 1ekd:
             choice:
                 7
         "monika 1dkd_static"
-        0.05
+        0.06
         repeat
 
 image monika 1eksdla:
@@ -323,7 +323,7 @@ image monika 1eksdla:
             choice:
                 7
         "monika 1dksdla_static"
-        0.05
+        0.06
         repeat
 
 image monika 1eksdlb:
@@ -337,7 +337,7 @@ image monika 1eksdlb:
             choice:
                 7
         "monika 1dksdlb_static"
-        0.05
+        0.06
         repeat
 
 image monika 1eksdlc:
@@ -351,7 +351,7 @@ image monika 1eksdlc:
             choice:
                 7
         "monika 1dksdlc_static"
-        0.05
+        0.06
         repeat
 
 image monika 1eksdld:
@@ -365,7 +365,7 @@ image monika 1eksdld:
             choice:
                 7
         "monika 1dksdld_static"
-        0.05
+        0.06
         repeat
 
 image monika 1ekt:
@@ -379,7 +379,7 @@ image monika 1ekt:
             choice:
                 7
         "monika 1dkt_static"
-        0.05
+        0.06
         repeat
 
 image monika 1ektda:
@@ -393,7 +393,7 @@ image monika 1ektda:
             choice:
                 7
         "monika 1dktda_static"
-        0.05
+        0.06
         repeat
 
 image monika 1ektdc:
@@ -407,7 +407,7 @@ image monika 1ektdc:
             choice:
                 7
         "monika 1dktdc_static"
-        0.05
+        0.06
         repeat
 
 image monika 1ektdd:
@@ -421,7 +421,7 @@ image monika 1ektdd:
             choice:
                 7
         "monika 1dktdd_static"
-        0.05
+        0.06
         repeat
 
 image monika 1ektpa:
@@ -435,7 +435,7 @@ image monika 1ektpa:
             choice:
                 7
         "monika 1dktpa_static"
-        0.05
+        0.06
         repeat
 
 image monika 1ektpu:
@@ -449,7 +449,7 @@ image monika 1ektpu:
             choice:
                 7
         "monika 1dktpu_static"
-        0.05
+        0.06
         repeat
 
 image monika 1ektsc:
@@ -463,7 +463,7 @@ image monika 1ektsc:
             choice:
                 7
         "monika 1dktsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 1ektsd:
@@ -477,7 +477,7 @@ image monika 1ektsd:
             choice:
                 7
         "monika 1dktsd_static"
-        0.05
+        0.06
         repeat
 
 image monika 1ektua:
@@ -491,7 +491,7 @@ image monika 1ektua:
             choice:
                 7
         "monika 1dktua_static"
-        0.05
+        0.06
         repeat
 
 image monika 1esa:
@@ -505,7 +505,7 @@ image monika 1esa:
             choice:
                 7
         "monika 1dsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 1esb:
@@ -519,7 +519,7 @@ image monika 1esb:
             choice:
                 7
         "monika 1dsb_static"
-        0.05
+        0.06
         repeat
 
 image monika 1esc:
@@ -533,7 +533,7 @@ image monika 1esc:
             choice:
                 7
         "monika 1dsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 1esd:
@@ -547,7 +547,7 @@ image monika 1esd:
             choice:
                 7
         "monika 1dsd_static"
-        0.05
+        0.06
         repeat
 
 image monika 1eua:
@@ -561,7 +561,7 @@ image monika 1eua:
             choice:
                 7
         "monika 1dua_static"
-        0.05
+        0.06
         repeat
 
 image monika 1eub:
@@ -575,7 +575,7 @@ image monika 1eub:
             choice:
                 7
         "monika 1dub_static"
-        0.05
+        0.06
         repeat
 
 image monika 1eubfa:
@@ -589,7 +589,7 @@ image monika 1eubfa:
             choice:
                 7
         "monika 1dubfa_static"
-        0.05
+        0.06
         repeat
 
 image monika 1eubfu:
@@ -603,7 +603,7 @@ image monika 1eubfu:
             choice:
                 7
         "monika 1dubfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 1euc:
@@ -617,7 +617,7 @@ image monika 1euc:
             choice:
                 7
         "monika 1duc_static"
-        0.05
+        0.06
         repeat
 
 image monika 1eud:
@@ -631,7 +631,7 @@ image monika 1eud:
             choice:
                 7
         "monika 1dud_static"
-        0.05
+        0.06
         repeat
 
 image monika 1kua:
@@ -657,7 +657,7 @@ image monika 1lfb:
             choice:
                 7
         "monika 1dfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 1lfc:
@@ -671,7 +671,7 @@ image monika 1lfc:
             choice:
                 7
         "monika 1dfc_static"
-        0.05
+        0.06
         repeat
 
 image monika 1lfd:
@@ -685,7 +685,7 @@ image monika 1lfd:
             choice:
                 7
         "monika 1dfd_static"
-        0.05
+        0.06
         repeat
 
 image monika 1lftsc:
@@ -699,7 +699,7 @@ image monika 1lftsc:
             choice:
                 7
         "monika 1dftsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 1lfu:
@@ -713,7 +713,7 @@ image monika 1lfu:
             choice:
                 7
         "monika 1dfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 1lfw:
@@ -727,7 +727,7 @@ image monika 1lfw:
             choice:
                 7
         "monika 1dfw_static"
-        0.05
+        0.06
         repeat
 
 image monika 1lfx:
@@ -741,7 +741,7 @@ image monika 1lfx:
             choice:
                 7
         "monika 1dfx_static"
-        0.05
+        0.06
         repeat
 
 image monika 1lkbfa:
@@ -755,7 +755,7 @@ image monika 1lkbfa:
             choice:
                 7
         "monika 1dkbfa_static"
-        0.05
+        0.06
         repeat
 
 image monika 1lkbfb:
@@ -769,7 +769,7 @@ image monika 1lkbfb:
             choice:
                 7
         "monika 1dkbfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 1lkbltpa:
@@ -783,7 +783,7 @@ image monika 1lkbltpa:
             choice:
                 7
         "monika 1dkbltpa_static"
-        0.05
+        0.06
         repeat
 
 image monika 1lkbsa:
@@ -797,7 +797,7 @@ image monika 1lkbsa:
             choice:
                 7
         "monika 1dkbsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 1lkbsc:
@@ -811,7 +811,7 @@ image monika 1lkbsc:
             choice:
                 7
         "monika 1dkbsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 1lksdla:
@@ -825,7 +825,7 @@ image monika 1lksdla:
             choice:
                 7
         "monika 1dksdla_static"
-        0.05
+        0.06
         repeat
 
 image monika 1lksdlb:
@@ -839,7 +839,7 @@ image monika 1lksdlb:
             choice:
                 7
         "monika 1dksdlb_static"
-        0.05
+        0.06
         repeat
 
 image monika 1lksdlc:
@@ -853,7 +853,7 @@ image monika 1lksdlc:
             choice:
                 7
         "monika 1dksdlc_static"
-        0.05
+        0.06
         repeat
 
 image monika 1lksdld:
@@ -867,7 +867,7 @@ image monika 1lksdld:
             choice:
                 7
         "monika 1dksdld_static"
-        0.05
+        0.06
         repeat
 
 image monika 1lksdlw:
@@ -881,7 +881,7 @@ image monika 1lksdlw:
             choice:
                 7
         "monika 1dksdlw_static"
-        0.05
+        0.06
         repeat
 
 image monika 1lksdrb:
@@ -895,7 +895,7 @@ image monika 1lksdrb:
             choice:
                 7
         "monika 1dksdrb_static"
-        0.05
+        0.06
         repeat
 
 image monika 1lktsc:
@@ -909,7 +909,7 @@ image monika 1lktsc:
             choice:
                 7
         "monika 1dktsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 1lsbsa:
@@ -923,7 +923,7 @@ image monika 1lsbsa:
             choice:
                 7
         "monika 1dsbsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 1lsbssdrb:
@@ -937,7 +937,7 @@ image monika 1lsbssdrb:
             choice:
                 7
         "monika 1dsbssdrb_static"
-        0.05
+        0.06
         repeat
 
 image monika 1lsc:
@@ -951,7 +951,7 @@ image monika 1lsc:
             choice:
                 7
         "monika 1dsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 1lssdrb:
@@ -965,7 +965,7 @@ image monika 1lssdrb:
             choice:
                 7
         "monika 1dssdrb_static"
-        0.05
+        0.06
         repeat
 
 image monika 1lssdrc:
@@ -979,7 +979,7 @@ image monika 1lssdrc:
             choice:
                 7
         "monika 1dssdrc_static"
-        0.05
+        0.06
         repeat
 
 image monika 1ltsdlc:
@@ -993,7 +993,7 @@ image monika 1ltsdlc:
             choice:
                 7
         "monika 1dtsdlc_static"
-        0.05
+        0.06
         repeat
 
 image monika 1lubfb:
@@ -1007,7 +1007,7 @@ image monika 1lubfb:
             choice:
                 7
         "monika 1dubfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 1lud:
@@ -1021,7 +1021,7 @@ image monika 1lud:
             choice:
                 7
         "monika 1dud_static"
-        0.05
+        0.06
         repeat
 
 image monika 1rfb:
@@ -1035,7 +1035,7 @@ image monika 1rfb:
             choice:
                 7
         "monika 1dfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 1rfc:
@@ -1049,7 +1049,7 @@ image monika 1rfc:
             choice:
                 7
         "monika 1dfc_static"
-        0.05
+        0.06
         repeat
 
 image monika 1rfd:
@@ -1063,7 +1063,7 @@ image monika 1rfd:
             choice:
                 7
         "monika 1dfd_static"
-        0.05
+        0.06
         repeat
 
 image monika 1rfu:
@@ -1077,7 +1077,7 @@ image monika 1rfu:
             choice:
                 7
         "monika 1dfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 1rfw:
@@ -1091,7 +1091,7 @@ image monika 1rfw:
             choice:
                 7
         "monika 1dfw_static"
-        0.05
+        0.06
         repeat
 
 image monika 1rfx:
@@ -1105,7 +1105,7 @@ image monika 1rfx:
             choice:
                 7
         "monika 1dfx_static"
-        0.05
+        0.06
         repeat
 
 image monika 1rkbfb:
@@ -1119,7 +1119,7 @@ image monika 1rkbfb:
             choice:
                 7
         "monika 1dkbfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 1rkbfsdlb:
@@ -1133,7 +1133,7 @@ image monika 1rkbfsdlb:
             choice:
                 7
         "monika 1dkbfsdlb_static"
-        0.05
+        0.06
         repeat
 
 image monika 1rkbsa:
@@ -1147,7 +1147,7 @@ image monika 1rkbsa:
             choice:
                 7
         "monika 1dkbsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 1rkbsb:
@@ -1161,7 +1161,7 @@ image monika 1rkbsb:
             choice:
                 7
         "monika 1dkbsb_static"
-        0.05
+        0.06
         repeat
 
 image monika 1rkc:
@@ -1175,7 +1175,7 @@ image monika 1rkc:
             choice:
                 7
         "monika 1dkc_static"
-        0.05
+        0.06
         repeat
 
 image monika 1rkd:
@@ -1189,7 +1189,7 @@ image monika 1rkd:
             choice:
                 7
         "monika 1dkd_static"
-        0.05
+        0.06
         repeat
 
 image monika 1rksdla:
@@ -1203,7 +1203,7 @@ image monika 1rksdla:
             choice:
                 7
         "monika 1dksdla_static"
-        0.05
+        0.06
         repeat
 
 image monika 1rksdlb:
@@ -1217,7 +1217,7 @@ image monika 1rksdlb:
             choice:
                 7
         "monika 1dksdlb_static"
-        0.05
+        0.06
         repeat
 
 image monika 1rksdlc:
@@ -1231,7 +1231,7 @@ image monika 1rksdlc:
             choice:
                 7
         "monika 1dksdlc_static"
-        0.05
+        0.06
         repeat
 
 image monika 1rksdld:
@@ -1245,7 +1245,7 @@ image monika 1rksdld:
             choice:
                 7
         "monika 1dksdld_static"
-        0.05
+        0.06
         repeat
 
 image monika 1rktsc:
@@ -1259,7 +1259,7 @@ image monika 1rktsc:
             choice:
                 7
         "monika 1dktsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 1rsbssdlu:
@@ -1273,7 +1273,7 @@ image monika 1rsbssdlu:
             choice:
                 7
         "monika 1dsbssdlu_static"
-        0.05
+        0.06
         repeat
 
 image monika 1rsc:
@@ -1287,7 +1287,7 @@ image monika 1rsc:
             choice:
                 7
         "monika 1dsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 1rssdlb:
@@ -1301,7 +1301,7 @@ image monika 1rssdlb:
             choice:
                 7
         "monika 1dssdlb_static"
-        0.05
+        0.06
         repeat
 
 image monika 1ruc:
@@ -1315,7 +1315,7 @@ image monika 1ruc:
             choice:
                 7
         "monika 1duc_static"
-        0.05
+        0.06
         repeat
 
 image monika 1rud:
@@ -1329,7 +1329,7 @@ image monika 1rud:
             choice:
                 7
         "monika 1dud_static"
-        0.05
+        0.06
         repeat
 
 image monika 1rusdlb:
@@ -1343,7 +1343,7 @@ image monika 1rusdlb:
             choice:
                 7
         "monika 1dusdlb_static"
-        0.05
+        0.06
         repeat
 
 image monika 1sfa:
@@ -1357,7 +1357,7 @@ image monika 1sfa:
             choice:
                 7
         "monika 1dfa_static"
-        0.05
+        0.06
         repeat
 
 image monika 1skbla:
@@ -1371,7 +1371,7 @@ image monika 1skbla:
             choice:
                 7
         "monika 1dkbla_static"
-        0.05
+        0.06
         repeat
 
 image monika 1skbltda:
@@ -1385,7 +1385,7 @@ image monika 1skbltda:
             choice:
                 7
         "monika 1dkbltda_static"
-        0.05
+        0.06
         repeat
 
 image monika 1skbltpa:
@@ -1399,7 +1399,7 @@ image monika 1skbltpa:
             choice:
                 7
         "monika 1dkbltpa_static"
-        0.05
+        0.06
         repeat
 
 image monika 1sua:
@@ -1413,7 +1413,7 @@ image monika 1sua:
             choice:
                 7
         "monika 1dua_static"
-        0.05
+        0.06
         repeat
 
 image monika 1sub:
@@ -1427,7 +1427,7 @@ image monika 1sub:
             choice:
                 7
         "monika 1dub_static"
-        0.05
+        0.06
         repeat
 
 image monika 1subfa:
@@ -1441,7 +1441,7 @@ image monika 1subfa:
             choice:
                 7
         "monika 1dubfa_static"
-        0.05
+        0.06
         repeat
 
 image monika 1subfb:
@@ -1455,7 +1455,7 @@ image monika 1subfb:
             choice:
                 7
         "monika 1dubfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 1subftsb:
@@ -1469,7 +1469,7 @@ image monika 1subftsb:
             choice:
                 7
         "monika 1dubftsb_static"
-        0.05
+        0.06
         repeat
 
 image monika 1sublo:
@@ -1483,7 +1483,7 @@ image monika 1sublo:
             choice:
                 7
         "monika 1dublo_static"
-        0.05
+        0.06
         repeat
 
 image monika 1subsa:
@@ -1497,7 +1497,7 @@ image monika 1subsa:
             choice:
                 7
         "monika 1dubsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 1suo:
@@ -1511,7 +1511,7 @@ image monika 1suo:
             choice:
                 7
         "monika 1duo_static"
-        0.05
+        0.06
         repeat
 
 image monika 1sutsa:
@@ -1525,7 +1525,7 @@ image monika 1sutsa:
             choice:
                 7
         "monika 1dutsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 1tfb:
@@ -1539,7 +1539,7 @@ image monika 1tfb:
             choice:
                 7
         "monika 1dfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 1tfc:
@@ -1553,7 +1553,7 @@ image monika 1tfc:
             choice:
                 7
         "monika 1dfc_static"
-        0.05
+        0.06
         repeat
 
 image monika 1tfd:
@@ -1567,7 +1567,7 @@ image monika 1tfd:
             choice:
                 7
         "monika 1dfd_static"
-        0.05
+        0.06
         repeat
 
 image monika 1tfu:
@@ -1581,7 +1581,7 @@ image monika 1tfu:
             choice:
                 7
         "monika 1dfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 1tfx:
@@ -1595,7 +1595,7 @@ image monika 1tfx:
             choice:
                 7
         "monika 1dfx_static"
-        0.05
+        0.06
         repeat
 
 image monika 1tkbfu:
@@ -1609,7 +1609,7 @@ image monika 1tkbfu:
             choice:
                 7
         "monika 1dkbfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 1tkc:
@@ -1623,7 +1623,7 @@ image monika 1tkc:
             choice:
                 7
         "monika 1dkc_static"
-        0.05
+        0.06
         repeat
 
 image monika 1tkd:
@@ -1637,7 +1637,7 @@ image monika 1tkd:
             choice:
                 7
         "monika 1dkd_static"
-        0.05
+        0.06
         repeat
 
 image monika 1tku:
@@ -1651,7 +1651,7 @@ image monika 1tku:
             choice:
                 7
         "monika 1dku_static"
-        0.05
+        0.06
         repeat
 
 image monika 1tkx:
@@ -1665,7 +1665,7 @@ image monika 1tkx:
             choice:
                 7
         "monika 1dkx_static"
-        0.05
+        0.06
         repeat
 
 image monika 1tsb:
@@ -1679,7 +1679,7 @@ image monika 1tsb:
             choice:
                 7
         "monika 1dsb_static"
-        0.05
+        0.06
         repeat
 
 image monika 1tsbfa:
@@ -1693,7 +1693,7 @@ image monika 1tsbfa:
             choice:
                 7
         "monika 1dsbfa_static"
-        0.05
+        0.06
         repeat
 
 image monika 1tsbsa:
@@ -1707,7 +1707,7 @@ image monika 1tsbsa:
             choice:
                 7
         "monika 1dsbsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 1tsc:
@@ -1721,7 +1721,7 @@ image monika 1tsc:
             choice:
                 7
         "monika 1dsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 1tsu:
@@ -1735,7 +1735,7 @@ image monika 1tsu:
             choice:
                 7
         "monika 1dsu_static"
-        0.05
+        0.06
         repeat
 
 image monika 1ttu:
@@ -1749,7 +1749,7 @@ image monika 1ttu:
             choice:
                 7
         "monika 1dtu_static"
-        0.05
+        0.06
         repeat
 
 image monika 1tua:
@@ -1763,7 +1763,7 @@ image monika 1tua:
             choice:
                 7
         "monika 1dua_static"
-        0.05
+        0.06
         repeat
 
 image monika 1tub:
@@ -1777,7 +1777,7 @@ image monika 1tub:
             choice:
                 7
         "monika 1dub_static"
-        0.05
+        0.06
         repeat
 
 image monika 1tubfa:
@@ -1791,7 +1791,7 @@ image monika 1tubfa:
             choice:
                 7
         "monika 1dubfa_static"
-        0.05
+        0.06
         repeat
 
 image monika 1tubfb:
@@ -1805,7 +1805,7 @@ image monika 1tubfb:
             choice:
                 7
         "monika 1dubfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 1tubfu:
@@ -1819,7 +1819,7 @@ image monika 1tubfu:
             choice:
                 7
         "monika 1dubfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 1tubsa:
@@ -1833,7 +1833,7 @@ image monika 1tubsa:
             choice:
                 7
         "monika 1dubsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 1tuu:
@@ -1847,7 +1847,7 @@ image monika 1tuu:
             choice:
                 7
         "monika 1duu_static"
-        0.05
+        0.06
         repeat
 
 image monika 1wfa:
@@ -1861,7 +1861,7 @@ image monika 1wfa:
             choice:
                 7
         "monika 1dfa_static"
-        0.05
+        0.06
         repeat
 
 image monika 1wfw:
@@ -1875,7 +1875,7 @@ image monika 1wfw:
             choice:
                 7
         "monika 1dfw_static"
-        0.05
+        0.06
         repeat
 
 image monika 1wfx:
@@ -1889,7 +1889,7 @@ image monika 1wfx:
             choice:
                 7
         "monika 1dfx_static"
-        0.05
+        0.06
         repeat
 
 image monika 1wka:
@@ -1903,7 +1903,7 @@ image monika 1wka:
             choice:
                 7
         "monika 1dka_static"
-        0.05
+        0.06
         repeat
 
 image monika 1wkb:
@@ -1917,7 +1917,7 @@ image monika 1wkb:
             choice:
                 7
         "monika 1dkb_static"
-        0.05
+        0.06
         repeat
 
 image monika 1wkbltpa:
@@ -1931,7 +1931,7 @@ image monika 1wkbltpa:
             choice:
                 7
         "monika 1dkbltpa_static"
-        0.05
+        0.06
         repeat
 
 image monika 1wkbsc:
@@ -1945,7 +1945,7 @@ image monika 1wkbsc:
             choice:
                 7
         "monika 1dkbsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 1wkd:
@@ -1959,7 +1959,7 @@ image monika 1wkd:
             choice:
                 7
         "monika 1dkd_static"
-        0.05
+        0.06
         repeat
 
 image monika 1wktpa:
@@ -1973,7 +1973,7 @@ image monika 1wktpa:
             choice:
                 7
         "monika 1dktpa_static"
-        0.05
+        0.06
         repeat
 
 image monika 1wktsd:
@@ -1987,7 +1987,7 @@ image monika 1wktsd:
             choice:
                 7
         "monika 1dktsd_static"
-        0.05
+        0.06
         repeat
 
 image monika 1wua:
@@ -2001,7 +2001,7 @@ image monika 1wua:
             choice:
                 7
         "monika 1dua_static"
-        0.05
+        0.06
         repeat
 
 image monika 1wub:
@@ -2015,7 +2015,7 @@ image monika 1wub:
             choice:
                 7
         "monika 1dub_static"
-        0.05
+        0.06
         repeat
 
 image monika 1wubfb:
@@ -2029,7 +2029,7 @@ image monika 1wubfb:
             choice:
                 7
         "monika 1dubfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 1wubfsdld:
@@ -2043,7 +2043,7 @@ image monika 1wubfsdld:
             choice:
                 7
         "monika 1dubfsdld_static"
-        0.05
+        0.06
         repeat
 
 image monika 1wubso:
@@ -2057,7 +2057,7 @@ image monika 1wubso:
             choice:
                 7
         "monika 1dubso_static"
-        0.05
+        0.06
         repeat
 
 image monika 1wubsw:
@@ -2071,7 +2071,7 @@ image monika 1wubsw:
             choice:
                 7
         "monika 1dubsw_static"
-        0.05
+        0.06
         repeat
 
 image monika 1wud:
@@ -2085,7 +2085,7 @@ image monika 1wud:
             choice:
                 7
         "monika 1dud_static"
-        0.05
+        0.06
         repeat
 
 image monika 1wuo:
@@ -2099,7 +2099,7 @@ image monika 1wuo:
             choice:
                 7
         "monika 1duo_static"
-        0.05
+        0.06
         repeat
 
 image monika 1wuw:
@@ -2113,7 +2113,7 @@ image monika 1wuw:
             choice:
                 7
         "monika 1duw_static"
-        0.05
+        0.06
         repeat
 
 image monika 2efb:
@@ -2127,7 +2127,7 @@ image monika 2efb:
             choice:
                 7
         "monika 2dfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 2efc:
@@ -2141,7 +2141,7 @@ image monika 2efc:
             choice:
                 7
         "monika 2dfc_static"
-        0.05
+        0.06
         repeat
 
 image monika 2efd:
@@ -2155,7 +2155,7 @@ image monika 2efd:
             choice:
                 7
         "monika 2dfd_static"
-        0.05
+        0.06
         repeat
 
 image monika 2efo:
@@ -2169,7 +2169,7 @@ image monika 2efo:
             choice:
                 7
         "monika 2dfo_static"
-        0.05
+        0.06
         repeat
 
 image monika 2eft:
@@ -2183,7 +2183,7 @@ image monika 2eft:
             choice:
                 7
         "monika 2dft_static"
-        0.05
+        0.06
         repeat
 
 image monika 2eftsu:
@@ -2197,7 +2197,7 @@ image monika 2eftsu:
             choice:
                 7
         "monika 2dftsu_static"
-        0.05
+        0.06
         repeat
 
 image monika 2efu:
@@ -2211,7 +2211,7 @@ image monika 2efu:
             choice:
                 7
         "monika 2dfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 2efw:
@@ -2225,7 +2225,7 @@ image monika 2efw:
             choice:
                 7
         "monika 2dfw_static"
-        0.05
+        0.06
         repeat
 
 image monika 2efx:
@@ -2239,7 +2239,7 @@ image monika 2efx:
             choice:
                 7
         "monika 2dfx_static"
-        0.05
+        0.06
         repeat
 
 image monika 2eka:
@@ -2253,7 +2253,7 @@ image monika 2eka:
             choice:
                 7
         "monika 2dka_static"
-        0.05
+        0.06
         repeat
 
 image monika 2ekb:
@@ -2267,7 +2267,7 @@ image monika 2ekb:
             choice:
                 7
         "monika 2dkb_static"
-        0.05
+        0.06
         repeat
 
 image monika 2ekbfa:
@@ -2281,7 +2281,7 @@ image monika 2ekbfa:
             choice:
                 7
         "monika 2dkbfa_static"
-        0.05
+        0.06
         repeat
 
 image monika 2ekbfb:
@@ -2295,7 +2295,7 @@ image monika 2ekbfb:
             choice:
                 7
         "monika 2dkbfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 2ekc:
@@ -2309,7 +2309,7 @@ image monika 2ekc:
             choice:
                 7
         "monika 2dkc_static"
-        0.05
+        0.06
         repeat
 
 image monika 2ekd:
@@ -2323,7 +2323,7 @@ image monika 2ekd:
             choice:
                 7
         "monika 2dkd_static"
-        0.05
+        0.06
         repeat
 
 image monika 2ekp:
@@ -2337,7 +2337,7 @@ image monika 2ekp:
             choice:
                 7
         "monika 2dkp_static"
-        0.05
+        0.06
         repeat
 
 image monika 2eksdla:
@@ -2351,7 +2351,7 @@ image monika 2eksdla:
             choice:
                 7
         "monika 2dksdla_static"
-        0.05
+        0.06
         repeat
 
 image monika 2eksdlc:
@@ -2365,7 +2365,7 @@ image monika 2eksdlc:
             choice:
                 7
         "monika 2dksdlc_static"
-        0.05
+        0.06
         repeat
 
 image monika 2eksdld:
@@ -2379,7 +2379,7 @@ image monika 2eksdld:
             choice:
                 7
         "monika 2dksdld_static"
-        0.05
+        0.06
         repeat
 
 image monika 2ekt:
@@ -2393,7 +2393,7 @@ image monika 2ekt:
             choice:
                 7
         "monika 2dkt_static"
-        0.05
+        0.06
         repeat
 
 image monika 2ektsc:
@@ -2407,7 +2407,7 @@ image monika 2ektsc:
             choice:
                 7
         "monika 2dktsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 2eku:
@@ -2421,7 +2421,7 @@ image monika 2eku:
             choice:
                 7
         "monika 2dku_static"
-        0.05
+        0.06
         repeat
 
 image monika 2esa:
@@ -2435,7 +2435,7 @@ image monika 2esa:
             choice:
                 7
         "monika 2dsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 2esb:
@@ -2449,7 +2449,7 @@ image monika 2esb:
             choice:
                 7
         "monika 2dsb_static"
-        0.05
+        0.06
         repeat
 
 image monika 2esc:
@@ -2463,7 +2463,7 @@ image monika 2esc:
             choice:
                 7
         "monika 2dsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 2esd:
@@ -2477,7 +2477,7 @@ image monika 2esd:
             choice:
                 7
         "monika 2dsd_static"
-        0.05
+        0.06
         repeat
 
 image monika 2etc:
@@ -2491,7 +2491,7 @@ image monika 2etc:
             choice:
                 7
         "monika 2dtc_static"
-        0.05
+        0.06
         repeat
 
 image monika 2eua:
@@ -2505,7 +2505,7 @@ image monika 2eua:
             choice:
                 7
         "monika 2dua_static"
-        0.05
+        0.06
         repeat
 
 image monika 2eub:
@@ -2519,7 +2519,7 @@ image monika 2eub:
             choice:
                 7
         "monika 2dub_static"
-        0.05
+        0.06
         repeat
 
 image monika 2euc:
@@ -2533,7 +2533,7 @@ image monika 2euc:
             choice:
                 7
         "monika 2duc_static"
-        0.05
+        0.06
         repeat
 
 image monika 2eud:
@@ -2547,7 +2547,7 @@ image monika 2eud:
             choice:
                 7
         "monika 2dud_static"
-        0.05
+        0.06
         repeat
 
 image monika 2lfb:
@@ -2561,7 +2561,7 @@ image monika 2lfb:
             choice:
                 7
         "monika 2dfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 2lfc:
@@ -2575,7 +2575,7 @@ image monika 2lfc:
             choice:
                 7
         "monika 2dfc_static"
-        0.05
+        0.06
         repeat
 
 image monika 2lfd:
@@ -2589,7 +2589,7 @@ image monika 2lfd:
             choice:
                 7
         "monika 2dfd_static"
-        0.05
+        0.06
         repeat
 
 image monika 2lfp:
@@ -2603,7 +2603,7 @@ image monika 2lfp:
             choice:
                 7
         "monika 2dfp_static"
-        0.05
+        0.06
         repeat
 
 image monika 2lftsc:
@@ -2617,7 +2617,7 @@ image monika 2lftsc:
             choice:
                 7
         "monika 2dftsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 2lfu:
@@ -2631,7 +2631,7 @@ image monika 2lfu:
             choice:
                 7
         "monika 2dfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 2lfw:
@@ -2645,7 +2645,7 @@ image monika 2lfw:
             choice:
                 7
         "monika 2dfw_static"
-        0.05
+        0.06
         repeat
 
 image monika 2lfx:
@@ -2659,7 +2659,7 @@ image monika 2lfx:
             choice:
                 7
         "monika 2dfx_static"
-        0.05
+        0.06
         repeat
 
 image monika 2lkbfb:
@@ -2673,7 +2673,7 @@ image monika 2lkbfb:
             choice:
                 7
         "monika 2dkbfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 2lkbsa:
@@ -2687,7 +2687,7 @@ image monika 2lkbsa:
             choice:
                 7
         "monika 2dkbsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 2lkbsc:
@@ -2701,7 +2701,7 @@ image monika 2lkbsc:
             choice:
                 7
         "monika 2dkbsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 2lksdla:
@@ -2715,7 +2715,7 @@ image monika 2lksdla:
             choice:
                 7
         "monika 2dksdla_static"
-        0.05
+        0.06
         repeat
 
 image monika 2lksdlb:
@@ -2729,7 +2729,7 @@ image monika 2lksdlb:
             choice:
                 7
         "monika 2dksdlb_static"
-        0.05
+        0.06
         repeat
 
 image monika 2lksdlc:
@@ -2743,7 +2743,7 @@ image monika 2lksdlc:
             choice:
                 7
         "monika 2dksdlc_static"
-        0.05
+        0.06
         repeat
 
 image monika 2lksdld:
@@ -2757,7 +2757,7 @@ image monika 2lksdld:
             choice:
                 7
         "monika 2dksdld_static"
-        0.05
+        0.06
         repeat
 
 image monika 2lksdlw:
@@ -2771,7 +2771,7 @@ image monika 2lksdlw:
             choice:
                 7
         "monika 2dksdlw_static"
-        0.05
+        0.06
         repeat
 
 image monika 2lksdrb:
@@ -2785,7 +2785,7 @@ image monika 2lksdrb:
             choice:
                 7
         "monika 2dksdrb_static"
-        0.05
+        0.06
         repeat
 
 image monika 2lktsc:
@@ -2799,7 +2799,7 @@ image monika 2lktsc:
             choice:
                 7
         "monika 2dktsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 2lsbsa:
@@ -2813,7 +2813,7 @@ image monika 2lsbsa:
             choice:
                 7
         "monika 2dsbsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 2lsbssdlb:
@@ -2827,7 +2827,7 @@ image monika 2lsbssdlb:
             choice:
                 7
         "monika 2dsbssdlb_static"
-        0.05
+        0.06
         repeat
 
 image monika 2lsbssdrb:
@@ -2841,7 +2841,7 @@ image monika 2lsbssdrb:
             choice:
                 7
         "monika 2dsbssdrb_static"
-        0.05
+        0.06
         repeat
 
 image monika 2lsc:
@@ -2855,7 +2855,7 @@ image monika 2lsc:
             choice:
                 7
         "monika 2dsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 2lssdlb:
@@ -2869,7 +2869,7 @@ image monika 2lssdlb:
             choice:
                 7
         "monika 2dssdlb_static"
-        0.05
+        0.06
         repeat
 
 image monika 2lssdrb:
@@ -2883,7 +2883,7 @@ image monika 2lssdrb:
             choice:
                 7
         "monika 2dssdrb_static"
-        0.05
+        0.06
         repeat
 
 image monika 2lssdrc:
@@ -2897,7 +2897,7 @@ image monika 2lssdrc:
             choice:
                 7
         "monika 2dssdrc_static"
-        0.05
+        0.06
         repeat
 
 image monika 2lubfb:
@@ -2911,7 +2911,7 @@ image monika 2lubfb:
             choice:
                 7
         "monika 2dubfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 2lud:
@@ -2925,7 +2925,7 @@ image monika 2lud:
             choice:
                 7
         "monika 2dud_static"
-        0.05
+        0.06
         repeat
 
 image monika 2rfb:
@@ -2939,7 +2939,7 @@ image monika 2rfb:
             choice:
                 7
         "monika 2dfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 2rfc:
@@ -2953,7 +2953,7 @@ image monika 2rfc:
             choice:
                 7
         "monika 2dfc_static"
-        0.05
+        0.06
         repeat
 
 image monika 2rfd:
@@ -2967,7 +2967,7 @@ image monika 2rfd:
             choice:
                 7
         "monika 2dfd_static"
-        0.05
+        0.06
         repeat
 
 image monika 2rfu:
@@ -2981,7 +2981,7 @@ image monika 2rfu:
             choice:
                 7
         "monika 2dfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 2rfw:
@@ -2995,7 +2995,7 @@ image monika 2rfw:
             choice:
                 7
         "monika 2dfw_static"
-        0.05
+        0.06
         repeat
 
 image monika 2rfx:
@@ -3009,7 +3009,7 @@ image monika 2rfx:
             choice:
                 7
         "monika 2dfx_static"
-        0.05
+        0.06
         repeat
 
 image monika 2rka:
@@ -3023,7 +3023,7 @@ image monika 2rka:
             choice:
                 7
         "monika 2dka_static"
-        0.05
+        0.06
         repeat
 
 image monika 2rkbfsdlb:
@@ -3037,7 +3037,7 @@ image monika 2rkbfsdlb:
             choice:
                 7
         "monika 2dkbfsdlb_static"
-        0.05
+        0.06
         repeat
 
 image monika 2rkbfsdld:
@@ -3051,7 +3051,7 @@ image monika 2rkbfsdld:
             choice:
                 7
         "monika 2dkbfsdld_static"
-        0.05
+        0.06
         repeat
 
 image monika 2rkbfsdlu:
@@ -3065,7 +3065,7 @@ image monika 2rkbfsdlu:
             choice:
                 7
         "monika 2dkbfsdlu_static"
-        0.05
+        0.06
         repeat
 
 image monika 2rkbsa:
@@ -3079,7 +3079,7 @@ image monika 2rkbsa:
             choice:
                 7
         "monika 2dkbsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 2rkc:
@@ -3093,7 +3093,7 @@ image monika 2rkc:
             choice:
                 7
         "monika 2dkc_static"
-        0.05
+        0.06
         repeat
 
 image monika 2rksdla:
@@ -3107,7 +3107,7 @@ image monika 2rksdla:
             choice:
                 7
         "monika 2dksdla_static"
-        0.05
+        0.06
         repeat
 
 image monika 2rksdlb:
@@ -3121,7 +3121,7 @@ image monika 2rksdlb:
             choice:
                 7
         "monika 2dksdlb_static"
-        0.05
+        0.06
         repeat
 
 image monika 2rksdlc:
@@ -3135,7 +3135,7 @@ image monika 2rksdlc:
             choice:
                 7
         "monika 2dksdlc_static"
-        0.05
+        0.06
         repeat
 
 image monika 2rksdld:
@@ -3149,7 +3149,7 @@ image monika 2rksdld:
             choice:
                 7
         "monika 2dksdld_static"
-        0.05
+        0.06
         repeat
 
 image monika 2rktpc:
@@ -3163,7 +3163,7 @@ image monika 2rktpc:
             choice:
                 7
         "monika 2dktpc_static"
-        0.05
+        0.06
         repeat
 
 image monika 2rktsc:
@@ -3177,7 +3177,7 @@ image monika 2rktsc:
             choice:
                 7
         "monika 2dktsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 2rktsd:
@@ -3191,7 +3191,7 @@ image monika 2rktsd:
             choice:
                 7
         "monika 2dktsd_static"
-        0.05
+        0.06
         repeat
 
 image monika 2rsbsa:
@@ -3205,7 +3205,7 @@ image monika 2rsbsa:
             choice:
                 7
         "monika 2dsbsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 2rsc:
@@ -3219,7 +3219,7 @@ image monika 2rsc:
             choice:
                 7
         "monika 2dsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 2rubfu:
@@ -3233,7 +3233,7 @@ image monika 2rubfu:
             choice:
                 7
         "monika 2dubfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 2sub:
@@ -3247,7 +3247,7 @@ image monika 2sub:
             choice:
                 7
         "monika 2dub_static"
-        0.05
+        0.06
         repeat
 
 image monika 2subfb:
@@ -3261,7 +3261,7 @@ image monika 2subfb:
             choice:
                 7
         "monika 2dubfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 2subftsb:
@@ -3275,7 +3275,7 @@ image monika 2subftsb:
             choice:
                 7
         "monika 2dubftsb_static"
-        0.05
+        0.06
         repeat
 
 image monika 2sutsa:
@@ -3289,7 +3289,7 @@ image monika 2sutsa:
             choice:
                 7
         "monika 2dutsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 2tfb:
@@ -3303,7 +3303,7 @@ image monika 2tfb:
             choice:
                 7
         "monika 2dfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 2tfc:
@@ -3317,7 +3317,7 @@ image monika 2tfc:
             choice:
                 7
         "monika 2dfc_static"
-        0.05
+        0.06
         repeat
 
 image monika 2tfd:
@@ -3331,7 +3331,7 @@ image monika 2tfd:
             choice:
                 7
         "monika 2dfd_static"
-        0.05
+        0.06
         repeat
 
 image monika 2tfp:
@@ -3345,7 +3345,7 @@ image monika 2tfp:
             choice:
                 7
         "monika 2dfp_static"
-        0.05
+        0.06
         repeat
 
 image monika 2tfu:
@@ -3359,7 +3359,7 @@ image monika 2tfu:
             choice:
                 7
         "monika 2dfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 2tfx:
@@ -3373,7 +3373,7 @@ image monika 2tfx:
             choice:
                 7
         "monika 2dfx_static"
-        0.05
+        0.06
         repeat
 
 image monika 2tkb:
@@ -3387,7 +3387,7 @@ image monika 2tkb:
             choice:
                 7
         "monika 2dkb_static"
-        0.05
+        0.06
         repeat
 
 image monika 2tkc:
@@ -3401,7 +3401,7 @@ image monika 2tkc:
             choice:
                 7
         "monika 2dkc_static"
-        0.05
+        0.06
         repeat
 
 image monika 2tkd:
@@ -3415,7 +3415,7 @@ image monika 2tkd:
             choice:
                 7
         "monika 2dkd_static"
-        0.05
+        0.06
         repeat
 
 image monika 2tku:
@@ -3429,7 +3429,7 @@ image monika 2tku:
             choice:
                 7
         "monika 2dku_static"
-        0.05
+        0.06
         repeat
 
 image monika 2tkx:
@@ -3443,7 +3443,7 @@ image monika 2tkx:
             choice:
                 7
         "monika 2dkx_static"
-        0.05
+        0.06
         repeat
 
 image monika 2tsb:
@@ -3457,7 +3457,7 @@ image monika 2tsb:
             choice:
                 7
         "monika 2dsb_static"
-        0.05
+        0.06
         repeat
 
 image monika 2tsbsa:
@@ -3471,7 +3471,7 @@ image monika 2tsbsa:
             choice:
                 7
         "monika 2dsbsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 2tsc:
@@ -3485,7 +3485,7 @@ image monika 2tsc:
             choice:
                 7
         "monika 2dsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 2tsu:
@@ -3499,7 +3499,7 @@ image monika 2tsu:
             choice:
                 7
         "monika 2dsu_static"
-        0.05
+        0.06
         repeat
 
 image monika 2ttu:
@@ -3513,7 +3513,7 @@ image monika 2ttu:
             choice:
                 7
         "monika 2dtu_static"
-        0.05
+        0.06
         repeat
 
 image monika 2tub:
@@ -3527,7 +3527,7 @@ image monika 2tub:
             choice:
                 7
         "monika 2dub_static"
-        0.05
+        0.06
         repeat
 
 image monika 2tubfb:
@@ -3541,7 +3541,7 @@ image monika 2tubfb:
             choice:
                 7
         "monika 2dubfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 2tubfu:
@@ -3555,7 +3555,7 @@ image monika 2tubfu:
             choice:
                 7
         "monika 2dubfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 2tuu:
@@ -3569,7 +3569,7 @@ image monika 2tuu:
             choice:
                 7
         "monika 2duu_static"
-        0.05
+        0.06
         repeat
 
 image monika 2wfc:
@@ -3583,7 +3583,7 @@ image monika 2wfc:
             choice:
                 7
         "monika 2dfc_static"
-        0.05
+        0.06
         repeat
 
 image monika 2wfd:
@@ -3597,7 +3597,7 @@ image monika 2wfd:
             choice:
                 7
         "monika 2dfd_static"
-        0.05
+        0.06
         repeat
 
 image monika 2wfw:
@@ -3611,7 +3611,7 @@ image monika 2wfw:
             choice:
                 7
         "monika 2dfw_static"
-        0.05
+        0.06
         repeat
 
 image monika 2wfx:
@@ -3625,7 +3625,7 @@ image monika 2wfx:
             choice:
                 7
         "monika 2dfx_static"
-        0.05
+        0.06
         repeat
 
 image monika 2wkbsc:
@@ -3639,7 +3639,7 @@ image monika 2wkbsc:
             choice:
                 7
         "monika 2dkbsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 2wkc:
@@ -3653,7 +3653,7 @@ image monika 2wkc:
             choice:
                 7
         "monika 2dkc_static"
-        0.05
+        0.06
         repeat
 
 image monika 2wkd:
@@ -3667,7 +3667,7 @@ image monika 2wkd:
             choice:
                 7
         "monika 2dkd_static"
-        0.05
+        0.06
         repeat
 
 image monika 2wktsd:
@@ -3681,7 +3681,7 @@ image monika 2wktsd:
             choice:
                 7
         "monika 2dktsd_static"
-        0.05
+        0.06
         repeat
 
 image monika 2wub:
@@ -3695,7 +3695,7 @@ image monika 2wub:
             choice:
                 7
         "monika 2dub_static"
-        0.05
+        0.06
         repeat
 
 image monika 2wubfb:
@@ -3709,7 +3709,7 @@ image monika 2wubfb:
             choice:
                 7
         "monika 2dubfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 2wubfsdld:
@@ -3723,7 +3723,7 @@ image monika 2wubfsdld:
             choice:
                 7
         "monika 2dubfsdld_static"
-        0.05
+        0.06
         repeat
 
 image monika 2wubso:
@@ -3737,7 +3737,7 @@ image monika 2wubso:
             choice:
                 7
         "monika 2dubso_static"
-        0.05
+        0.06
         repeat
 
 image monika 2wubsw:
@@ -3751,7 +3751,7 @@ image monika 2wubsw:
             choice:
                 7
         "monika 2dubsw_static"
-        0.05
+        0.06
         repeat
 
 image monika 2wuc:
@@ -3765,7 +3765,7 @@ image monika 2wuc:
             choice:
                 7
         "monika 2duc_static"
-        0.05
+        0.06
         repeat
 
 image monika 2wud:
@@ -3779,7 +3779,7 @@ image monika 2wud:
             choice:
                 7
         "monika 2dud_static"
-        0.05
+        0.06
         repeat
 
 image monika 2wuo:
@@ -3793,7 +3793,7 @@ image monika 2wuo:
             choice:
                 7
         "monika 2duo_static"
-        0.05
+        0.06
         repeat
 
 image monika 2wuw:
@@ -3807,7 +3807,7 @@ image monika 2wuw:
             choice:
                 7
         "monika 2duw_static"
-        0.05
+        0.06
         repeat
 
 image monika 3efb:
@@ -3821,7 +3821,7 @@ image monika 3efb:
             choice:
                 7
         "monika 3dfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 3efc:
@@ -3835,7 +3835,7 @@ image monika 3efc:
             choice:
                 7
         "monika 3dfc_static"
-        0.05
+        0.06
         repeat
 
 image monika 3efd:
@@ -3849,7 +3849,7 @@ image monika 3efd:
             choice:
                 7
         "monika 3dfd_static"
-        0.05
+        0.06
         repeat
 
 image monika 3efo:
@@ -3863,7 +3863,7 @@ image monika 3efo:
             choice:
                 7
         "monika 3dfo_static"
-        0.05
+        0.06
         repeat
 
 image monika 3eft:
@@ -3877,7 +3877,7 @@ image monika 3eft:
             choice:
                 7
         "monika 3dft_static"
-        0.05
+        0.06
         repeat
 
 image monika 3eftsu:
@@ -3891,7 +3891,7 @@ image monika 3eftsu:
             choice:
                 7
         "monika 3dftsu_static"
-        0.05
+        0.06
         repeat
 
 image monika 3efu:
@@ -3905,7 +3905,7 @@ image monika 3efu:
             choice:
                 7
         "monika 3dfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 3efw:
@@ -3919,7 +3919,7 @@ image monika 3efw:
             choice:
                 7
         "monika 3dfw_static"
-        0.05
+        0.06
         repeat
 
 image monika 3efx:
@@ -3933,7 +3933,7 @@ image monika 3efx:
             choice:
                 7
         "monika 3dfx_static"
-        0.05
+        0.06
         repeat
 
 image monika 3eka:
@@ -3947,7 +3947,7 @@ image monika 3eka:
             choice:
                 7
         "monika 3dka_static"
-        0.05
+        0.06
         repeat
 
 image monika 3ekb:
@@ -3961,7 +3961,7 @@ image monika 3ekb:
             choice:
                 7
         "monika 3dkb_static"
-        0.05
+        0.06
         repeat
 
 image monika 3ekbfa:
@@ -3975,7 +3975,7 @@ image monika 3ekbfa:
             choice:
                 7
         "monika 3dkbfa_static"
-        0.05
+        0.06
         repeat
 
 image monika 3ekbfb:
@@ -3989,7 +3989,7 @@ image monika 3ekbfb:
             choice:
                 7
         "monika 3dkbfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 3ekbla:
@@ -4003,7 +4003,7 @@ image monika 3ekbla:
             choice:
                 7
         "monika 3dkbla_static"
-        0.05
+        0.06
         repeat
 
 image monika 3ekbsa:
@@ -4017,7 +4017,7 @@ image monika 3ekbsa:
             choice:
                 7
         "monika 3dkbsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 3ekc:
@@ -4031,7 +4031,7 @@ image monika 3ekc:
             choice:
                 7
         "monika 3dkc_static"
-        0.05
+        0.06
         repeat
 
 image monika 3ekd:
@@ -4045,7 +4045,7 @@ image monika 3ekd:
             choice:
                 7
         "monika 3dkd_static"
-        0.05
+        0.06
         repeat
 
 image monika 3eksdla:
@@ -4059,7 +4059,7 @@ image monika 3eksdla:
             choice:
                 7
         "monika 3dksdla_static"
-        0.05
+        0.06
         repeat
 
 image monika 3eksdlc:
@@ -4073,7 +4073,7 @@ image monika 3eksdlc:
             choice:
                 7
         "monika 3dksdlc_static"
-        0.05
+        0.06
         repeat
 
 image monika 3eksdld:
@@ -4087,7 +4087,7 @@ image monika 3eksdld:
             choice:
                 7
         "monika 3dksdld_static"
-        0.05
+        0.06
         repeat
 
 image monika 3ektda:
@@ -4101,7 +4101,7 @@ image monika 3ektda:
             choice:
                 7
         "monika 3dktda_static"
-        0.05
+        0.06
         repeat
 
 image monika 3ektsc:
@@ -4115,7 +4115,7 @@ image monika 3ektsc:
             choice:
                 7
         "monika 3dktsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 3esa:
@@ -4129,7 +4129,7 @@ image monika 3esa:
             choice:
                 7
         "monika 3dsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 3esb:
@@ -4143,7 +4143,7 @@ image monika 3esb:
             choice:
                 7
         "monika 3dsb_static"
-        0.05
+        0.06
         repeat
 
 image monika 3esc:
@@ -4157,7 +4157,7 @@ image monika 3esc:
             choice:
                 7
         "monika 3dsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 3esd:
@@ -4171,7 +4171,7 @@ image monika 3esd:
             choice:
                 7
         "monika 3dsd_static"
-        0.05
+        0.06
         repeat
 
 image monika 3etc:
@@ -4185,7 +4185,7 @@ image monika 3etc:
             choice:
                 7
         "monika 3dtc_static"
-        0.05
+        0.06
         repeat
 
 image monika 3etd:
@@ -4199,7 +4199,7 @@ image monika 3etd:
             choice:
                 7
         "monika 3dtd_static"
-        0.05
+        0.06
         repeat
 
 image monika 3eua:
@@ -4213,7 +4213,7 @@ image monika 3eua:
             choice:
                 7
         "monika 3dua_static"
-        0.05
+        0.06
         repeat
 
 image monika 3eub:
@@ -4227,7 +4227,7 @@ image monika 3eub:
             choice:
                 7
         "monika 3dub_static"
-        0.05
+        0.06
         repeat
 
 image monika 3euc:
@@ -4241,7 +4241,7 @@ image monika 3euc:
             choice:
                 7
         "monika 3duc_static"
-        0.05
+        0.06
         repeat
 
 image monika 3eud:
@@ -4255,7 +4255,7 @@ image monika 3eud:
             choice:
                 7
         "monika 3dud_static"
-        0.05
+        0.06
         repeat
 
 image monika 3lfb:
@@ -4269,7 +4269,7 @@ image monika 3lfb:
             choice:
                 7
         "monika 3dfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 3lfc:
@@ -4283,7 +4283,7 @@ image monika 3lfc:
             choice:
                 7
         "monika 3dfc_static"
-        0.05
+        0.06
         repeat
 
 image monika 3lfd:
@@ -4297,7 +4297,7 @@ image monika 3lfd:
             choice:
                 7
         "monika 3dfd_static"
-        0.05
+        0.06
         repeat
 
 image monika 3lftsc:
@@ -4311,7 +4311,7 @@ image monika 3lftsc:
             choice:
                 7
         "monika 3dftsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 3lfu:
@@ -4325,7 +4325,7 @@ image monika 3lfu:
             choice:
                 7
         "monika 3dfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 3lfw:
@@ -4339,7 +4339,7 @@ image monika 3lfw:
             choice:
                 7
         "monika 3dfw_static"
-        0.05
+        0.06
         repeat
 
 image monika 3lfx:
@@ -4353,7 +4353,7 @@ image monika 3lfx:
             choice:
                 7
         "monika 3dfx_static"
-        0.05
+        0.06
         repeat
 
 image monika 3lkbfb:
@@ -4367,7 +4367,7 @@ image monika 3lkbfb:
             choice:
                 7
         "monika 3dkbfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 3lkbltpa:
@@ -4381,7 +4381,7 @@ image monika 3lkbltpa:
             choice:
                 7
         "monika 3dkbltpa_static"
-        0.05
+        0.06
         repeat
 
 image monika 3lkbsa:
@@ -4395,7 +4395,7 @@ image monika 3lkbsa:
             choice:
                 7
         "monika 3dkbsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 3lkbsc:
@@ -4409,7 +4409,7 @@ image monika 3lkbsc:
             choice:
                 7
         "monika 3dkbsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 3lksdla:
@@ -4423,7 +4423,7 @@ image monika 3lksdla:
             choice:
                 7
         "monika 3dksdla_static"
-        0.05
+        0.06
         repeat
 
 image monika 3lksdlb:
@@ -4437,7 +4437,7 @@ image monika 3lksdlb:
             choice:
                 7
         "monika 3dksdlb_static"
-        0.05
+        0.06
         repeat
 
 image monika 3lksdlc:
@@ -4451,7 +4451,7 @@ image monika 3lksdlc:
             choice:
                 7
         "monika 3dksdlc_static"
-        0.05
+        0.06
         repeat
 
 image monika 3lksdld:
@@ -4465,7 +4465,7 @@ image monika 3lksdld:
             choice:
                 7
         "monika 3dksdld_static"
-        0.05
+        0.06
         repeat
 
 image monika 3lksdlw:
@@ -4479,7 +4479,7 @@ image monika 3lksdlw:
             choice:
                 7
         "monika 3dksdlw_static"
-        0.05
+        0.06
         repeat
 
 image monika 3lksdrb:
@@ -4493,7 +4493,7 @@ image monika 3lksdrb:
             choice:
                 7
         "monika 3dksdrb_static"
-        0.05
+        0.06
         repeat
 
 image monika 3lktsc:
@@ -4507,7 +4507,7 @@ image monika 3lktsc:
             choice:
                 7
         "monika 3dktsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 3lsbsa:
@@ -4521,7 +4521,7 @@ image monika 3lsbsa:
             choice:
                 7
         "monika 3dsbsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 3lsbssdrb:
@@ -4535,7 +4535,7 @@ image monika 3lsbssdrb:
             choice:
                 7
         "monika 3dsbssdrb_static"
-        0.05
+        0.06
         repeat
 
 image monika 3lsc:
@@ -4549,7 +4549,7 @@ image monika 3lsc:
             choice:
                 7
         "monika 3dsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 3lssdrb:
@@ -4563,7 +4563,7 @@ image monika 3lssdrb:
             choice:
                 7
         "monika 3dssdrb_static"
-        0.05
+        0.06
         repeat
 
 image monika 3lssdrc:
@@ -4577,7 +4577,7 @@ image monika 3lssdrc:
             choice:
                 7
         "monika 3dssdrc_static"
-        0.05
+        0.06
         repeat
 
 image monika 3lubfb:
@@ -4591,7 +4591,7 @@ image monika 3lubfb:
             choice:
                 7
         "monika 3dubfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 3lud:
@@ -4605,7 +4605,7 @@ image monika 3lud:
             choice:
                 7
         "monika 3dud_static"
-        0.05
+        0.06
         repeat
 
 image monika 3rfb:
@@ -4619,7 +4619,7 @@ image monika 3rfb:
             choice:
                 7
         "monika 3dfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 3rfc:
@@ -4633,7 +4633,7 @@ image monika 3rfc:
             choice:
                 7
         "monika 3dfc_static"
-        0.05
+        0.06
         repeat
 
 image monika 3rfd:
@@ -4647,7 +4647,7 @@ image monika 3rfd:
             choice:
                 7
         "monika 3dfd_static"
-        0.05
+        0.06
         repeat
 
 image monika 3rfu:
@@ -4661,7 +4661,7 @@ image monika 3rfu:
             choice:
                 7
         "monika 3dfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 3rfw:
@@ -4675,7 +4675,7 @@ image monika 3rfw:
             choice:
                 7
         "monika 3dfw_static"
-        0.05
+        0.06
         repeat
 
 image monika 3rfx:
@@ -4689,7 +4689,7 @@ image monika 3rfx:
             choice:
                 7
         "monika 3dfx_static"
-        0.05
+        0.06
         repeat
 
 image monika 3rka:
@@ -4703,7 +4703,7 @@ image monika 3rka:
             choice:
                 7
         "monika 3dka_static"
-        0.05
+        0.06
         repeat
 
 image monika 3rkbfsdla:
@@ -4717,7 +4717,7 @@ image monika 3rkbfsdla:
             choice:
                 7
         "monika 3dkbfsdla_static"
-        0.05
+        0.06
         repeat
 
 image monika 3rkbsa:
@@ -4731,7 +4731,7 @@ image monika 3rkbsa:
             choice:
                 7
         "monika 3dkbsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 3rkc:
@@ -4745,7 +4745,7 @@ image monika 3rkc:
             choice:
                 7
         "monika 3dkc_static"
-        0.05
+        0.06
         repeat
 
 image monika 3rkd:
@@ -4759,7 +4759,7 @@ image monika 3rkd:
             choice:
                 7
         "monika 3dkd_static"
-        0.05
+        0.06
         repeat
 
 image monika 3rksdla:
@@ -4773,7 +4773,7 @@ image monika 3rksdla:
             choice:
                 7
         "monika 3dksdla_static"
-        0.05
+        0.06
         repeat
 
 image monika 3rksdlb:
@@ -4787,7 +4787,7 @@ image monika 3rksdlb:
             choice:
                 7
         "monika 3dksdlb_static"
-        0.05
+        0.06
         repeat
 
 image monika 3rksdlc:
@@ -4801,7 +4801,7 @@ image monika 3rksdlc:
             choice:
                 7
         "monika 3dksdlc_static"
-        0.05
+        0.06
         repeat
 
 image monika 3rksdld:
@@ -4815,7 +4815,7 @@ image monika 3rksdld:
             choice:
                 7
         "monika 3dksdld_static"
-        0.05
+        0.06
         repeat
 
 image monika 3rktsc:
@@ -4829,7 +4829,7 @@ image monika 3rktsc:
             choice:
                 7
         "monika 3dktsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 3rsa:
@@ -4843,7 +4843,7 @@ image monika 3rsa:
             choice:
                 7
         "monika 3dsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 3rsc:
@@ -4857,7 +4857,7 @@ image monika 3rsc:
             choice:
                 7
         "monika 3dsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 3rssdlb:
@@ -4871,7 +4871,7 @@ image monika 3rssdlb:
             choice:
                 7
         "monika 3dssdlb_static"
-        0.05
+        0.06
         repeat
 
 image monika 3rssdlc:
@@ -4885,7 +4885,7 @@ image monika 3rssdlc:
             choice:
                 7
         "monika 3dssdlc_static"
-        0.05
+        0.06
         repeat
 
 image monika 3rssdrc:
@@ -4899,7 +4899,7 @@ image monika 3rssdrc:
             choice:
                 7
         "monika 3dssdrc_static"
-        0.05
+        0.06
         repeat
 
 image monika 3rubfb:
@@ -4913,7 +4913,7 @@ image monika 3rubfb:
             choice:
                 7
         "monika 3dubfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 3rud:
@@ -4927,7 +4927,7 @@ image monika 3rud:
             choice:
                 7
         "monika 3dud_static"
-        0.05
+        0.06
         repeat
 
 image monika 3skbltda:
@@ -4941,7 +4941,7 @@ image monika 3skbltda:
             choice:
                 7
         "monika 3dkbltda_static"
-        0.05
+        0.06
         repeat
 
 image monika 3sua:
@@ -4955,7 +4955,7 @@ image monika 3sua:
             choice:
                 7
         "monika 3dua_static"
-        0.05
+        0.06
         repeat
 
 image monika 3sub:
@@ -4969,7 +4969,7 @@ image monika 3sub:
             choice:
                 7
         "monika 3dub_static"
-        0.05
+        0.06
         repeat
 
 image monika 3subfb:
@@ -4983,7 +4983,7 @@ image monika 3subfb:
             choice:
                 7
         "monika 3dubfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 3subftsb:
@@ -4997,7 +4997,7 @@ image monika 3subftsb:
             choice:
                 7
         "monika 3dubftsb_static"
-        0.05
+        0.06
         repeat
 
 image monika 3sutsa:
@@ -5011,7 +5011,7 @@ image monika 3sutsa:
             choice:
                 7
         "monika 3dutsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 3tfb:
@@ -5025,7 +5025,7 @@ image monika 3tfb:
             choice:
                 7
         "monika 3dfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 3tfc:
@@ -5039,7 +5039,7 @@ image monika 3tfc:
             choice:
                 7
         "monika 3dfc_static"
-        0.05
+        0.06
         repeat
 
 image monika 3tfd:
@@ -5053,7 +5053,7 @@ image monika 3tfd:
             choice:
                 7
         "monika 3dfd_static"
-        0.05
+        0.06
         repeat
 
 image monika 3tfu:
@@ -5067,7 +5067,7 @@ image monika 3tfu:
             choice:
                 7
         "monika 3dfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 3tfx:
@@ -5081,7 +5081,7 @@ image monika 3tfx:
             choice:
                 7
         "monika 3dfx_static"
-        0.05
+        0.06
         repeat
 
 image monika 3tkbsu:
@@ -5095,7 +5095,7 @@ image monika 3tkbsu:
             choice:
                 7
         "monika 3dkbsu_static"
-        0.05
+        0.06
         repeat
 
 image monika 3tkc:
@@ -5109,7 +5109,7 @@ image monika 3tkc:
             choice:
                 7
         "monika 3dkc_static"
-        0.05
+        0.06
         repeat
 
 image monika 3tkd:
@@ -5123,7 +5123,7 @@ image monika 3tkd:
             choice:
                 7
         "monika 3dkd_static"
-        0.05
+        0.06
         repeat
 
 image monika 3tku:
@@ -5137,7 +5137,7 @@ image monika 3tku:
             choice:
                 7
         "monika 3dku_static"
-        0.05
+        0.06
         repeat
 
 image monika 3tkx:
@@ -5151,7 +5151,7 @@ image monika 3tkx:
             choice:
                 7
         "monika 3dkx_static"
-        0.05
+        0.06
         repeat
 
 image monika 3tsb:
@@ -5165,7 +5165,7 @@ image monika 3tsb:
             choice:
                 7
         "monika 3dsb_static"
-        0.05
+        0.06
         repeat
 
 image monika 3tsbsa:
@@ -5179,7 +5179,7 @@ image monika 3tsbsa:
             choice:
                 7
         "monika 3dsbsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 3tsd:
@@ -5193,7 +5193,7 @@ image monika 3tsd:
             choice:
                 7
         "monika 3dsd_static"
-        0.05
+        0.06
         repeat
 
 image monika 3tsu:
@@ -5207,7 +5207,7 @@ image monika 3tsu:
             choice:
                 7
         "monika 3dsu_static"
-        0.05
+        0.06
         repeat
 
 image monika 3tua:
@@ -5221,7 +5221,7 @@ image monika 3tua:
             choice:
                 7
         "monika 3dua_static"
-        0.05
+        0.06
         repeat
 
 image monika 3tub:
@@ -5235,7 +5235,7 @@ image monika 3tub:
             choice:
                 7
         "monika 3dub_static"
-        0.05
+        0.06
         repeat
 
 image monika 3tubfb:
@@ -5249,7 +5249,7 @@ image monika 3tubfb:
             choice:
                 7
         "monika 3dubfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 3tuu:
@@ -5263,7 +5263,7 @@ image monika 3tuu:
             choice:
                 7
         "monika 3duu_static"
-        0.05
+        0.06
         repeat
 
 image monika 3wfc:
@@ -5277,7 +5277,7 @@ image monika 3wfc:
             choice:
                 7
         "monika 3dfc_static"
-        0.05
+        0.06
         repeat
 
 image monika 3wfw:
@@ -5291,7 +5291,7 @@ image monika 3wfw:
             choice:
                 7
         "monika 3dfw_static"
-        0.05
+        0.06
         repeat
 
 image monika 3wfx:
@@ -5305,7 +5305,7 @@ image monika 3wfx:
             choice:
                 7
         "monika 3dfx_static"
-        0.05
+        0.06
         repeat
 
 image monika 3wkbsc:
@@ -5319,7 +5319,7 @@ image monika 3wkbsc:
             choice:
                 7
         "monika 3dkbsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 3wkd:
@@ -5333,7 +5333,7 @@ image monika 3wkd:
             choice:
                 7
         "monika 3dkd_static"
-        0.05
+        0.06
         repeat
 
 image monika 3wub:
@@ -5347,7 +5347,7 @@ image monika 3wub:
             choice:
                 7
         "monika 3dub_static"
-        0.05
+        0.06
         repeat
 
 image monika 3wubfb:
@@ -5361,7 +5361,7 @@ image monika 3wubfb:
             choice:
                 7
         "monika 3dubfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 3wubfsdld:
@@ -5375,7 +5375,7 @@ image monika 3wubfsdld:
             choice:
                 7
         "monika 3dubfsdld_static"
-        0.05
+        0.06
         repeat
 
 image monika 3wubfsdlo:
@@ -5389,7 +5389,7 @@ image monika 3wubfsdlo:
             choice:
                 7
         "monika 3dubfsdlo_static"
-        0.05
+        0.06
         repeat
 
 image monika 3wubso:
@@ -5403,7 +5403,7 @@ image monika 3wubso:
             choice:
                 7
         "monika 3dubso_static"
-        0.05
+        0.06
         repeat
 
 image monika 3wubsw:
@@ -5417,7 +5417,7 @@ image monika 3wubsw:
             choice:
                 7
         "monika 3dubsw_static"
-        0.05
+        0.06
         repeat
 
 image monika 3wud:
@@ -5431,7 +5431,7 @@ image monika 3wud:
             choice:
                 7
         "monika 3dud_static"
-        0.05
+        0.06
         repeat
 
 image monika 3wuo:
@@ -5445,7 +5445,7 @@ image monika 3wuo:
             choice:
                 7
         "monika 3duo_static"
-        0.05
+        0.06
         repeat
 
 image monika 3wuw:
@@ -5459,7 +5459,7 @@ image monika 3wuw:
             choice:
                 7
         "monika 3duw_static"
-        0.05
+        0.06
         repeat
 
 image monika 4efb:
@@ -5473,7 +5473,7 @@ image monika 4efb:
             choice:
                 7
         "monika 4dfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 4efc:
@@ -5487,7 +5487,7 @@ image monika 4efc:
             choice:
                 7
         "monika 4dfc_static"
-        0.05
+        0.06
         repeat
 
 image monika 4efd:
@@ -5501,7 +5501,7 @@ image monika 4efd:
             choice:
                 7
         "monika 4dfd_static"
-        0.05
+        0.06
         repeat
 
 image monika 4efo:
@@ -5515,7 +5515,7 @@ image monika 4efo:
             choice:
                 7
         "monika 4dfo_static"
-        0.05
+        0.06
         repeat
 
 image monika 4eft:
@@ -5529,7 +5529,7 @@ image monika 4eft:
             choice:
                 7
         "monika 4dft_static"
-        0.05
+        0.06
         repeat
 
 image monika 4eftsu:
@@ -5543,7 +5543,7 @@ image monika 4eftsu:
             choice:
                 7
         "monika 4dftsu_static"
-        0.05
+        0.06
         repeat
 
 image monika 4efu:
@@ -5557,7 +5557,7 @@ image monika 4efu:
             choice:
                 7
         "monika 4dfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 4efw:
@@ -5571,7 +5571,7 @@ image monika 4efw:
             choice:
                 7
         "monika 4dfw_static"
-        0.05
+        0.06
         repeat
 
 image monika 4efx:
@@ -5585,7 +5585,7 @@ image monika 4efx:
             choice:
                 7
         "monika 4dfx_static"
-        0.05
+        0.06
         repeat
 
 image monika 4eka:
@@ -5599,7 +5599,7 @@ image monika 4eka:
             choice:
                 7
         "monika 4dka_static"
-        0.05
+        0.06
         repeat
 
 image monika 4ekbfa:
@@ -5613,7 +5613,7 @@ image monika 4ekbfa:
             choice:
                 7
         "monika 4dkbfa_static"
-        0.05
+        0.06
         repeat
 
 image monika 4ekbfb:
@@ -5627,7 +5627,7 @@ image monika 4ekbfb:
             choice:
                 7
         "monika 4dkbfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 4ekbsa:
@@ -5641,7 +5641,7 @@ image monika 4ekbsa:
             choice:
                 7
         "monika 4dkbsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 4ekc:
@@ -5655,7 +5655,7 @@ image monika 4ekc:
             choice:
                 7
         "monika 4dkc_static"
-        0.05
+        0.06
         repeat
 
 image monika 4ekd:
@@ -5669,7 +5669,7 @@ image monika 4ekd:
             choice:
                 7
         "monika 4dkd_static"
-        0.05
+        0.06
         repeat
 
 image monika 4eksdla:
@@ -5683,7 +5683,7 @@ image monika 4eksdla:
             choice:
                 7
         "monika 4dksdla_static"
-        0.05
+        0.06
         repeat
 
 image monika 4eksdlc:
@@ -5697,7 +5697,7 @@ image monika 4eksdlc:
             choice:
                 7
         "monika 4dksdlc_static"
-        0.05
+        0.06
         repeat
 
 image monika 4eksdld:
@@ -5711,7 +5711,7 @@ image monika 4eksdld:
             choice:
                 7
         "monika 4dksdld_static"
-        0.05
+        0.06
         repeat
 
 image monika 4ektdc:
@@ -5725,7 +5725,7 @@ image monika 4ektdc:
             choice:
                 7
         "monika 4dktdc_static"
-        0.05
+        0.06
         repeat
 
 image monika 4ektsc:
@@ -5739,7 +5739,7 @@ image monika 4ektsc:
             choice:
                 7
         "monika 4dktsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 4esa:
@@ -5753,7 +5753,7 @@ image monika 4esa:
             choice:
                 7
         "monika 4dsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 4esb:
@@ -5767,7 +5767,7 @@ image monika 4esb:
             choice:
                 7
         "monika 4dsb_static"
-        0.05
+        0.06
         repeat
 
 image monika 4esc:
@@ -5781,7 +5781,7 @@ image monika 4esc:
             choice:
                 7
         "monika 4dsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 4esd:
@@ -5795,7 +5795,7 @@ image monika 4esd:
             choice:
                 7
         "monika 4dsd_static"
-        0.05
+        0.06
         repeat
 
 image monika 4eua:
@@ -5809,7 +5809,7 @@ image monika 4eua:
             choice:
                 7
         "monika 4dua_static"
-        0.05
+        0.06
         repeat
 
 image monika 4eub:
@@ -5823,7 +5823,7 @@ image monika 4eub:
             choice:
                 7
         "monika 4dub_static"
-        0.05
+        0.06
         repeat
 
 image monika 4euc:
@@ -5837,7 +5837,7 @@ image monika 4euc:
             choice:
                 7
         "monika 4duc_static"
-        0.05
+        0.06
         repeat
 
 image monika 4eud:
@@ -5851,7 +5851,7 @@ image monika 4eud:
             choice:
                 7
         "monika 4dud_static"
-        0.05
+        0.06
         repeat
 
 image monika 4lfb:
@@ -5865,7 +5865,7 @@ image monika 4lfb:
             choice:
                 7
         "monika 4dfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 4lfc:
@@ -5879,7 +5879,7 @@ image monika 4lfc:
             choice:
                 7
         "monika 4dfc_static"
-        0.05
+        0.06
         repeat
 
 image monika 4lfd:
@@ -5893,7 +5893,7 @@ image monika 4lfd:
             choice:
                 7
         "monika 4dfd_static"
-        0.05
+        0.06
         repeat
 
 image monika 4lftsc:
@@ -5907,7 +5907,7 @@ image monika 4lftsc:
             choice:
                 7
         "monika 4dftsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 4lfu:
@@ -5921,7 +5921,7 @@ image monika 4lfu:
             choice:
                 7
         "monika 4dfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 4lfw:
@@ -5935,7 +5935,7 @@ image monika 4lfw:
             choice:
                 7
         "monika 4dfw_static"
-        0.05
+        0.06
         repeat
 
 image monika 4lfx:
@@ -5949,7 +5949,7 @@ image monika 4lfx:
             choice:
                 7
         "monika 4dfx_static"
-        0.05
+        0.06
         repeat
 
 image monika 4lkbfb:
@@ -5963,7 +5963,7 @@ image monika 4lkbfb:
             choice:
                 7
         "monika 4dkbfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 4lkbsa:
@@ -5977,7 +5977,7 @@ image monika 4lkbsa:
             choice:
                 7
         "monika 4dkbsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 4lkbsc:
@@ -5991,7 +5991,7 @@ image monika 4lkbsc:
             choice:
                 7
         "monika 4dkbsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 4lksdla:
@@ -6005,7 +6005,7 @@ image monika 4lksdla:
             choice:
                 7
         "monika 4dksdla_static"
-        0.05
+        0.06
         repeat
 
 image monika 4lksdlb:
@@ -6019,7 +6019,7 @@ image monika 4lksdlb:
             choice:
                 7
         "monika 4dksdlb_static"
-        0.05
+        0.06
         repeat
 
 image monika 4lksdlc:
@@ -6033,7 +6033,7 @@ image monika 4lksdlc:
             choice:
                 7
         "monika 4dksdlc_static"
-        0.05
+        0.06
         repeat
 
 image monika 4lksdld:
@@ -6047,7 +6047,7 @@ image monika 4lksdld:
             choice:
                 7
         "monika 4dksdld_static"
-        0.05
+        0.06
         repeat
 
 image monika 4lksdlw:
@@ -6061,7 +6061,7 @@ image monika 4lksdlw:
             choice:
                 7
         "monika 4dksdlw_static"
-        0.05
+        0.06
         repeat
 
 image monika 4lksdrb:
@@ -6075,7 +6075,7 @@ image monika 4lksdrb:
             choice:
                 7
         "monika 4dksdrb_static"
-        0.05
+        0.06
         repeat
 
 image monika 4lktsc:
@@ -6089,7 +6089,7 @@ image monika 4lktsc:
             choice:
                 7
         "monika 4dktsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 4lsbsa:
@@ -6103,7 +6103,7 @@ image monika 4lsbsa:
             choice:
                 7
         "monika 4dsbsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 4lsbssdrb:
@@ -6117,7 +6117,7 @@ image monika 4lsbssdrb:
             choice:
                 7
         "monika 4dsbssdrb_static"
-        0.05
+        0.06
         repeat
 
 image monika 4lsc:
@@ -6131,7 +6131,7 @@ image monika 4lsc:
             choice:
                 7
         "monika 4dsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 4lssdrb:
@@ -6145,7 +6145,7 @@ image monika 4lssdrb:
             choice:
                 7
         "monika 4dssdrb_static"
-        0.05
+        0.06
         repeat
 
 image monika 4lssdrc:
@@ -6159,7 +6159,7 @@ image monika 4lssdrc:
             choice:
                 7
         "monika 4dssdrc_static"
-        0.05
+        0.06
         repeat
 
 image monika 4lubfb:
@@ -6173,7 +6173,7 @@ image monika 4lubfb:
             choice:
                 7
         "monika 4dubfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 4lud:
@@ -6187,7 +6187,7 @@ image monika 4lud:
             choice:
                 7
         "monika 4dud_static"
-        0.05
+        0.06
         repeat
 
 image monika 4rfb:
@@ -6201,7 +6201,7 @@ image monika 4rfb:
             choice:
                 7
         "monika 4dfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 4rfc:
@@ -6215,7 +6215,7 @@ image monika 4rfc:
             choice:
                 7
         "monika 4dfc_static"
-        0.05
+        0.06
         repeat
 
 image monika 4rfd:
@@ -6229,7 +6229,7 @@ image monika 4rfd:
             choice:
                 7
         "monika 4dfd_static"
-        0.05
+        0.06
         repeat
 
 image monika 4rfu:
@@ -6243,7 +6243,7 @@ image monika 4rfu:
             choice:
                 7
         "monika 4dfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 4rfw:
@@ -6257,7 +6257,7 @@ image monika 4rfw:
             choice:
                 7
         "monika 4dfw_static"
-        0.05
+        0.06
         repeat
 
 image monika 4rfx:
@@ -6271,7 +6271,7 @@ image monika 4rfx:
             choice:
                 7
         "monika 4dfx_static"
-        0.05
+        0.06
         repeat
 
 image monika 4rkbfb:
@@ -6285,7 +6285,7 @@ image monika 4rkbfb:
             choice:
                 7
         "monika 4dkbfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 4rkc:
@@ -6299,7 +6299,7 @@ image monika 4rkc:
             choice:
                 7
         "monika 4dkc_static"
-        0.05
+        0.06
         repeat
 
 image monika 4rkd:
@@ -6313,7 +6313,7 @@ image monika 4rkd:
             choice:
                 7
         "monika 4dkd_static"
-        0.05
+        0.06
         repeat
 
 image monika 4rksdla:
@@ -6327,7 +6327,7 @@ image monika 4rksdla:
             choice:
                 7
         "monika 4dksdla_static"
-        0.05
+        0.06
         repeat
 
 image monika 4rksdlb:
@@ -6341,7 +6341,7 @@ image monika 4rksdlb:
             choice:
                 7
         "monika 4dksdlb_static"
-        0.05
+        0.06
         repeat
 
 image monika 4rksdlc:
@@ -6355,7 +6355,7 @@ image monika 4rksdlc:
             choice:
                 7
         "monika 4dksdlc_static"
-        0.05
+        0.06
         repeat
 
 image monika 4rksdld:
@@ -6369,7 +6369,7 @@ image monika 4rksdld:
             choice:
                 7
         "monika 4dksdld_static"
-        0.05
+        0.06
         repeat
 
 image monika 4rktpc:
@@ -6383,7 +6383,7 @@ image monika 4rktpc:
             choice:
                 7
         "monika 4dktpc_static"
-        0.05
+        0.06
         repeat
 
 image monika 4rktsc:
@@ -6397,7 +6397,7 @@ image monika 4rktsc:
             choice:
                 7
         "monika 4dktsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 4rsc:
@@ -6411,7 +6411,7 @@ image monika 4rsc:
             choice:
                 7
         "monika 4dsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 4rssdrb:
@@ -6425,7 +6425,7 @@ image monika 4rssdrb:
             choice:
                 7
         "monika 4dssdrb_static"
-        0.05
+        0.06
         repeat
 
 image monika 4rssdrc:
@@ -6439,7 +6439,7 @@ image monika 4rssdrc:
             choice:
                 7
         "monika 4dssdrc_static"
-        0.05
+        0.06
         repeat
 
 image monika 4sub:
@@ -6453,7 +6453,7 @@ image monika 4sub:
             choice:
                 7
         "monika 4dub_static"
-        0.05
+        0.06
         repeat
 
 image monika 4subfb:
@@ -6467,7 +6467,7 @@ image monika 4subfb:
             choice:
                 7
         "monika 4dubfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 4subftsb:
@@ -6481,7 +6481,7 @@ image monika 4subftsb:
             choice:
                 7
         "monika 4dubftsb_static"
-        0.05
+        0.06
         repeat
 
 image monika 4sutsa:
@@ -6495,7 +6495,7 @@ image monika 4sutsa:
             choice:
                 7
         "monika 4dutsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 4tfb:
@@ -6509,7 +6509,7 @@ image monika 4tfb:
             choice:
                 7
         "monika 4dfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 4tfc:
@@ -6523,7 +6523,7 @@ image monika 4tfc:
             choice:
                 7
         "monika 4dfc_static"
-        0.05
+        0.06
         repeat
 
 image monika 4tfd:
@@ -6537,7 +6537,7 @@ image monika 4tfd:
             choice:
                 7
         "monika 4dfd_static"
-        0.05
+        0.06
         repeat
 
 image monika 4tfu:
@@ -6551,7 +6551,7 @@ image monika 4tfu:
             choice:
                 7
         "monika 4dfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 4tfx:
@@ -6565,7 +6565,7 @@ image monika 4tfx:
             choice:
                 7
         "monika 4dfx_static"
-        0.05
+        0.06
         repeat
 
 image monika 4tkc:
@@ -6579,7 +6579,7 @@ image monika 4tkc:
             choice:
                 7
         "monika 4dkc_static"
-        0.05
+        0.06
         repeat
 
 image monika 4tkd:
@@ -6593,7 +6593,7 @@ image monika 4tkd:
             choice:
                 7
         "monika 4dkd_static"
-        0.05
+        0.06
         repeat
 
 image monika 4tku:
@@ -6607,7 +6607,7 @@ image monika 4tku:
             choice:
                 7
         "monika 4dku_static"
-        0.05
+        0.06
         repeat
 
 image monika 4tkx:
@@ -6621,7 +6621,7 @@ image monika 4tkx:
             choice:
                 7
         "monika 4dkx_static"
-        0.05
+        0.06
         repeat
 
 image monika 4tsb:
@@ -6635,7 +6635,7 @@ image monika 4tsb:
             choice:
                 7
         "monika 4dsb_static"
-        0.05
+        0.06
         repeat
 
 image monika 4tsbsa:
@@ -6649,7 +6649,7 @@ image monika 4tsbsa:
             choice:
                 7
         "monika 4dsbsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 4tub:
@@ -6663,7 +6663,7 @@ image monika 4tub:
             choice:
                 7
         "monika 4dub_static"
-        0.05
+        0.06
         repeat
 
 image monika 4tubfb:
@@ -6677,7 +6677,7 @@ image monika 4tubfb:
             choice:
                 7
         "monika 4dubfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 4wfw:
@@ -6691,7 +6691,7 @@ image monika 4wfw:
             choice:
                 7
         "monika 4dfw_static"
-        0.05
+        0.06
         repeat
 
 image monika 4wfx:
@@ -6705,7 +6705,7 @@ image monika 4wfx:
             choice:
                 7
         "monika 4dfx_static"
-        0.05
+        0.06
         repeat
 
 image monika 4wkbsc:
@@ -6719,7 +6719,7 @@ image monika 4wkbsc:
             choice:
                 7
         "monika 4dkbsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 4wkc:
@@ -6733,7 +6733,7 @@ image monika 4wkc:
             choice:
                 7
         "monika 4dkc_static"
-        0.05
+        0.06
         repeat
 
 image monika 4wkd:
@@ -6747,7 +6747,7 @@ image monika 4wkd:
             choice:
                 7
         "monika 4dkd_static"
-        0.05
+        0.06
         repeat
 
 image monika 4wktsw:
@@ -6761,7 +6761,7 @@ image monika 4wktsw:
             choice:
                 7
         "monika 4dktsw_static"
-        0.05
+        0.06
         repeat
 
 image monika 4wua:
@@ -6775,7 +6775,7 @@ image monika 4wua:
             choice:
                 7
         "monika 4dua_static"
-        0.05
+        0.06
         repeat
 
 image monika 4wub:
@@ -6789,7 +6789,7 @@ image monika 4wub:
             choice:
                 7
         "monika 4dub_static"
-        0.05
+        0.06
         repeat
 
 image monika 4wubfb:
@@ -6803,7 +6803,7 @@ image monika 4wubfb:
             choice:
                 7
         "monika 4dubfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 4wubfsdld:
@@ -6817,7 +6817,7 @@ image monika 4wubfsdld:
             choice:
                 7
         "monika 4dubfsdld_static"
-        0.05
+        0.06
         repeat
 
 image monika 4wubso:
@@ -6831,7 +6831,7 @@ image monika 4wubso:
             choice:
                 7
         "monika 4dubso_static"
-        0.05
+        0.06
         repeat
 
 image monika 4wubsw:
@@ -6845,7 +6845,7 @@ image monika 4wubsw:
             choice:
                 7
         "monika 4dubsw_static"
-        0.05
+        0.06
         repeat
 
 image monika 4wuc:
@@ -6859,7 +6859,7 @@ image monika 4wuc:
             choice:
                 7
         "monika 4duc_static"
-        0.05
+        0.06
         repeat
 
 image monika 4wud:
@@ -6873,7 +6873,7 @@ image monika 4wud:
             choice:
                 7
         "monika 4dud_static"
-        0.05
+        0.06
         repeat
 
 image monika 4wuo:
@@ -6887,7 +6887,7 @@ image monika 4wuo:
             choice:
                 7
         "monika 4duo_static"
-        0.05
+        0.06
         repeat
 
 image monika 4wuw:
@@ -6901,7 +6901,7 @@ image monika 4wuw:
             choice:
                 7
         "monika 4duw_static"
-        0.05
+        0.06
         repeat
 
 image monika 5efa:
@@ -6915,7 +6915,7 @@ image monika 5efa:
             choice:
                 7
         "monika 5dfa_static"
-        0.05
+        0.06
         repeat
 
 image monika 5eka:
@@ -6929,7 +6929,7 @@ image monika 5eka:
             choice:
                 7
         "monika 5dka_static"
-        0.05
+        0.06
         repeat
 
 image monika 5ekbfa:
@@ -6943,7 +6943,7 @@ image monika 5ekbfa:
             choice:
                 7
         "monika 5dkbfa_static"
-        0.05
+        0.06
         repeat
 
 image monika 5ekbla:
@@ -6957,7 +6957,7 @@ image monika 5ekbla:
             choice:
                 7
         "monika 5dkbla_static"
-        0.05
+        0.06
         repeat
 
 image monika 5ekbsa:
@@ -6971,7 +6971,7 @@ image monika 5ekbsa:
             choice:
                 7
         "monika 5dkbsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 5esbfa:
@@ -6985,6 +6985,6 @@ image monika 5esbfa:
             choice:
                 7
         "monika 5dsbfa_static"
-        0.05
+        0.06
         repeat
 

--- a/Monika After Story/game/sprite-chart-21.rpy
+++ b/Monika After Story/game/sprite-chart-21.rpy
@@ -15,7 +15,7 @@ image monika 5esu:
             choice:
                 7
         "monika 5dsu_static"
-        0.05
+        0.06
         repeat
 
 image monika 5eua:
@@ -29,7 +29,7 @@ image monika 5eua:
             choice:
                 7
         "monika 5dua_static"
-        0.05
+        0.06
         repeat
 
 image monika 5eub:
@@ -43,7 +43,7 @@ image monika 5eub:
             choice:
                 7
         "monika 5dub_static"
-        0.05
+        0.06
         repeat
 
 image monika 5eubfb:
@@ -57,7 +57,7 @@ image monika 5eubfb:
             choice:
                 7
         "monika 5dubfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 5eubfu:
@@ -71,7 +71,7 @@ image monika 5eubfu:
             choice:
                 7
         "monika 5dubfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 5eubla:
@@ -85,7 +85,7 @@ image monika 5eubla:
             choice:
                 7
         "monika 5dubla_static"
-        0.05
+        0.06
         repeat
 
 image monika 5euc:
@@ -99,7 +99,7 @@ image monika 5euc:
             choice:
                 7
         "monika 5duc_static"
-        0.05
+        0.06
         repeat
 
 image monika 5lfc:
@@ -113,7 +113,7 @@ image monika 5lfc:
             choice:
                 7
         "monika 5dfc_static"
-        0.05
+        0.06
         repeat
 
 image monika 5lkc:
@@ -127,7 +127,7 @@ image monika 5lkc:
             choice:
                 7
         "monika 5dkc_static"
-        0.05
+        0.06
         repeat
 
 image monika 5lsc:
@@ -141,7 +141,7 @@ image monika 5lsc:
             choice:
                 7
         "monika 5dsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 5lubfb:
@@ -155,7 +155,7 @@ image monika 5lubfb:
             choice:
                 7
         "monika 5dubfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 5lubfsdrb:
@@ -169,7 +169,7 @@ image monika 5lubfsdrb:
             choice:
                 7
         "monika 5dubfsdrb_static"
-        0.05
+        0.06
         repeat
 
 image monika 5lubfsdru:
@@ -183,7 +183,7 @@ image monika 5lubfsdru:
             choice:
                 7
         "monika 5dubfsdru_static"
-        0.05
+        0.06
         repeat
 
 image monika 5lubfu:
@@ -197,7 +197,7 @@ image monika 5lubfu:
             choice:
                 7
         "monika 5dubfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 5lubsa:
@@ -211,7 +211,7 @@ image monika 5lubsa:
             choice:
                 7
         "monika 5dubsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 5lusdrb:
@@ -225,7 +225,7 @@ image monika 5lusdrb:
             choice:
                 7
         "monika 5dusdrb_static"
-        0.05
+        0.06
         repeat
 
 image monika 5lusdru:
@@ -239,7 +239,7 @@ image monika 5lusdru:
             choice:
                 7
         "monika 5dusdru_static"
-        0.05
+        0.06
         repeat
 
 image monika 5luu:
@@ -253,7 +253,7 @@ image monika 5luu:
             choice:
                 7
         "monika 5duu_static"
-        0.05
+        0.06
         repeat
 
 image monika 5rfc:
@@ -267,7 +267,7 @@ image monika 5rfc:
             choice:
                 7
         "monika 5dfc_static"
-        0.05
+        0.06
         repeat
 
 image monika 5rkc:
@@ -281,7 +281,7 @@ image monika 5rkc:
             choice:
                 7
         "monika 5dkc_static"
-        0.05
+        0.06
         repeat
 
 image monika 5rsc:
@@ -295,7 +295,7 @@ image monika 5rsc:
             choice:
                 7
         "monika 5dsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 5rub:
@@ -309,7 +309,7 @@ image monika 5rub:
             choice:
                 7
         "monika 5dub_static"
-        0.05
+        0.06
         repeat
 
 image monika 5rubfb:
@@ -323,7 +323,7 @@ image monika 5rubfb:
             choice:
                 7
         "monika 5dubfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 5rubfsdrb:
@@ -337,7 +337,7 @@ image monika 5rubfsdrb:
             choice:
                 7
         "monika 5dubfsdrb_static"
-        0.05
+        0.06
         repeat
 
 image monika 5rubfsdru:
@@ -351,7 +351,7 @@ image monika 5rubfsdru:
             choice:
                 7
         "monika 5dubfsdru_static"
-        0.05
+        0.06
         repeat
 
 image monika 5rubfu:
@@ -365,7 +365,7 @@ image monika 5rubfu:
             choice:
                 7
         "monika 5dubfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 5rusdrb:
@@ -379,7 +379,7 @@ image monika 5rusdrb:
             choice:
                 7
         "monika 5dusdrb_static"
-        0.05
+        0.06
         repeat
 
 image monika 5rusdru:
@@ -393,7 +393,7 @@ image monika 5rusdru:
             choice:
                 7
         "monika 5dusdru_static"
-        0.05
+        0.06
         repeat
 
 image monika 5ruu:
@@ -407,7 +407,7 @@ image monika 5ruu:
             choice:
                 7
         "monika 5duu_static"
-        0.05
+        0.06
         repeat
 
 image monika 5tsbfu:
@@ -421,7 +421,7 @@ image monika 5tsbfu:
             choice:
                 7
         "monika 5dsbfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 5tsc:
@@ -435,7 +435,7 @@ image monika 5tsc:
             choice:
                 7
         "monika 5dsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 5tsu:
@@ -449,7 +449,7 @@ image monika 5tsu:
             choice:
                 7
         "monika 5dsu_static"
-        0.05
+        0.06
         repeat
 
 image monika 5ttu:
@@ -463,7 +463,7 @@ image monika 5ttu:
             choice:
                 7
         "monika 5dtu_static"
-        0.05
+        0.06
         repeat
 
 image monika 5tubfb:
@@ -477,7 +477,7 @@ image monika 5tubfb:
             choice:
                 7
         "monika 5dubfb_static"
-        0.05
+        0.06
         repeat
 
 image monika 5tubfu:
@@ -491,7 +491,7 @@ image monika 5tubfu:
             choice:
                 7
         "monika 5dubfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 5wubfw:
@@ -505,7 +505,7 @@ image monika 5wubfw:
             choice:
                 7
         "monika 5dubfw_static"
-        0.05
+        0.06
         repeat
 
 image monika 5wuw:
@@ -519,7 +519,7 @@ image monika 5wuw:
             choice:
                 7
         "monika 5duw_static"
-        0.05
+        0.06
         repeat
 
 image monika 6cfw:
@@ -533,7 +533,7 @@ image monika 6cfw:
             choice:
                 7
         "monika 6dfw_static"
-        0.05
+        0.06
         repeat
 
 image monika 6ckc:
@@ -547,7 +547,7 @@ image monika 6ckc:
             choice:
                 7
         "monika 6dkc_static"
-        0.05
+        0.06
         repeat
 
 image monika 6eftsc:
@@ -561,7 +561,7 @@ image monika 6eftsc:
             choice:
                 7
         "monika 6dftsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 6eka:
@@ -575,7 +575,7 @@ image monika 6eka:
             choice:
                 7
         "monika 6dka_static"
-        0.05
+        0.06
         repeat
 
 image monika 6ekbfa:
@@ -589,7 +589,7 @@ image monika 6ekbfa:
             choice:
                 7
         "monika 6dkbfa_static"
-        0.05
+        0.06
         repeat
 
 image monika 6ekbfd:
@@ -603,7 +603,7 @@ image monika 6ekbfd:
             choice:
                 7
         "monika 6dkbfd_static"
-        0.05
+        0.06
         repeat
 
 image monika 6ekbsa:
@@ -617,7 +617,7 @@ image monika 6ekbsa:
             choice:
                 7
         "monika 6dkbsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 6ekbsu:
@@ -631,7 +631,7 @@ image monika 6ekbsu:
             choice:
                 7
         "monika 6dkbsu_static"
-        0.05
+        0.06
         repeat
 
 image monika 6ekc:
@@ -645,7 +645,7 @@ image monika 6ekc:
             choice:
                 7
         "monika 6dkc_static"
-        0.05
+        0.06
         repeat
 
 image monika 6ekd:
@@ -659,7 +659,7 @@ image monika 6ekd:
             choice:
                 7
         "monika 6dkd_static"
-        0.05
+        0.06
         repeat
 
 image monika 6eksdla:
@@ -673,7 +673,7 @@ image monika 6eksdla:
             choice:
                 7
         "monika 6dksdla_static"
-        0.05
+        0.06
         repeat
 
 image monika 6ektda:
@@ -687,7 +687,7 @@ image monika 6ektda:
             choice:
                 7
         "monika 6dktda_static"
-        0.05
+        0.06
         repeat
 
 image monika 6ektdc:
@@ -701,7 +701,7 @@ image monika 6ektdc:
             choice:
                 7
         "monika 6dktdc_static"
-        0.05
+        0.06
         repeat
 
 image monika 6ektpc:
@@ -715,7 +715,7 @@ image monika 6ektpc:
             choice:
                 7
         "monika 6dktpc_static"
-        0.05
+        0.06
         repeat
 
 image monika 6ektrd:
@@ -729,7 +729,7 @@ image monika 6ektrd:
             choice:
                 7
         "monika 6dktrd_static"
-        0.05
+        0.06
         repeat
 
 image monika 6ektsa:
@@ -743,7 +743,7 @@ image monika 6ektsa:
             choice:
                 7
         "monika 6dktsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 6ektsc:
@@ -757,7 +757,7 @@ image monika 6ektsc:
             choice:
                 7
         "monika 6dktsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 6esa:
@@ -771,7 +771,7 @@ image monika 6esa:
             choice:
                 7
         "monika 6dsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 6esbfa:
@@ -785,7 +785,7 @@ image monika 6esbfa:
             choice:
                 7
         "monika 6dsbfa_static"
-        0.05
+        0.06
         repeat
 
 image monika 6eua:
@@ -799,7 +799,7 @@ image monika 6eua:
             choice:
                 7
         "monika 6dua_static"
-        0.05
+        0.06
         repeat
 
 image monika 6eud:
@@ -813,7 +813,7 @@ image monika 6eud:
             choice:
                 7
         "monika 6dud_static"
-        0.05
+        0.06
         repeat
 
 image monika 6lftsc:
@@ -827,7 +827,7 @@ image monika 6lftsc:
             choice:
                 7
         "monika 6dftsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 6lkc:
@@ -841,7 +841,7 @@ image monika 6lkc:
             choice:
                 7
         "monika 6dkc_static"
-        0.05
+        0.06
         repeat
 
 image monika 6lktdc:
@@ -855,7 +855,7 @@ image monika 6lktdc:
             choice:
                 7
         "monika 6dktdc_static"
-        0.05
+        0.06
         repeat
 
 image monika 6lktsc:
@@ -869,7 +869,7 @@ image monika 6lktsc:
             choice:
                 7
         "monika 6dktsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 6rkbfd:
@@ -883,7 +883,7 @@ image monika 6rkbfd:
             choice:
                 7
         "monika 6dkbfd_static"
-        0.05
+        0.06
         repeat
 
 image monika 6rkc:
@@ -897,7 +897,7 @@ image monika 6rkc:
             choice:
                 7
         "monika 6dkc_static"
-        0.05
+        0.06
         repeat
 
 image monika 6rksdla:
@@ -911,7 +911,7 @@ image monika 6rksdla:
             choice:
                 7
         "monika 6dksdla_static"
-        0.05
+        0.06
         repeat
 
 image monika 6rksdlc:
@@ -925,7 +925,7 @@ image monika 6rksdlc:
             choice:
                 7
         "monika 6dksdlc_static"
-        0.05
+        0.06
         repeat
 
 image monika 6rktda:
@@ -939,7 +939,7 @@ image monika 6rktda:
             choice:
                 7
         "monika 6dktda_static"
-        0.05
+        0.06
         repeat
 
 image monika 6rktdc:
@@ -953,7 +953,7 @@ image monika 6rktdc:
             choice:
                 7
         "monika 6dktdc_static"
-        0.05
+        0.06
         repeat
 
 image monika 6rktsc:
@@ -967,7 +967,7 @@ image monika 6rktsc:
             choice:
                 7
         "monika 6dktsc_static"
-        0.05
+        0.06
         repeat
 
 image monika 6rktuc:
@@ -981,7 +981,7 @@ image monika 6rktuc:
             choice:
                 7
         "monika 6dktuc_static"
-        0.05
+        0.06
         repeat
 
 image monika 6sua:
@@ -995,7 +995,7 @@ image monika 6sua:
             choice:
                 7
         "monika 6dua_static"
-        0.05
+        0.06
         repeat
 
 image monika 6sub:
@@ -1009,7 +1009,7 @@ image monika 6sub:
             choice:
                 7
         "monika 6dub_static"
-        0.05
+        0.06
         repeat
 
 image monika 6suu:
@@ -1023,7 +1023,7 @@ image monika 6suu:
             choice:
                 7
         "monika 6duu_static"
-        0.05
+        0.06
         repeat
 
 image monika 6tftpc:
@@ -1037,7 +1037,7 @@ image monika 6tftpc:
             choice:
                 7
         "monika 6dftpc_static"
-        0.05
+        0.06
         repeat
 
 image monika 6tkbfu:
@@ -1051,7 +1051,7 @@ image monika 6tkbfu:
             choice:
                 7
         "monika 6dkbfu_static"
-        0.05
+        0.06
         repeat
 
 image monika 6tsbfa:
@@ -1065,7 +1065,7 @@ image monika 6tsbfa:
             choice:
                 7
         "monika 6dsbfa_static"
-        0.05
+        0.06
         repeat
 
 image monika 6tsbsa:
@@ -1079,7 +1079,7 @@ image monika 6tsbsa:
             choice:
                 7
         "monika 6dsbsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 6tst:
@@ -1093,7 +1093,7 @@ image monika 6tst:
             choice:
                 7
         "monika 6dst_static"
-        0.05
+        0.06
         repeat
 
 image monika 6tubfa:
@@ -1107,7 +1107,7 @@ image monika 6tubfa:
             choice:
                 7
         "monika 6dubfa_static"
-        0.05
+        0.06
         repeat
 
 image monika 6tubsa:
@@ -1121,7 +1121,7 @@ image monika 6tubsa:
             choice:
                 7
         "monika 6dubsa_static"
-        0.05
+        0.06
         repeat
 
 image monika 6wfw:
@@ -1135,7 +1135,7 @@ image monika 6wfw:
             choice:
                 7
         "monika 6dfw_static"
-        0.05
+        0.06
         repeat
 
 image monika 6wka:
@@ -1149,7 +1149,7 @@ image monika 6wka:
             choice:
                 7
         "monika 6dka_static"
-        0.05
+        0.06
         repeat
 
 image monika 6wub:
@@ -1163,7 +1163,7 @@ image monika 6wub:
             choice:
                 7
         "monika 6dub_static"
-        0.05
+        0.06
         repeat
 
 image monika 6wubfo:
@@ -1177,7 +1177,7 @@ image monika 6wubfo:
             choice:
                 7
         "monika 6dubfo_static"
-        0.05
+        0.06
         repeat
 
 image monika 6wubsw:
@@ -1191,7 +1191,7 @@ image monika 6wubsw:
             choice:
                 7
         "monika 6dubsw_static"
-        0.05
+        0.06
         repeat
 
 image monika 6wuo:
@@ -1205,6 +1205,6 @@ image monika 6wuo:
             choice:
                 7
         "monika 6duo_static"
-        0.05
+        0.06
         repeat
 

--- a/Monika After Story/game/zz_windowreacts.rpy
+++ b/Monika After Story/game/zz_windowreacts.rpy
@@ -208,6 +208,21 @@ init python:
         """
         return persistent._mas_enable_notifications and persistent._mas_windowreacts_notif_filters.get(group,False)
 
+    def mas_unlockFailedWRS(ev_label=None):
+        """
+        Unlocks a wrs again provided that it showed, but failed to show (failed checks in the notif label)
+        NOTE: This should only be used for wrs that are only a notification
+
+        IN:
+            ev_label: eventlabel of the wrs
+        """
+        if (
+                ev_label
+                and renpy.has_label(ev_label)
+                and ev_label not in persistent._mas_windowreacts_no_unlock_list
+            ):
+            mas_unlockEVL(ev_label,"WRS")
+
     def mas_tryShowNotificationOSX(title, body):
         """
         Tries to push a notification to the notification center on macOS.
@@ -237,6 +252,9 @@ init python:
 #   body: Notification body text
 #   group: Notification group (for checking if we have this enabled)
 #   skip_checks: Whether or not we skips checks
+#
+#OUT:
+#   bool indicating status (notif shown or not (by check))
 
 label display_notif(title, body, group=None, skip_checks=False):
     #We only show notifications if:
@@ -280,7 +298,9 @@ label display_notif(title, body, group=None, skip_checks=False):
         elif (renpy.linux):
             # The Linux way
             $ mas_tryShowNotificationLinux(renpy.substitute(title),renpy.substitute(body))
-    return
+
+        return True
+    return False
 
 
 #START: Window Reacts
@@ -298,6 +318,10 @@ init 5 python:
 
 label monika_whatwatching:
     call display_notif(m_name,"What are you watching, [player]?",'Window Reactions')
+
+    #Unlock again if we failed
+    if not _return:
+        $ mas_unlockFailedWRS('monika_whatwatching')
     return
 
 init 5 python:
@@ -350,4 +374,8 @@ init 5 python:
 
 label monika_monikamoddev:
     call display_notif(m_name, "Aww, are you doing something for me?\nYou're so sweet~",'Window Reactions')
+
+    #Unlock again if we failed
+    if not _return:
+        $ mas_unlockFailedWRS('monika_monikamoddev')
     return

--- a/Monika After Story/game/zz_windowreacts.rpy
+++ b/Monika After Story/game/zz_windowreacts.rpy
@@ -121,7 +121,7 @@ init python:
         Checks if MAS is the focused window
         """
         #TODO: Mac vers (if possible)
-        return store.mas_windowreacts.can_show_notifs and mas_getActiveWindow(True) == config.name.lower()
+        return store.mas_windowreacts.can_show_notifs and mas_getActiveWindow(True) == config.name
 
     def mas_isInActiveWindow(keywords):
         """

--- a/Monika After Story/game/zz_windowreacts.rpy
+++ b/Monika After Story/game/zz_windowreacts.rpy
@@ -110,7 +110,7 @@ init python:
             if not friendly:
                 return GetWindowText(GetForegroundWindow()).lower().replace(" ","")
             else:
-                return GetWindowText(GetForegroundWindow()).lower()
+                return GetWindowText(GetForegroundWindow())
         else:
             #TODO: Mac vers (if possible)
             #NOTE: We return "" so this doesn't rule out notifications

--- a/Monika After Story/game/zz_windowreacts.rpy
+++ b/Monika After Story/game/zz_windowreacts.rpy
@@ -71,12 +71,22 @@ init python:
             tip.hwnd = None
 
     #List of notif quips (used for topic alerts)
-    notif_quips = [
+    #Windows
+    win_notif_quips = [
         "[player], I want to talk to you about something.",
         "Are you there, [player]?",
         "Can you come here for a second?",
         "[player], do you have a second?",
         "I have something to tell you, [player]!",
+        "Do you have a minute, [player]?",
+    ]
+
+    #OSX/Linux
+    other_notif_quips = [
+        "I've got something to talk about, [player]!",
+        "I have something to tell you, [player]!",
+        "Hey [player], I want to tell you something.",
+        "Do you have a minute, [player]?",
     ]
 
     #List of hwnd IDs to destroy
@@ -93,7 +103,7 @@ init python:
         if (
                 renpy.windows
                 and mas_windowreacts.can_show_notifs
-                and persistent._mas_windowreacts_windowreacts_enabled
+                and (persistent._mas_windowreacts_windowreacts_enabled or persistent._mas_enable_notifications)
             ):
             from win32gui import GetWindowText, GetForegroundWindow
 
@@ -370,7 +380,6 @@ init 5 python:
         ),
         code="WRS"
     )
-
 
 label monika_monikamoddev:
     call display_notif(m_name, "Aww, are you doing something for me?\nYou're so sweet~",'Window Reactions')

--- a/tools/sprite.py
+++ b/tools/sprite.py
@@ -669,7 +669,7 @@ class StaticSprite(object):
             "\n",
 
             self._dbl_tab,
-            "0.05\n",
+            "0.06\n",
 
             self._dbl_tab,
             self._repeat,


### PR DESCRIPTION
This should fix the seizure issue when Moni switches exp during a spaceroom call, also more notif fixes because some labels still got past the original check.

Make sure that the crashed greeting doesn't create a notif, same goes for the monikaroom greetings.

Also made coffee/hotchoc auto-progress as if it were in idle when MAS isn't the active window.