### PR TITLE
Notif crash handling

### DIFF
--- a/Monika After Story/game/python-packages/balloontip.py
+++ b/Monika After Story/game/python-packages/balloontip.py
@@ -48,8 +48,10 @@ class WindowsBalloonTip:
 
             #If we got here, that means we had no issue making the notif
             return True
-        #Something went wrong, need to flag this to not make a sound
-        return False
+
+        except:
+            #Something went wrong, need to flag this to not make a sound
+            return False
 
     def OnDestroy(self, hwnd, msg, wparam, lparam):
         nid = (self.hwnd, 0)

--- a/Monika After Story/game/python-packages/balloontip.py
+++ b/Monika After Story/game/python-packages/balloontip.py
@@ -1,5 +1,5 @@
 # -- coding: utf-8 --
- 
+
 from win32api import *
 from win32gui import *
 import win32con
@@ -39,10 +39,17 @@ class WindowsBalloonTip:
         #Initialize the notif itself
         flags = NIF_ICON | NIF_MESSAGE | NIF_TIP
         nid = (self.hwnd, 0, flags, win32con.WM_USER+20, hicon, "Monika After Story")
-        Shell_NotifyIcon(NIM_ADD, nid)
-        Shell_NotifyIcon(NIM_MODIFY, \
-                         (self.hwnd, 0, NIF_INFO, win32con.WM_USER+20,\
-                          hicon, "Balloon  tooltip",msg,200,title))
+
+        try:
+            Shell_NotifyIcon(NIM_ADD, nid)
+            Shell_NotifyIcon(NIM_MODIFY, \
+                            (self.hwnd, 0, NIF_INFO, win32con.WM_USER+20,\
+                            hicon, "Balloon  tooltip",msg,200,title))
+
+            #If we got here, that means we had no issue making the notif
+            return True
+        #Something went wrong, need to flag this to not make a sound
+        return False
 
     def OnDestroy(self, hwnd, msg, wparam, lparam):
         nid = (self.hwnd, 0)

--- a/Monika After Story/game/zz_windowreacts.rpy
+++ b/Monika After Story/game/zz_windowreacts.rpy
@@ -322,7 +322,7 @@ init python:
             #Play the notif sound if we have that enabled and notif was successful
             if persistent._mas_notification_sounds and notif_success:
                 renpy.sound.play("mod_assets/sounds/effects/notif.wav")
-            return True
+                return True
         return False
 
 

--- a/Monika After Story/game/zz_windowreacts.rpy
+++ b/Monika After Story/game/zz_windowreacts.rpy
@@ -322,6 +322,9 @@ init python:
             #Play the notif sound if we have that enabled and notif was successful
             if persistent._mas_notification_sounds and notif_success:
                 renpy.sound.play("mod_assets/sounds/effects/notif.wav")
+
+            #Now we return true if notif was successful, false otherwise
+            if notif_success:
                 return True
         return False
 

--- a/Monika After Story/game/zz_windowreacts.rpy
+++ b/Monika After Story/game/zz_windowreacts.rpy
@@ -300,14 +300,13 @@ init python:
                 or skip_checks
             ):
 
-            #Play the notif sound if we have that enabled
-            if persistent._mas_notification_sounds:
-                renpy.sound.play("mod_assets/sounds/effects/notif.wav")
+            #We keep this flag so we know whether or not the notif was sent successfully (NOTE: weassume True because only windows can 'fail')
+            notif_success = True
 
             #Now we make the notif
             if (renpy.windows):
-                # The Windows way
-                tip.showWindow(renpy.substitute(title), renpy.substitute(renpy.random.choice(body)))
+                # The Windows way, notif_success is adjusted if need be
+                notif_success = tip.showWindow(renpy.substitute(title), renpy.substitute(renpy.random.choice(body)))
 
                 #We need the IDs of the notifs to delete them from the tray
                 destroy_list.append(tip.hwnd)
@@ -320,6 +319,9 @@ init python:
                 # The Linux way
                 mas_tryShowNotificationLinux(renpy.substitute(title), renpy.substitute(renpy.random.choice(body)))
 
+            #Play the notif sound if we have that enabled and notif was successful
+            if persistent._mas_notification_sounds and notif_success:
+                renpy.sound.play("mod_assets/sounds/effects/notif.wav")
             return True
         return False
 
@@ -543,7 +545,7 @@ label mas_wrs_twitter:
     if not wrs_success:
         $ mas_unlockFailedWRS('mas_wrs_twitter')
     return
-  
+
 init 5 python:
     addEvent(
         Event(

--- a/Monika After Story/game/zz_windowreacts.rpy
+++ b/Monika After Story/game/zz_windowreacts.rpy
@@ -324,7 +324,7 @@ init python:
                 renpy.sound.play("mod_assets/sounds/effects/notif.wav")
 
             #Now we return true if notif was successful, false otherwise
-            return notif_success:
+            return notif_success
         return False
 
 

--- a/Monika After Story/game/zz_windowreacts.rpy
+++ b/Monika After Story/game/zz_windowreacts.rpy
@@ -324,8 +324,7 @@ init python:
                 renpy.sound.play("mod_assets/sounds/effects/notif.wav")
 
             #Now we return true if notif was successful, false otherwise
-            if notif_success:
-                return True
+            return notif_success:
         return False
 
 


### PR DESCRIPTION
Been seeing cases where users have been having crashes as a result of this area for notifs on windows. Added a try/except block to handle this, along with the notification success return.

In terms of testing... Not entirely sure. This is a case I don't know how to replicate.

I guess just put some bad code in the try block and make sure that no sound happens/wrs remain unlocked since they should fail as a result. Also make sure notifs still work properly otherwise.