### PR TITLE
bitmask flags type

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -128,6 +128,8 @@ python early:
     #   show_in_idle - True if this Event can be shown during idle
     #       False if not
     #       (Default: False)
+    #   flags - bitmask system that acts as unchanging flags.
+    #       (Default: 0)
     class Event(object):
 
         # tuple constants
@@ -145,7 +147,7 @@ python early:
             "end_date":10,
             "unlock_date":11,
             "shown_count":12,
-            "diary_entry":13,
+            #"diary_entry":13, # NOTE: this will not be removed until later
             "last_seen":14,
             "years":15,
             "sensitive":16,
@@ -154,7 +156,14 @@ python early:
         }
 
         # name constants
-        N_EVENT_NAMES = ("per_eventdb", "eventlabel", "locks", "rules")
+        N_EVENT_NAMES = (
+            "per_eventdb",
+            "eventlabel",
+            "locks",
+            "rules",
+            "diary_entry",
+            "flags"
+        )
 
         # other constants
         DIARY_LIMIT = 500
@@ -190,13 +199,14 @@ python early:
                 start_date=None,
                 end_date=None,
                 unlock_date=None,
-                diary_entry=None,
+#                diary_entry=None,
                 rules=dict(),
                 last_seen=None,
                 years=None,
                 sensitive=False,
                 aff_range=None,
-                show_in_idle=False
+                show_in_idle=False,
+                flags=0
             ):
 
             # setting up defaults
@@ -206,12 +216,12 @@ python early:
                 raise EventException("'per_eventdb' cannot be None")
             if action is not None and action not in EV_ACTIONS:
                 raise EventException("'" + action + "' is not a valid action")
-            if diary_entry is not None and len(diary_entry) > self.DIARY_LIMIT:
-                raise Exception(
-                    (
-                        "diary entry for {0} is longer than {1} characters"
-                    ).format(eventlabel, self.DIARY_LIMIT)
-                )
+#            if diary_entry is not None and len(diary_entry) > self.DIARY_LIMIT:
+#                raise Exception(
+#                    (
+#                        "diary entry for {0} is longer than {1} characters"
+#                    ).format(eventlabel, self.DIARY_LIMIT)
+#                )
             if rules is None:
                 raise Exception(
                     "'{0}' - rules property cannot be None".format(eventlabel)
@@ -251,6 +261,9 @@ python early:
                     eventlabel, str(aff_range)
                 ))
 
+            if not isinstance(flags, int):
+                raise Exception("'{0}' - invalid flags".format(eventlabel))
+
             self.eventlabel = eventlabel
             self.per_eventdb = per_eventdb
 
@@ -275,7 +288,7 @@ python early:
                 )
 
             self.rules = rules
-
+            self.flags = flags
 
             # this is the data tuple. we assemble it here because we need
             # it in two different flows

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -306,7 +306,7 @@ python early:
                 end_date,
                 unlock_date,
                 0, # shown_count
-                diary_entry,
+                "", # diary_entry
                 last_seen,
                 years,
                 sensitive,
@@ -356,7 +356,7 @@ python early:
                     # actaully this should be always
                     self.prompt = prompt
                     self.category = category
-                    self.diary_entry = diary_entry
+#                    self.diary_entry = diary_entry
 #                    self.rules = rules
                     self.years = years
                     self.sensitive = sensitive

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -161,7 +161,7 @@ init -950 python in mas_ev_data_ver:
         10: MASCurriedVerify(_verify_dt, True), # end_date
         11: MASCurriedVerify(_verify_dt, True), # unlock_date
         12: MASCurriedVerify(_verify_int, False), # shown_count
-        13: MASCurriedVerify(_verify_str, True), # diary_entry
+        #13: MASCurriedVerify(_verify_str, True), # diary_entry
         14: MASCurriedVerify(_verify_dt, True), # last_seen
         15: MASCurriedVerify(_verify_tuli, True), # years
         16: MASCurriedVerify(_verify_bool, True), # sensitive


### PR DESCRIPTION
Removes `diary_entry` from dictionary access (not the actual prop, should be done later when we're not in holiday season).

Adds `flags` as a bitmaskable property for generic types. this prop should only be used for type management for things that do not change dynamically.

# Testing
* verify no crashes