### PR TITLE
move version nubmer to top right

### DIFF
--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -1324,11 +1324,14 @@ screen preferences():
         xalign 0.0 yalign 1.0
         xoffset 300 yoffset -10
         style "main_menu_version"
+#        layout "greedy"
+#        text_align 0.5
+#        xmaximum 650
 
     text "v[config.version]":
-                xalign 1.0 yalign 1.0
-                xoffset -10 yoffset -10
-                style "main_menu_version"
+        xalign 1.0 yalign 0.0
+        xoffset -10 
+        style "main_menu_version"
 
 style pref_label is gui_label
 style pref_label_text is gui_label_text


### PR DESCRIPTION
this moves version number to top right so it can never collide with tooltip text

# Testing
* verify version number is on top right
* verify tooltips look ok