### PR TITLE
push random seen limit if all topics seen within last seen delta

### DIFF
--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -939,7 +939,7 @@ init -1 python in evhand:
 
     # time stuff
     import datetime
-    LAST_SEEN_DELTA = datetime.timedelta(hours=6)
+    LAST_SEEN_DELTA = datetime.timedelta(hours=3)
 
     # restart topic blacklist
     # TODO: consider an addEvent param instead

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -939,7 +939,7 @@ init -1 python in evhand:
 
     # time stuff
     import datetime
-    LAST_SEEN_DELTA = datetime.timedelta(hours=3)
+    LAST_SEEN_DELTA = datetime.timedelta(hours=6)
 
     # restart topic blacklist
     # TODO: consider an addEvent param instead

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1564,14 +1564,18 @@ label mas_ch30_select_seen:
         # rebuild the event lists
         $ mas_rev_seen, mas_rev_mostseen = mas_buildSeenEventLists()
 
-        # all topics seen within last seen delta, push random seen limit
-        # if not already.
-        if (
-                len(mas_rev_seen) == 0
-                and len(mas_rev_mostseen) == 0
-                and not seen_random_limit
-        ):
-            $ pushEvent("random_limit_reached")
+        if len(mas_rev_seen) == 0:
+            if len(mas_rev_mostseen) > 0:
+                # jump to most seen if we have any left
+                jump mas_ch30_select_mostseen
+
+            if len(mas_rev_mostseen) == 0 and not seen_random_limit:
+                # all topics seen within last seen delta, push random seen 
+                # limit if not already.
+                $ pushEvent("random_limit_reached")
+                jump post_pick_random_topic
+            
+            # if still no events, just jump to idle loop
             jump post_pick_random_topic
 
     $ mas_randomSelectAndPush(mas_rev_seen)

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1564,6 +1564,16 @@ label mas_ch30_select_seen:
         # rebuild the event lists
         $ mas_rev_seen, mas_rev_mostseen = mas_buildSeenEventLists()
 
+        # all topics seen within last seen delta, push random seen limit
+        # if not already.
+        if (
+                len(mas_rev_seen) == 0
+                and len(mas_rev_mostseen) == 0
+                and not seen_random_limit
+        ):
+            $ pushEvent("random_limit_reached")
+            jump post_pick_random_topic
+
     $ mas_randomSelectAndPush(mas_rev_seen)
 
     jump post_pick_random_topic

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -27,7 +27,7 @@ init -2 python in mas_topics:
     S_TOP_SEEN = 0.2
 
     # limit to how many top seen until we move to most seen alg
-    S_TOP_LIMIT = 0.7
+    S_TOP_LIMIT = 0.3
 
     # selection weights (out of 100)
     UNSEEN = 50


### PR DESCRIPTION
~~from 6 hours to 3 hours.~~

~~this was the cause of monika going silent after a long session.~~

ok instead just pushes the randon limit reached topic if no topics because of last seen delta.

also lowers the threshold to using most_count instead of top_count alg to 30%. (aka, if 30% of all topics are considered part of the top 20% of shown counts, then we use the most count selection, which is 10% of all topics for the most count list). This should expand the pool of random seen selectables.

also if you have most seen but no more seen, you should now get the most seen topics.