### PR TITLE
greeting_tears fix

### DIFF
--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -1538,7 +1538,7 @@ init 20 python:
         # store the value for easiercomparisons
         curr_affection = _mas_getAffection()
 
-        # If affection is between AFF_MIN_POS_TRESH and AFF_MAX_POS_TRESH, update good exp. Simulates growing affection.
+        # If affection is greater then AFF_MIN_POS_TRESH, update good exp. Simulates growing affection.
         if  affection.AFF_MIN_POS_TRESH <= curr_affection:
             persistent._mas_affection["goodexp"] = 3
             persistent._mas_affection["badexp"] = 1

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -1539,7 +1539,7 @@ init 20 python:
         curr_affection = _mas_getAffection()
 
         # If affection is between AFF_MIN_POS_TRESH and AFF_MAX_POS_TRESH, update good exp. Simulates growing affection.
-        if  affection.AFF_MIN_POS_TRESH <= curr_affection < affection.AFF_MAX_POS_TRESH:
+        if  affection.AFF_MIN_POS_TRESH <= curr_affection:
             persistent._mas_affection["goodexp"] = 3
             persistent._mas_affection["badexp"] = 1
 

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -1543,10 +1543,6 @@ init 20 python:
             persistent._mas_affection["goodexp"] = 3
             persistent._mas_affection["badexp"] = 1
 
-        # If affection is more than AFF_MAX_TRESH, update good exp. Simulates increasing affection.
-        elif curr_affection >= affection.AFF_MAX_POS_TRESH:
-            persistent._mas_affection["goodexp"] = 3
-
         # If affection is between AFF_MAX_NEG_TRESH and AFF_MIN_NEG_TRESH, update both exps. Simulates erosion of affection.
         elif affection.AFF_MAX_NEG_TRESH < curr_affection <= affection.AFF_MIN_NEG_TRESH:
             persistent._mas_affection["goodexp"] = 0.5
@@ -1780,9 +1776,6 @@ init 20 python:
         elif curr_affection <= -50 and not seen_event("mas_affection_apology"):
             if not persistent._mas_disable_sorry:
                 queueEvent("mas_affection_apology", notify=True)
-        # If affection level is equal or less than -100 and the label hasn't been seen yet, push this event where Monika says she's upset with you and wants you to apologize.
-        elif curr_affection <= -100 and not seen_event("greeting_tears"):
-            mas_unlockEVL("greeting_tears", "GRE")
 
     # Easy functions to add and subtract points, designed to make it easier to sadden her so player has to work harder to keep her happy.
     # Check function is added to make sure mas_curr_affection is always appropriate to the points counter.

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -2523,7 +2523,7 @@ init 5 python:
             persistent.greeting_database,
             eventlabel="greeting_tears",
             unlocked=True,
-            aff_range=(mas_aff.DISTRESSED, mas_aff.DISTRESSED),
+            aff_range=(None, mas_aff.DISTRESSED),
             rules=ev_rules,
         ),
         code="GRE"
@@ -2531,18 +2531,18 @@ init 5 python:
     del ev_rules
 
 label greeting_tears:
-    m 1q "...[player]."
-    m 1f "..."
-    m 2f "Is there something wrong with me?"
-    m 2g "Am I not good enough for you...?"
-    m 2o "I've been trying my best for you...for {i}us{/i}."
-    m 2p "Did I do something to hurt you or make you feel mistreated?"
+    m 1dsc "...[player]."
+    m 1ekc "..."
+    m 2ekc "Is there something wrong with me?"
+    m 2ekd "Am I not good enough for you...?"
+    m 2lksdlc "I've been trying my best for you...for {i}us{/i}."
+    m 2lksdld "Did I do something to hurt you or make you feel mistreated?"
     m "Are you still upset about the other girls after all?"
-    m 2f "If so, I really am sorry..."
+    m 2ekc "If so, I really am sorry..."
     m "I'm so, so sorry!"
