### PR TITLE
Ribbon Selector Unlock

### DIFF
--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -341,7 +341,6 @@ label v0_9_6(version="v0_9_6"):
         family_ev = mas_getEV("monika_family")
         if family_ev is not None:
             family_ev.pool = True
-
     return
 
 # 0.9.5

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -342,9 +342,6 @@ label v0_9_6(version="v0_9_6"):
         if family_ev is not None:
             family_ev.pool = True
 
-        #Fix the ribbon select to be unlocked if we're in something which supports ribbons
-        if not monika_chr.is_wearing_clothes_with_exprop("baked outfit") and monika_chr.is_wearing_hair_with_exprop("ribbon"):
-            store.mas_filterUnlockGroup(store.mas_sprites_json.SP_ACS, "ribbon")
     return
 
 # 0.9.5

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -341,6 +341,10 @@ label v0_9_6(version="v0_9_6"):
         family_ev = mas_getEV("monika_family")
         if family_ev is not None:
             family_ev.pool = True
+
+        #Fix the ribbon select to be unlocked if we're in something which supports ribbons
+        if not monika_chr.is_wearing_clothes_with_exprop("baked outfit") and monika_chr.is_wearing_hair_with_exprop("ribbon"):
+            store.mas_filterUnlockGroup(store.mas_sprites_json.SP_ACS, "ribbon")
     return
 
 # 0.9.5

--- a/Monika After Story/game/zz_reactions.rpy
+++ b/Monika After Story/game/zz_reactions.rpy
@@ -1637,12 +1637,12 @@ label _mas_reaction_ribbon_helper(label):
     #if we already have that ribbon
     if store.mas_selspr.get_sel_acs(_mas_gifted_ribbon_acs).unlocked:
         call mas_reaction_old_ribbon
+
     else:
         # since we don't have it we can accept it
         call mas_reaction_new_ribbon
         $ persistent._mas_current_gifted_ribbons += 1
-        #unlock the ribbon selector
-        $ store.mas_unlockEVL("monika_ribbon_select", "EVE")
+
     # normal gift processing
     $ mas_receivedGift(label)
     $ gift_ev = mas_getEV(label)

--- a/Monika After Story/game/zz_selector.rpy
+++ b/Monika After Story/game/zz_selector.rpy
@@ -2912,7 +2912,6 @@ init 5 python:
             prompt=store.mas_selspr.get_prompt("ribbon", "change"),
             pool=True,
             unlocked=True,
-            aff_range=(mas_aff.HAPPY, None)
         )
     )
 

--- a/Monika After Story/game/zz_selector.rpy
+++ b/Monika After Story/game/zz_selector.rpy
@@ -473,7 +473,7 @@ init -10 python in mas_selspr:
     #   [0] - topic label
     #   [2] - number of items before unlocking
     GRP_TOPIC_MAP = {
-        "ribbon": ("monika_ribbon_select", 2),
+        "ribbon": ("monika_ribbon_select", 1),
         "left-hair-clip": ("monika_hairclip_select", 1),
     }
 
@@ -2911,8 +2911,8 @@ init 5 python:
             category=["appearance"],
             prompt=store.mas_selspr.get_prompt("ribbon", "change"),
             pool=True,
-            unlocked=False,
-            rules={"no unlock": None}
+            unlocked=True,
+            aff_range=(mas_aff.HAPPY, None)
         )
     )
 

--- a/Monika After Story/game/zz_selector.rpy
+++ b/Monika After Story/game/zz_selector.rpy
@@ -2911,7 +2911,8 @@ init 5 python:
             category=["appearance"],
             prompt=store.mas_selspr.get_prompt("ribbon", "change"),
             pool=True,
-            unlocked=True,
+            unlocked=False,
+            rules={"no unlock": None}
         )
     )
 

--- a/Monika After Story/game/zz_spriteobjects.rpy
+++ b/Monika After Story/game/zz_spriteobjects.rpy
@@ -574,7 +574,7 @@ init -1 python:
     ### PONYTAIL WITH RIBBON (default)
     ## def
     # Monika's default hairstyle, aka the ponytail
-    # thanks Ryuse/Iron707/Taross/Metisz/Tri/JMO
+    # thanks Ryuse/Iron707/Taross/Metisz/Tri/JMO/Orca
     mas_hair_def = MASHair(
         "def",
         "def",
@@ -604,7 +604,7 @@ init -1 python:
     ### DOWN
     ## down
     # Hair is down, not tied up
-    # thanks Ryuse/Finale/Iron707/Taross/Metisz/Tri/JMO
+    # thanks Ryuse/Finale/Iron707/Taross/Metisz/Tri/JMO/Orca
     mas_hair_down = MASHair(
         "down",
         "down",


### PR DESCRIPTION
Ribbon selector is now always unlocked since ribbonless/def ribbon are available by default.
Selector is available at happy+.

Added update script to unlock the selector if you're in a valid hair/outfit combi too, pls verify that it's not unlocked when it shouldn't be.

(Also added credits to Orca for the hair bits and bobs)