### PR TITLE
Prevent Old versions from triggering updates

### DIFF
--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -527,9 +527,15 @@ init -1 python:
                 thread_result.append(MASUpdaterDisplayable.STATE_BAD_JSON)
                 return
 
+            # parse version
+            parsed_version = "v" + latest_version.replace(".", "_")
+
             # okay we have a latest version, compare to the current version
-            if latest_version == config.version:
-                # same version
+            if (
+                    latest_version == config.version
+                    or parsed_version in store.updates.version_updates
+            ):
+                # same version (or version on server is older)
                 thread_result.append(MASUpdaterDisplayable.STATE_UPDATED)
 
             else:

--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -527,14 +527,30 @@ init -1 python:
                 thread_result.append(MASUpdaterDisplayable.STATE_BAD_JSON)
                 return
 
-            # parse version
-            parsed_version = "v" + latest_version.replace(".", "_")
+            # old version check
+            if persistent._mas_unstable_mode:
+                # rpartion the ., the last item should be build number
+                lv_build_number = store.mas_utils.tryparseint(
+                    latest_version.rpartition(".")[2],
+                    default=None
+                )
+                build_number = store.mas_utils.tryparseint(
+                    config.version.rpartition(".")[2],
+                    default=None
+                )
+                if lv_build_number is None or build_number is None:
+                    thread_result.append(MASUpdaterDisplayable.STATE_BAD_JSON)
+                    return
+
+                lv_is_old = lv_build_number <= build_number
+
+            else:
+                # just replcae dots with underscores, prefix v
+                parsed_version = "v" + latest_version.replace(".", "_") 
+                lv_is_old = parsed_version in store.updates.version_updates
 
             # okay we have a latest version, compare to the current version
-            if (
-                    latest_version == config.version
-                    or parsed_version in store.updates.version_updates
-            ):
+            if latest_version == config.version or lv_is_old:
                 # same version (or version on server is older)
                 thread_result.append(MASUpdaterDisplayable.STATE_UPDATED)
 

--- a/Monika After Story/game/updates_topics.rpy
+++ b/Monika After Story/game/updates_topics.rpy
@@ -45,18 +45,15 @@ init -1 python:
 
         updates.topics.clear()
         updates.topics = None
-        updates.version_updates.clear()
-        updates.version_updates = None
+        #updates.version_updates.clear()
+        #updates.version_updates = None
         # TODO
         # is there a way to delete a renpy storemodule?
 
 
 # runs before updates.rpy
 init 9 python:
-
-    if persistent.version_number != config.version:
-        renpy.call_in_new_context("vv_updates_topics")
-
+    renpy.call_in_new_context("vv_updates_topics")
 
 # init label for updats_topics
 label vv_updates_topics:


### PR DESCRIPTION
#4705 

This adds updater checking so if old versions exist on teh server, they wont trigger an update. Should prevent the possibility of users updating to an older version if the cloudfront cache in their region isn't updated with the newest jsons and they've already updated to the newer version manually.

# Testing

## Regular versions:
1. Open `options.rpy` and change the `config.version` to be something in the future (like `0.11.1`)
2. Open `updater_topics.rpy` and add a line to `version_updates` like: `updates.version_updates[vv0_10_1] = "v0_10_2"`
3. Launch the game.
4. Verify that the "Update found..." box doesn't appear in the top right
5. Open settings and click "check Update"
6. Verify that No update is found

## Unstable versions
1. **before testing this PR/adding changes from this PR**, ensure you have a working unstable build (aka **unstable is checked in settings and version in top right is unstable**
2. add changes from this PR to the unstable build. 
3. Open `options.rpy` and change the `config.version` to be a future build (like `0.10.1-unstable.2019.09.07.200`) (what matters is the "build number" at the end of the version string, which must be a number larger than the current unstable build)
4. Launch the game.
5. Verify that the "Update found..." box doesn't appear in the top right
6. Open settings and click "check Update"
7. Verify that No update is found