### PR TITLE
Unlock clothes selector on player bday

### DIFF
--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -2979,6 +2979,10 @@ label greeting_returned_home:
     $ time_out = store.mas_dockstat.diffCheckTimes()
 
     # event checks
+    if mas_isplayer_bday() and persistent._mas_player_bday_in_player_bday_mode and len(mas_selspr.filter_clothes(True)) > 1:
+        # make sure we do this since we skip the autoload check
+        $ clothes_sel_special_unlock()
+
     if mas_isMonikaBirthday():
         jump greeting_returned_home_bday
 

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -2981,7 +2981,7 @@ label greeting_returned_home:
     # event checks
     if mas_isplayer_bday() and persistent._mas_player_bday_in_player_bday_mode and len(mas_selspr.filter_clothes(True)) > 1:
         # make sure we do this since we skip the autoload check
-        $ clothes_sel_special_unlock()
+        $ mas_clothes_sel_special_unlock()
 
     if mas_isMonikaBirthday():
         jump greeting_returned_home_bday

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -3355,6 +3355,7 @@ init -11 python:
         unlocks the clothes selector for special occassions
         IN:
             affrange - the affection range we want to unlock the clothes selector for
+                default is Normal+
         """
         if affrange is None:
             affrange = (mas_aff.NORMAL, None)

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -3577,10 +3577,10 @@ label mas_player_bday_cake:
         # they can still use the selector for their bday
         $ mas_unlockEVL("monika_clothes_select", "EVE")
         $ mas_getEV("monika_clothes_select").aff_range = (mas_aff.NORMAL, None)
-    if mas_isMoniEnamored(lower=True) and mas_getEV("monika_clothes_select").unlocked:
-        # only give this dialogue at enam and lower since people at love already have this
-        m 4eub "Oh! Also, just ask and I'll wear any outfit you'd like today, [player]!"
-        m 4hua "I really want to make your day as special as possible~"
+        if mas_isMoniEnamored(lower=True):
+            # only give this dialogue at enam and lower since people at love already have this
+            m 4eub "Oh! Also, just ask and I'll wear any outfit you'd like today, [player]!"
+            m 4hua "I really want to make your day as special as possible~"
 
     m 6dkbsu "..."
     m 6ekbsu "I...{w=0.5}I also made a card for you, [player]. I hope you like it..."

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -3350,6 +3350,12 @@ init -11 python:
         else:
             return store.mas_utils.add_years(persistent._mas_player_bday,_date.year-persistent._mas_player_bday.year)
 
+    def clothes_sel_special_unlock(aff_range=None):
+        if aff_range is None:
+            aff_range = (mas_aff.NORMAL, None)
+        mas_unlockEVL("monika_clothes_select", "EVE")
+        mas_getEV("monika_clothes_select").aff_range = aff_range
+
 init -810 python:
     # MASHistorySaver for player_bday
     store.mas_history.addMHS(MASHistorySaver(
@@ -3383,10 +3389,10 @@ init -11 python in mas_player_bday_event:
 label mas_player_bday_autoload_check:
     # making sure we are already not in bday mode, have confirmed birthday, have normal+ affection and have not celebrated in any way
     if (
-            not persistent._mas_player_bday_in_player_bday_mode 
+            not persistent._mas_player_bday_in_player_bday_mode
             and persistent._mas_player_confirmed_bday 
             and mas_isMoniNormal(higher=True) 
-            and not persistent._mas_player_bday_spent_time 
+            and not persistent._mas_player_bday_spent_time
             and not mas_isD25() 
             and not mas_isO31()
             and not mas_isF14()
@@ -3403,11 +3409,12 @@ label mas_player_bday_autoload_check:
         $ persistent._mas_player_bday_decor = False
         $ persistent._mas_player_bday_in_player_bday_mode = False
         $ mas_lockEVL("bye_player_bday", "BYE")
+        if mas_isMoniEnamored(lower=True):
+            $ monika_chr.reset_clothes(False)
 
     elif persistent._mas_player_bday_in_player_bday_mode and len(mas_selspr.filter_clothes(True)) > 1:
         # keep the clothes selector unlocked while it's player bday/unlock if we've added an outfit since the party
-        $ mas_unlockEVL("monika_clothes_select", "EVE")
-        $ mas_getEV("monika_clothes_select").aff_range = (mas_aff.NORMAL, None)
+        $ clothes_sel_special_unlock()
 
     if mas_isO31():
         return
@@ -3575,8 +3582,7 @@ label mas_player_bday_cake:
     if len(mas_selspr.filter_clothes(True)) > 1:
         # we do this even at love just in case the player drops below today
         # they can still use the selector for their bday
-        $ mas_unlockEVL("monika_clothes_select", "EVE")
-        $ mas_getEV("monika_clothes_select").aff_range = (mas_aff.NORMAL, None)
+        $ clothes_sel_special_unlock()
         if mas_isMoniEnamored(lower=True):
             # only give this dialogue at enam and lower since people at love already have this
             m 4eub "Oh! Also, just ask and I'll wear any outfit you'd like today, [player]!"
@@ -3854,10 +3860,10 @@ label return_home_post_player_bday:
         $ persistent._mas_player_bday_decor = False
         m 3rksdla "Oh...it's not your birthday anymore..."
         m 3hksdlb "We should probably take these decorations down now, ahaha!"
-        m 3eka "Just give me one second..."
-        show monika 1dsc
-        pause 2.0
+        m 3dka "Just give me one second.{w=0.5}.{w=0.5}.{nw}"
         $ store.mas_player_bday_event.hide_player_bday_Visuals()
+        if mas_isMoniEnamored(lower=True):
+            $ monika_chr.reset_clothes(False)
         m 3eua "There we go!"
         if not persistent._mas_f14_gone_over_f14:
             m 1hua "Now, let's enjoy the day together, [player]~"

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -3404,6 +3404,11 @@ label mas_player_bday_autoload_check:
         $ persistent._mas_player_bday_in_player_bday_mode = False
         $ mas_lockEVL("bye_player_bday", "BYE")
 
+    elif persistent._mas_player_bday_in_player_bday_mode and len(mas_selspr.filter_clothes(True)) > 1:
+        # keep the clothes selector unlocked while it's player bday/unlock if we've added an outfit since the party
+        $ mas_unlockEVL("monika_clothes_select", "EVE")
+        $ mas_getEV("monika_clothes_select").aff_range = (mas_aff.NORMAL, None)
+
     if mas_isO31():
         return
     else:
@@ -3565,8 +3570,20 @@ label mas_player_bday_cake:
     call monika_zoom_transition(mas_temp_zoom_level,1.0)
 
     pause 0.5
+
+    # unlock the clothes selector
+    if len(mas_selspr.filter_clothes(True)) > 1:
+        # we do this even at love just in case the player drops below today
+        # they can still use the selector for their bday
+        $ mas_unlockEVL("monika_clothes_select", "EVE")
+        $ mas_getEV("monika_clothes_select").aff_range = (mas_aff.NORMAL, None)
+    if mas_isMoniEnamored(lower=True) and mas_getEV("monika_clothes_select").unlocked:
+        # only give this dialogue at enam and lower since people at love already have this
+        m 4eub "Oh! Also, just ask and I'll wear any outfit you'd like today, [player]!"
+        m 4hua "I really want to make your day as special as possible~"
+
     m 6dkbsu "..."
-    m 6ekbsu "I...I also made a card for you, [player]. I hope you like it..."
+    m 6ekbsu "I...{w=0.5}I also made a card for you, [player]. I hope you like it..."
     $ p_bday_month = mas_player_bday_curr().month
     call showpoem(poem_pbday, music=False,paper="mod_assets/poem_assets/poem_pbday_[p_bday_month].png")
     if mas_isMoniEnamored(higher=True):

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -3350,11 +3350,16 @@ init -11 python:
         else:
             return store.mas_utils.add_years(persistent._mas_player_bday,_date.year-persistent._mas_player_bday.year)
 
-    def clothes_sel_special_unlock(aff_range=None):
-        if aff_range is None:
-            aff_range = (mas_aff.NORMAL, None)
+    def mas_clothes_sel_special_unlock(affrange=None):
+        """
+        unlocks the clothes selector for special occassions
+        IN:
+            affrange - the affection range we want to unlock the clothes selector for
+        """
+        if affrange is None:
+            affrange = (mas_aff.NORMAL, None)
         mas_unlockEVL("monika_clothes_select", "EVE")
-        mas_getEV("monika_clothes_select").aff_range = aff_range
+        mas_getEV("monika_clothes_select").aff_range = affrange
 
 init -810 python:
     # MASHistorySaver for player_bday
@@ -3414,7 +3419,7 @@ label mas_player_bday_autoload_check:
 
     elif persistent._mas_player_bday_in_player_bday_mode and len(mas_selspr.filter_clothes(True)) > 1:
         # keep the clothes selector unlocked while it's player bday/unlock if we've added an outfit since the party
-        $ clothes_sel_special_unlock()
+        $ mas_clothes_sel_special_unlock()
 
     if mas_isO31():
         return
@@ -3582,7 +3587,7 @@ label mas_player_bday_cake:
     if len(mas_selspr.filter_clothes(True)) > 1:
         # we do this even at love just in case the player drops below today
         # they can still use the selector for their bday
-        $ clothes_sel_special_unlock()
+        $ mas_clothes_sel_special_unlock()
         if mas_isMoniEnamored(lower=True):
             # only give this dialogue at enam and lower since people at love already have this
             m 4eub "Oh! Also, just ask and I'll wear any outfit you'd like today, [player]!"

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -507,6 +507,8 @@ label calendar_birthdate:
     m 1eud "So [player], when were you born?"
     call mas_bday_player_bday_select_select
     $ mas_stripEVL('mas_birthdate',True)
+    $ mas_HKBDropShield()
+    $ mas_calDropOverlayShield()
     return
 
 ## Game unlock events

--- a/Monika After Story/game/zz_calendar.rpy
+++ b/Monika After Story/game/zz_calendar.rpy
@@ -1997,7 +1997,7 @@ label _first_time_calendar_use:
 
     # push calendar birthdate for users without any birthdate
     elif persistent._mas_player_bday is None:
-        $ pushEvent("calendar_birthdate")
+        $ pushEvent("calendar_birthdate",True)
 
     else:
         $ mas_HKBDropShield()

--- a/Monika After Story/game/zz_reactions.rpy
+++ b/Monika After Story/game/zz_reactions.rpy
@@ -620,6 +620,10 @@ init python:
             unlock_label=unlock_sel
         )
 
+        # make sure we use our special unlock if the gift is given on player bday
+        if persistent._mas_player_bday_in_player_bday_mode and mas_isplayer_bday() and sp_type == 2 and unlock_sel:
+            mas_clothes_sel_special_unlock()
+
         # save persistent
         renpy.save_persistent()
 

--- a/Monika After Story/game/zz_reactions.rpy
+++ b/Monika After Story/game/zz_reactions.rpy
@@ -614,15 +614,22 @@ init python:
                 giftname
             )
 
-        # unlock the selectable for this sprite object
-        store.mas_selspr.json_sprite_unlock(
-            store.mas_sprites.get_sprite(sp_type, sp_name),
-            unlock_label=unlock_sel
-        )
+        # unlock appropriate for selectors depending on sprite type
+        if sp_type == store.mas_sprites.SP_ACS:
+            # unlock the selectable for this sprite object
+            store.mas_selspr.json_sprite_unlock(
+                store.mas_sprites.get_sprite(sp_type, sp_name),
+                unlock_label=unlock_sel
+            )
 
-        # make sure we use our special unlock if the gift is given on player bday
-        if persistent._mas_player_bday_in_player_bday_mode and mas_isplayer_bday() and sp_type == 2 and unlock_sel:
-            mas_clothes_sel_special_unlock()
+        elif sp_type == store.mas_sprites.SP_CLOTHES:
+            # make sure we use our special unlock if the gift is given on player bday
+            if (
+                    persistent._mas_player_bday_in_player_bday_mode
+                    and mas_isplayer_bday()
+                    and unlock_sel
+            ):
+                mas_clothes_sel_special_unlock()
 
         # save persistent
         renpy.save_persistent()


### PR DESCRIPTION
This unlocks the clothes selector for people who get the birthday party on their birthday.

## Testing

- best way to test this is on a fresh persistent, set your birthday to tomorrow for minimal time travel, then unlock an outfit.

- at affection above normal but below love, with least one clothing set unlocked, trigger the birthday party and verify you get the dialogue referring to unlocking the clothes selector for the day

- verify the clothes selector is unlocked after the party and on all subsequent loads for the day

- verify the next day it is no longer available if under `love`

- verify if you start the party at `love` you do not get the dialogue

- verify if no clothing sets are unlocked you do not get the dialogue and the selector is not unlocked

- verify nothing else regarding player_bday was affected by this