-    m 2pp "Just tell me what I did wrong and I'll try even harder to be the perfect girlfriend for you."
-    m 2g "You're my entire world; how you feel means everything to me!"
-    m 2f "So please, just tell me what's wrong and I'll fix it."
+    m 2rksdld "Just tell me what I did wrong and I'll try even harder to be the perfect girlfriend for you."
+    m 2ekd "You're my entire world; how you feel means everything to me!"
+    m 2ekc "So please, just tell me what's wrong and I'll fix it."
     m 2dfc "I'll do anything for you because...I..."
     m 2dftdc "..."
     m 2dftsc "...I need you [player]..."
@@ -2559,11 +2559,11 @@ label greeting_tears:
     m 2dfc "...Okay...Okay..."
     m 2lssdrc "I have to be strong..."
     m "..."
-    m 2q "...Alright...I'm a bit better now..."
-    m 2h "But...I really do need you to think about what I said."
-    m 2f "Please...just...try to understand."
-    m 1r "I love you and I need you to show that you love me too..."
-    m 1q "Otherwise...I just won't be able to handle it anymore."
+    m 2dsc "...Alright...I'm a bit better now..."
+    m 2esc "But...I really do need you to think about what I said."
+    m 2ekc "Please...just...try to understand."
+    m 1dsd "I love you and I need you to show that you love me too..."
+    m 1dsc "Otherwise...I just won't be able to handle it anymore."
     $ mas_lockEVL("greeting_tears", "GRE")
     return
 

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -2522,7 +2522,8 @@ init 5 python:
         Event(
             persistent.greeting_database,
             eventlabel="greeting_tears",
-            unlocked=False,
+            unlocked=True,
+            aff_range=(mas_aff.DISTRESSED, mas_aff.DISTRESSED),
             rules=ev_rules,
         ),
         code="GRE"

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -333,6 +333,7 @@ label v0_9_6(version="v0_9_6"):
                 # erase this topic
                 mas_eraseTopic(old_ev_label, persistent.event_database)
 
+        # this doesn't need to be locked by default anymore with the new greet code
         if not seen_event("greeting_tears"):
             mas_unlockEVL("greeting_tears", "GRE")
     return

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -332,6 +332,9 @@ label v0_9_6(version="v0_9_6"):
 
                 # erase this topic
                 mas_eraseTopic(old_ev_label, persistent.event_database)
+
+        if not seen_event("greeting_tears"):
+            mas_unlockEVL("greeting_tears", "GRE")
     return
 
 # 0.9.5

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -336,6 +336,11 @@ label v0_9_6(version="v0_9_6"):
         # this doesn't need to be locked by default anymore with the new greet code
         if not renpy.seen_label("greeting_tears"):
             mas_unlockEVL("greeting_tears", "GRE")
+
+        # let's actually pool this finally
+        family_ev = mas_getEV("monika_family")
+        if family_ev is not None:
+            family_ev.pool = True
     return
 
 # 0.9.5

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -334,7 +334,7 @@ label v0_9_6(version="v0_9_6"):
                 mas_eraseTopic(old_ev_label, persistent.event_database)
 
         # this doesn't need to be locked by default anymore with the new greet code
-        if not seen_event("greeting_tears"):
+        if not renpy.seen_label("greeting_tears"):
             mas_unlockEVL("greeting_tears", "GRE")
     return
 


### PR DESCRIPTION
The code for `greeting_tears` was outdated and not taking advantage of our new `aff_range` property. We were locking it by default and then unlocking it in `script-affection` when reaching the desired affection. This fixes that and also makes it available starting at distressed instead of broken. Gives the player a chance to perhaps change their way before it's too late. Also updates the expressions of the greet as it still had some of the old expressions.

Also cleans up some redundant code related to good exp and affection at the request of @multimokia 

# Testing

- Run the update script (call v0_9_6) and verify that `greeting_tears` is now unlocked if not previously seen.

- Verify the greeting does not run at any affection level above distressed.

- Change affection to distressed or broken and verify the greeting runs.

- Verify the greeting is locked after it is seen.

- Also verify `monika_family` is now pooled after running the update script.

- On a different persistent, before running the update script, view `greeting_tears`.

- Run update script and verify that `greeting_tears` is locked.