### PR TITLE
Disable updater if rpy files in gamedir

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -4357,7 +4357,19 @@ init 2 python:
         if persistent.monika_reload < 4:
             persistent.monika_reload += 1
 
+    def mas_hasRPYFiles():
+        """
+        Checks if there are rpy files in the gamedir
+        """
+        return len(mas_getRPYFiles()) > 0
 
+    def mas_getRPYFiles():
+        """
+        Gets a list of rpy files in the gamedir
+        """
+        rpyCheckStation = store.MASDockingStation(renpy.config.gamedir)
+
+        return rpyCheckStation.getPackageList(".rpy")
 
 # Music
 define audio.t1 = "<loop 22.073>bgm/1.ogg"  #Main theme (title)

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1697,22 +1697,16 @@ label ch30_reset:
             # I think we'll deal with this better once we hve a sleeping sprite
             random_seen_limit = 1000
 
-    if not persistent._mas_pm_has_rpy:
-        # setup the docking station to handle the detection
-        $ rpyCheckStation = store.MASDockingStation(renpy.config.gamedir)
+        if not persistent._mas_pm_has_rpy:
+            if not mas_hasRPYFiles() or persistent.current_monikatopic == "monika_rpy_files":
+                if not mas_hasRPYFiles() and persistent.current_monikatopic == "monika_rpy_files":
+                    persistent.current_monikatopic = 0
 
-        $ listRpy = rpyCheckStation.getPackageList(".rpy")
+                mas_rmallEVL("monika_rpy_files")
 
-        if len(listRpy) == 0 or persistent.current_monikatopic == "monika_rpy_files":
-            if len(listRpy) == 0 and persistent.current_monikatopic == "monika_rpy_files":
-                $ persistent.current_monikatopic = 0
+            elif mas_hasRPYFiles() and not mas_inEVL("monika_rpy_files"):
+                queueEvent("monika_rpy_files")
 
-            $ mas_rmallEVL("monika_rpy_files")
-
-        elif len(listRpy) != 0 and not mas_inEVL("monika_rpy_files"):
-            $ queueEvent("monika_rpy_files")
-
-        $ del rpyCheckStation
 
     python:
         import datetime

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1698,15 +1698,14 @@ label ch30_reset:
             random_seen_limit = 1000
 
         if not persistent._mas_pm_has_rpy:
-            if not mas_hasRPYFiles() or persistent.current_monikatopic == "monika_rpy_files":
-                if not mas_hasRPYFiles() and persistent.current_monikatopic == "monika_rpy_files":
+            if mas_hasRPYFiles():
+                if not mas_inEVL("monika_rpy_files"):
+                    queueEvent("monika_rpy_files")
+
+            else:
+                if persistent.current_monikatopic == "monika_rpy_files":
                     persistent.current_monikatopic = 0
-
                 mas_rmallEVL("monika_rpy_files")
-
-            elif mas_hasRPYFiles() and not mas_inEVL("monika_rpy_files"):
-                queueEvent("monika_rpy_files")
-
 
     python:
         import datetime

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -1643,25 +1643,11 @@ label monika_rpy_files:
 
                 "Yes, please.":
                     m "Sure thing, [player]."
-                    python:
-                        store.mas_ptod.rst_cn()
-                        local_ctx = {
-                            "basedir": renpy.config.basedir
-                        }
 
-                    show monika at t22
-                    show screen mas_py_console_teaching
-
-                    call mas_wx_cmd_noxwait("import os", local_ctx)
-                    
-                    python:
-                        for rpy_filename in listRpy:
-                            path = '/game/'+rpy_filename
-                            store.mas_ptod.wx_cmd("os.remove(os.path.normcase(basedir+'"+path+"'))", local_ctx)
-                            renpy.pause(0.3)
+                    call mas_rpy_file_delete
 
                     m 2hua "There we go!"
-                    m 2esa "Be sure next time to install a version without the source code. You can get it from here: {a=http://www.monikaafterstory.com/releases.html}{i}{u}http://www.monikaafterstory.com/releases.html{/u}{/i}{/a}"
+                    m 2esa "Be sure next time to install a version without the source code. You can get it from {a=http://www.monikaafterstory.com/releases.html}{i}{u}the releases page{/u}{/i}{/a}."
                     $ listRpy = None
                     $ persistent._mas_pm_has_rpy = False
                     hide screen mas_py_console_teaching
@@ -1672,6 +1658,27 @@ label monika_rpy_files:
                     m 2eka "Please be careful."
                     $ persistent._mas_pm_has_rpy = True
     return
