### PR TITLE
non inclusive mas_isInActiveWindow() checks

### DIFF
--- a/Monika After Story/game/dev/dev_in_active_window_check.rpy
+++ b/Monika After Story/game/dev/dev_in_active_window_check.rpy
@@ -31,6 +31,6 @@ label monika_inActiveWindowCheck:
     m 1eua "Okay, I'll pause for 3 seconds, switch to the window and then I'll tell you if those keywords were in there."
     pause 3.0
     $ ActiveWindow = mas_getActiveWindow(True)
-    $ inActiveWindow = mas_isInActiveWindow(atv_wnd_keys, non_inclusive)
+    $ inActiveWindow = mas_isInActiveWindow(active_window_keys, non_inclusive)
     m 1hua "Okay, your active window was: [ActiveWindow], and your keys returned [inActiveWindow]."
     return

--- a/Monika After Story/game/dev/dev_in_active_window_check.rpy
+++ b/Monika After Story/game/dev/dev_in_active_window_check.rpy
@@ -12,12 +12,25 @@ init 5 python:
 
 
 label monika_inActiveWindowCheck:
-    $ atv_wnd_keys = None
+    $ active_window_keys = None
     m 1hub "Okay, [player]!"
-    m 3eub "Put some keywords in atv_wnd_keys now."
-    m 1eua "Okay, I'll pause for 3 seconds, switch to the window and then I'll tell you if those were in there."
+
+    m 3eua "Do you want it to be inclusive?{nw}"
+    $ _history_list.pop()
+    menu:
+        m "Do you want it to be inclusive?{fast}"
+
+        "Yes.":
+            $ non_inclusive = False
+
+        "No.":
+            $ non_inclusive = True
+
+    m 1hub "Okay!"
+    m 3eub "Put some keywords in the 'active_window_keys' list now."
+    m 1eua "Okay, I'll pause for 3 seconds, switch to the window and then I'll tell you if those keywords were in there."
     pause 3.0
     $ ActiveWindow = mas_getActiveWindow(True)
-    $ inActiveWindow = mas_isInActiveWindow(atv_wnd_keys)
+    $ inActiveWindow = mas_isInActiveWindow(atv_wnd_keys, non_inclusive)
     m 1hua "Okay, your active window was: [ActiveWindow], and your keys returned [inActiveWindow]."
     return

--- a/Monika After Story/game/zz_windowreacts.rpy
+++ b/Monika After Story/game/zz_windowreacts.rpy
@@ -149,10 +149,10 @@ init python:
         #Otherwise, let's get the active window
         active_window = mas_getActiveWindow()
 
-        if not non_inclusive:
-            return len([s for s in keywords if s.lower() not in active_window]) == 0
-        else:
+        if non_inclusive:
             return len([s for s in keywords if s.lower() in active_window]) > 0
+        else:
+            return len([s for s in keywords if s.lower() not in active_window]) == 0
 
     def mas_clearNotifs():
         """

--- a/Monika After Story/game/zz_windowreacts.rpy
+++ b/Monika After Story/game/zz_windowreacts.rpy
@@ -129,15 +129,30 @@ init python:
         #TODO: Mac vers (if possible)
         return store.mas_windowreacts.can_show_notifs and mas_getActiveWindow(True) == config.name
 
-    def mas_isInActiveWindow(keywords):
+    def mas_isInActiveWindow(keywords, non_inclusive=False):
         """
         Checks if ALL keywords are in the active window name
 
         IN:
-            List of keywords
+            keywords:
+                List of keywords to check for
+
+            non_inclusive:
+                Whether or the not the list is checked non-inclusively
+                (Default: False)
         """
+
+        #Don't do work if we don't have to
+        if not store.mas_windowreacts.can_show_notifs:
+            return False
+
+        #Otherwise, let's get the active window
         active_window = mas_getActiveWindow()
-        return store.mas_windowreacts.can_show_notifs and len([s for s in keywords if s.lower() not in active_window]) == 0
+
+        if not non_inclusive:
+            return len([s for s in keywords if s.lower() not in active_window]) == 0
+        else:
+            return len([s for s in keywords if s.lower() in active_window]) > 0
 
     def mas_clearNotifs():
         """
@@ -158,7 +173,7 @@ init python:
 
         for ev_label, ev in mas_windowreacts.windowreact_db.iteritems():
             if (
-                    (mas_isInActiveWindow(ev.category) and ev.unlocked and ev.checkAffection(mas_curr_affection))
+                    (mas_isInActiveWindow(ev.category, "non inclusive" in ev.rules) and ev.unlocked and ev.checkAffection(mas_curr_affection))
                     and ((not store.mas_globals.in_idle_mode) or (store.mas_globals.in_idle_mode and ev.show_in_idle))
                     and ("notif-group" not in ev.rules or mas_notifsEnabledForGroup(ev.rules.get("notif-group")))
                 ):


### PR DESCRIPTION
`mas_isInActiveWindow()` now accepts a `non_inclusive` parameter. (rules for wrs can now have a `"non inclusive"` key as well to use this)

This adjusts the method to check if only one of the items in the list of keys is in the active window, and if so it returns `True`. This allows for some more in depth checking if we were to make a non-specific wrs and then specify within the label itself.