### PR TITLE
Fixed multiple crash greetings on startup crashes

### DIFF
--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -1740,6 +1740,13 @@ init python:
 
         return False
 
+    def mas_cleanEventList():
+        """
+        Iterates through the event list and removes items which shouldn't be restarted
+        """
+        for index in range(len(persistent.event_list)-1,-1,-1):
+            if mas_isRstBlk(persistent.event_list[index][0]):
+                mas_rmEVL(persistent.event_list[index][0])
 
     def mas_cleanJustSeen(eventlist, db):
         """

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1193,13 +1193,15 @@ label mas_ch30_post_holiday_check:
                 # only crashed greeting.
                 # NOTE: we shouldnt actually have to do this ever, but
                 #   its here as a sanity check
-                sel_greeting_ev = mas_getEV("mas_crashed_start")
+                if not mas_inEVL("mas_crashed_start"):
+                    sel_greeting_ev = mas_getEV("mas_crashed_start")
 
             elif forced_quit:
                 # if we just forced quit, then we want to select the only
                 # reload greeting.
                 # NOTE: again, shouldnt have to do this, but its sanity checks
-                sel_greeting_ev = mas_getEV("ch30_reload_delegate")
+                if not mas_inEVL("ch30_reload_delegate"):
+                    sel_greeting_ev = mas_getEV("ch30_reload_delegate")
 
 
         # NOTE: this MUST be an if. it may be True if we crashed but

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1066,6 +1066,7 @@ label ch30_autoload:
     $ quick_menu = True
     $ startup_check = True #Flag for checking events at game startup
     $ mas_skip_visuals = False
+    $ mas_cleanEventList()
 
     # set the gender
     call set_gender from _autoload_gender
@@ -1193,15 +1194,13 @@ label mas_ch30_post_holiday_check:
                 # only crashed greeting.
                 # NOTE: we shouldnt actually have to do this ever, but
                 #   its here as a sanity check
-                if not mas_inEVL("mas_crashed_start"):
-                    sel_greeting_ev = mas_getEV("mas_crashed_start")
+                sel_greeting_ev = mas_getEV("mas_crashed_start")
 
             elif forced_quit:
                 # if we just forced quit, then we want to select the only
                 # reload greeting.
                 # NOTE: again, shouldnt have to do this, but its sanity checks
-                if not mas_inEVL("ch30_reload_delegate"):
-                    sel_greeting_ev = mas_getEV("ch30_reload_delegate")
+                sel_greeting_ev = mas_getEV("ch30_reload_delegate")
 
 
         # NOTE: this MUST be an if. it may be True if we crashed but


### PR DESCRIPTION
If you crashed after init, it was possible that crash greets would keep queuing and queuing, effectively having them repeat. This should make sure we only get one crashed greet, and one force close (just in case)

## Testing:
I find the easiest way to verify this is to head into `mod_assets/monika/` and then rename the `c` folder. Please first verify that on a normal install without this code in it the crashed start greet stacks by opening the game, getting the traceback, then exiting. (Repeat a couple times)

Once done, please then verify with this code that you only get a single crashed start greeting by once again launching, getting traceback, quitting, and then doing that again a couple times.