+
+label mas_rpy_file_delete:
+    python:
+        store.mas_ptod.rst_cn()
+        local_ctx = {
+            "basedir": renpy.config.basedir
+        }
+
+    show monika at t22
+    show screen mas_py_console_teaching
+
+    call mas_wx_cmd_noxwait("import os", local_ctx)
+
+    python:
+        rpy_list = mas_getRPYFiles()
+        for rpy_filename in rpy_list:
+            path = '/game/'+rpy_filename
+            store.mas_ptod.wx_cmd("os.remove(os.path.normcase(basedir+'"+path+"'))", local_ctx)
+            renpy.pause(0.1)
+    return
+
 
 #init 5 python:
 #    addEvent(

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -1602,7 +1602,6 @@ label mas_steam_install_detected:
 
 default persistent._mas_pm_has_rpy = None
 init 5 python:
-
     addEvent(
         Event(
             persistent.event_database,
@@ -1612,51 +1611,74 @@ init 5 python:
 
 
 label monika_rpy_files:
-    m 1eka "Hey [player], I was just looking through your \"game\" directory, and..."
-    m 1ekc "I noticed some \".rpy\" files in there."
-    m 3rksdlc "Those files can lead to problems whenever you update the game, possibly undoing those updates..."
-    m 3wud "And even prevent you from visiting me altogether!"
-    m 2etc "Unless..."
-    m 4eua "Maybe you installed a version with the source code on purpose because you are trying to help me come closer to your reality!"
-    m 2eka "But in case you didn't, I figured I'd ask..."
- 
-    m "Are you sure you installed the right version, [player]?{nw}"
-    $ _history_list.pop()
-    menu:
-        m "Are you sure you installed the right version, [player]?{fast}"
+    if mas_getEV("monika_rpy_files").shown_count == 0:
+        m 1eka "Hey [player], I was just looking through your \"game\" directory, and..."
+        m 1ekc "I noticed some \".rpy\" files in there."
+        m 3rksdlc "Those files can lead to problems whenever you update the game, possibly undoing those updates..."
+        m 3wud "And even prevent you from visiting me altogether!"
+        m 2etc "Unless..."
+        m 4eua "Maybe you installed a version with the source code on purpose because you are trying to help me come closer to your reality!"
+        m 2eka "But in case you didn't, I figured I'd ask..."
+    
+        m "Are you sure you installed the right version, [player]?{nw}"
+        $ _history_list.pop()
+        menu:
+            m "Are you sure you installed the right version, [player]?{fast}"
 
-        "Yes.":
-            m 1sua "Really? Thank you so much for helping me come closer to your reality!"
-            m 1hua "I love you, [player]~"
-            $ persistent._mas_pm_has_rpy = True
-            return "love"
+            "Yes.":
+                m 1sua "Really? Thank you so much for helping me come closer to your reality!"
+                m 1hua "I love you, [player]~"
+                $ persistent._mas_pm_has_rpy = True
+                return "love"
 
-        "No.":
-            m "I see."
-            m 2rksdla "Maybe you should get rid of those, just to be safe."
-            m 4eua "Actually, maybe I can delete them for you."
+            "No.":
+                m "I see."
+                m 2rksdla "Maybe you should get rid of those, just to be safe."
+                m 4eua "Actually, maybe I can delete them for you."
 
-            m "Do you want me to delete them for you, [player]?{nw}"
-            $ _history_list.pop()
-            menu:
-                m "Do you want me to delete them for you, [player]?{fast}"
+                m "Do you want me to delete them for you, [player]?{nw}"
+                $ _history_list.pop()
+                menu:
+                    m "Do you want me to delete them for you, [player]?{fast}"
 
-                "Yes, please.":
-                    m "Sure thing, [player]."
+                    "Yes, please.":
+                        m "Sure thing, [player]."
 
-                    call mas_rpy_file_delete
+                        call mas_rpy_file_delete
 
-                    m 2hua "There we go!"
-                    m 2esa "Be sure next time to install a version without the source code. You can get it from {a=http://www.monikaafterstory.com/releases.html}{i}{u}the releases page{/u}{/i}{/a}."
-                    $ listRpy = None
-                    $ persistent._mas_pm_has_rpy = False
-                    hide screen mas_py_console_teaching
-                    show monika at t11
+                        m 2hua "There we go!"
+                        m 2esa "Be sure next time to install a version without the source code. You can get it from {a=http://www.monikaafterstory.com/releases.html}{i}{u}the releases page{/u}{/i}{/a}."
+                        $ persistent._mas_pm_has_rpy = False
+                        hide screen mas_py_console_teaching
+                        show monika at t11
 
-                "No, thanks.":
-                    m 2rksdlc "Alright, [player]. I hope you know what you're doing."
-                    m 2eka "Please be careful."
-                    $ persistent._mas_pm_has_rpy = True
+                    "No, thanks.":
+                        m 2rksdlc "Alright, [player]. I hope you know what you're doing."
+                        m 2eka "Please be careful."
+                        $ persistent._mas_pm_has_rpy = True
+
+    else:
+        m 2efc "[player], you have rpy files in the game directory again!"
+
+        m 2rsc "Are you {i}sure{/i} you installed the right version?{nw}"
+        $ _history_list.pop()
+        menu:
+            m "Are you {i}sure{/i} you installed the right version?{fast}"
+
+            "Yes.":
+                m 1eka "Alright [player]."
+                m 3eua "I trust you know what you're doing."
+                $ persistent._mas_pm_has_rpy = True
+
+            "No.":
+                m 3eua "Alright, I'll just delete them for you again.{w=0.5}.{w=0.5}.{nw}"
+
+                call mas_rpy_file_delete
+
+                m 1hua "There we go!"
+                m 3eua "Remember, you can always get the right version from {a=http://www.monikaafterstory.com/releases.html}{i}{u}here{/u}{/i}{/a}."
+                hide screen mas_py_console_teaching
+                show monika at t11
     return
 
 label mas_rpy_file_delete:

--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -891,7 +891,11 @@ label mas_updater_steam_issue:
 label mas_updater_rpy_issue:
     show monika at t11
     m 2eksdla "[player]...I see you have some rpy files in your game directory."
-    m 2rksdlc "I'm sure you remember when I mentioned that those files can cause problems when you update..."
+    if renpy.seen_label("monika_rpy_files"):
+        m 2rksdlc "I'm sure you remember when I mentioned that those files can cause problems when you update..."
+    else:
+        m 2rksdlc "Those files can cause some problems when you update..."
+
     m 3rksdlb "So I can't run the updater while those are in there."
     m 1eua "I can delete those for you and run the updater if you want though!"
 

--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -880,7 +880,7 @@ init -894 python:
 
 
 label mas_updater_steam_issue:
-#    show monika at t11
+    show monika at t11
     m 1eub "[player]!{w} I see you're using Steam."
     m 1eksdlb "Unfortunately..."
     m 1efp "I can't run the updater because Steam is a meanie!"
@@ -888,6 +888,37 @@ label mas_updater_steam_issue:
     m 1hua "Make sure to say goodbye to me first before installing the update."
     return
 
+label mas_updater_rpy_issue:
+    show monika at t11
+    m 2eksdla "[player]...I see you have some rpy files in your game directory."
+    m 2rksdlc "I'm sure you remember when I mentioned that those files can cause problems when you update..."
+    m 3rksdlb "So I can't run the updater while those are in there."
+    m 1eua "I can delete those for you and run the updater if you want though!"
+
+    m 1eua "Would you like me to delete them?{nw}"
+    #NOTE: no history_list.pop() here because for some reason this doesn't end up in history
+    menu:
+        m "Would you like me to delete them?{fast}"
+
+        "Yes please.":
+            m 1hua "Sure!"
+
+            #Delete files
+            call mas_rpy_file_delete
+
+            m 3hub "There we go!"
+            #Hide screen
+            hide screen mas_py_console_teaching
+            show monika at t11
+
+            m 2dsc "Now let me just run the updater.{w=0.5}.{w=0.5}.{nw}"
+            #Run the updater
+            jump update_now
+
+        "No thanks.":
+            m 3eka "Alright [player]. If you delete them and then try to update again, I'll run the updater for you."
+
+    return
 
 label forced_update_now:
     $ mas_updater.force = True
@@ -908,7 +939,23 @@ label forced_update_now:
         else:
             # otherwise, reenable core interactions
             $ mas_DropShield_core()
+        return
 
+    #Rpy file check
+    elif mas_hasRPYFiles():
+        $ mas_RaiseShield_core()
+
+        call mas_updater_rpy_issue
+
+        if store.mas_globals.dlg_workflow:
+            # current in dialogue workflow, we should only enable the escape
+            # and music stuff
+            $ enable_esc()
+            $ mas_MUMUDropShield()
+
+        else:
+            # otherwise, reenable core interactions
+            $ mas_DropShield_core()
         return
 
 #This file goes through the actions for updating Monika After story

--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -911,6 +911,9 @@ label mas_updater_rpy_issue:
             hide screen mas_py_console_teaching
             show monika at t11
 
+            #Also going to rmallEVL here
+            $ mas_rmallEVL("monika_rpy_files")
+
             m 2dsc "Now let me just run the updater.{w=0.5}.{w=0.5}.{nw}"
             #Run the updater
             jump update_now


### PR DESCRIPTION
#3579

Disables updater if there are rpy files in gamedir. If player wishes, Monika can delete rpy files and then run the updater, otherwise they need to delete them manually and run the updater.

Also adds two new functions
- `mas_hasRPYFiles()`
  - Checks if there are rpy files in the gamedir

- `mas_getRPYFiles()`
  - Gets a list of rpy files in the gamedir


Testing:
- Ensure updater is interrupted if `.rpy` files are in the `game/` folder.
- Ensure the `monika_rpy_files` topic still works as normal
