### PR TITLE
music shield fix

### DIFF
--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -507,6 +507,8 @@ label calendar_birthdate:
     m 1eud "So [player], when were you born?"
     call mas_bday_player_bday_select_select
     $ mas_stripEVL('mas_birthdate',True)
+    $ mas_HKBDropShield()
+    $ mas_calDropOverlayShield()
     return
 
 ## Game unlock events

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -499,6 +499,7 @@ init 5 python:
     )
 
 label calendar_birthdate:
+    $ mas_MUMUDropShield()
     m 1lksdla "Hey [player]..."
     m 3eksdla "You may have noticed that my calendar was pretty empty..."
     m 1rksdla "Well...{w=0.5}there's one thing that should definitely be on it..."
@@ -507,8 +508,6 @@ label calendar_birthdate:
     m 1eud "So [player], when were you born?"
     call mas_bday_player_bday_select_select
     $ mas_stripEVL('mas_birthdate',True)
-    $ mas_HKBDropShield()
-    $ mas_calDropOverlayShield()
     return
 
 ## Game unlock events

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -499,7 +499,6 @@ init 5 python:
     )
 
 label calendar_birthdate:
-    $ mas_MUMUDropShield()
     m 1lksdla "Hey [player]..."
     m 3eksdla "You may have noticed that my calendar was pretty empty..."
     m 1rksdla "Well...{w=0.5}there's one thing that should definitely be on it..."

--- a/Monika After Story/game/zz_calendar.rpy
+++ b/Monika After Story/game/zz_calendar.rpy
@@ -1997,7 +1997,7 @@ label _first_time_calendar_use:
 
     # push calendar birthdate for users without any birthdate
     elif persistent._mas_player_bday is None:
-        $ pushEvent("calendar_birthdate")
+        $ pushEvent("calendar_birthdate",True)
 
     else:
         $ mas_HKBDropShield()

--- a/Monika After Story/game/zz_calendar.rpy
+++ b/Monika After Story/game/zz_calendar.rpy
@@ -1998,6 +1998,7 @@ label _first_time_calendar_use:
     # push calendar birthdate for users without any birthdate
     elif persistent._mas_player_bday is None:
         $ pushEvent("calendar_birthdate",True)
+        $ mas_MUMUDropShield()
 
     else:
         $ mas_HKBDropShield()


### PR DESCRIPTION
When viewing the calendar for the first time with `persistent._mas_player_bday` set to None, we push `calendar_birthdate` and never get to the shield drops. The main consequence of this is the music shield never dropped, so the music menu wasn't selectable.  This adds those shield drops to `calendar_birthdate` and also fixes an issue where another event could potentially jump in before `calendar_birthdate` ran.

For testing, using a fresh persistent, click the calendar right after the intro, ensure that `calendar_birthdate` runs immediately after the first time calendar event and that after `calendar_birthdate` is finished, the music menu is accessible.