### PR TITLE
Fix title bugs when Dark UI is enabled

### DIFF
--- a/Monika After Story/game/splash.rpy
+++ b/Monika After Story/game/splash.rpy
@@ -246,6 +246,12 @@ label splashscreen:
     pause 2.0
     hide splash_warning with Dissolve(0.5, alpha=True)
     $ config.allow_skipping = False
+
+    python:
+        if persistent._mas_auto_mode_enabled:
+            mas_darkMode(morning_flag)
+        else:
+            mas_darkMode(not persistent._mas_dark_mode_enabled)
     return
 
 label warningscreen:
@@ -359,4 +365,3 @@ label quit:
             store.mas_utils.trydel(mas_docking_station._trackPackage("monika"))
 
     return
-

--- a/Monika After Story/game/styles.rpy
+++ b/Monika After Story/game/styles.rpy
@@ -454,7 +454,7 @@ style main_menu_frame_dark:
     xsize 310
     yfill True
 
-    background "menu_nav_d"
+    background "menu_nav"
 
 style slider_def:
     ysize 18


### PR DESCRIPTION
### Fix title screen error when Dark UI is enabled

before:
![screenshot0001](https://user-images.githubusercontent.com/20186429/64904602-50b08780-d707-11e9-8099-43d32a4abd39.png)

after:
![screenshot0002](https://user-images.githubusercontent.com/20186429/64904610-632ac100-d707-11e9-9b06-449b6b7b0bf8.png)


### Fix Dark UI not enabled for title on restart

Steps to Reproduce:

1. delete MAS savedata.
2. launch MAS and enable Dark UI on setting.
3. relaunch MAS.
