### PR TITLE
Fix selector issues

### DIFF
--- a/Monika After Story/game/zz_spriteobjects.rpy
+++ b/Monika After Story/game/zz_spriteobjects.rpy
@@ -338,7 +338,7 @@ init -2 python in mas_sprites:
         if _moni_chr.is_wearing_hair_with_exprop("ribbon"):
             store.mas_filterUnlockGroup(SP_ACS, "ribbon")
         else:
-            store.mas_lockEVL("mas_ribbon_select", "EVE")
+            store.mas_lockEVL("monika_ribbon_select", "EVE")
 
 
     def _clothes_marisa_entry(_moni_chr, **kwargs):
@@ -438,7 +438,7 @@ init -2 python in mas_sprites:
         if _moni_chr.is_wearing_hair_with_exprop("ribbon"):
             store.mas_filterUnlockGroup(SP_ACS, "ribbon")
         else:
-            store.mas_lockEVL("monika_hair_select", "EVE")
+            store.mas_lockEVL("monika_ribbon_select", "EVE")
 
 
     def _clothes_santa_entry(_moni_chr, **kwargs):


### PR DESCRIPTION
#4617 (basing to content as its related to sprites objects)

There were some wrong labels being locked. This issue only affects people with baked outfits.
* neko outfit wouldnt lock anything
* witch outfit would lock the hair selector

Wearing/removing a baked outfit after this fix is enough to fix the issue on user builds, so update script is not necessary.

# Testing
1. Have monika wear a non-baked outfit and ponytail
2. Change hair to hair down, confirm.
3. Change outfit to a baked outfit, confirm.
4. Change outfit to a non-baked outfit, confirm/
5. Verify that hair selector is unlocked, ribbon selector locked.