### PR TITLE
Blazer intro

### DIFF
--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -500,6 +500,10 @@ init 15 python in mas_affection:
         # always rebuild randos
         store.mas_idle_mailbox.send_rebuild_msg()
 
+        # queue the blazerless intro event
+        if not store.seen_event("mas_blazerless_intro"):
+            store.queueEvent("mas_blazerless_intro")
+
         # unlock blazerless for use
         store.mas_selspr.unlock_clothes(store.mas_clothes_blazerless)
 

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -2502,20 +2502,19 @@ init 5 python:
     )
 
 label mas_change_to_def:
-    # sanity check for an extremely rare case where player dropped below happy
+    # acts as a sanity check for an extremely rare case where player dropped below happy
     # closed game before this was pushed and then deleted json before next load
-    if monika_chr.clothes == mas_clothes_def:
-        return "no_unlock"
+    if monika_chr.clothes != mas_clothes_def:
+        m 1eka "Hey [player], I miss my old school uniform..."
+        m 3eka "I'm just going to go change, be right back..."
+        
+        call mas_clothes_change()
 
-    m 1eka "Hey [player], I miss my old school uniform..."
-    m 3eka "I'm just going to go change, be right back..."
-    
-    call mas_clothes_change()
+        m "Okay, what else should we do today?"
 
-    m "Okay, what else should we do today?"
+        # remove from event list in case PP and ch30 both push
+        $ mas_rmallEVL("mas_change_to_def")
 
-    # remove from event list in case PP and ch30 both push
-    $ mas_rmallEVL("mas_change_to_def")
     return "no_unlock"
 
 # Changes clothes to the given outfit.
@@ -2546,3 +2545,24 @@ label mas_clothes_change(outfit=None):
     pause 0.5
     call monika_zoom_transition (curr_zoom, 1.0)
     return
+
+init 5 python:
+    addEvent(
+        Event(
+            persistent.event_database,
+            eventlabel="mas_blazerless_intro",
+            unlocked=False
+        )
+    )
+
+label mas_blazerless_intro:
+    # only want to do this if we are wearing def
+    # people not wearing def don't need to see this, so acts as a sanity check
+    if monika_chr.clothes == mas_clothes_def:
+        m 3esa "Give me a second [player], I'm just going to make myself a little more comfortable..."
+
+        call mas_clothes_change(mas_clothes_blazerless)
+
+        m 1eua "Ah, much better!"
+
+    return "no_unlock"

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -2563,6 +2563,8 @@ label mas_blazerless_intro:
 
         call mas_clothes_change(mas_clothes_blazerless)
 
-        m 1eua "Ah, much better!"
+        m 1hua "Ah, much better!"
+        # this line acts as a hint that there is a clothes selector
+        m 3eka "But if you miss my blazer, just ask and I'll put it back on."
 
     return "no_unlock"


### PR DESCRIPTION
Just a little intro event for people who may not be aware that blazerless is now a thing and that there is a clothes selector available at happy+

## Testing

-  on a fresh persist, increase affection past Happy and, while wearing def, verify that the topic runs.  

- on a persist with other outfits available, make sure you are wearing a non-def outfit before loading this branch, then load this branch, verify the event does not run and that `seen_event("mas_blazerless_intro")` is True.