### PR TITLE
skipeval on mood push

### DIFF
--- a/Monika After Story/game/script-moods.rpy
+++ b/Monika After Story/game/script-moods.rpy
@@ -107,7 +107,7 @@ label mas_mood_start:
 
     # return value? then push
     if _return:
-        $ pushEvent(_return)
+        $ pushEvent(_return, skipeval=True)
 
         # and set the moods
         $ persistent._mas_mood_current = _return


### PR DESCRIPTION
It was possible for other events to slip in if you used a mood at the right time. Added `skipeval` prop to force push the mood.

# Testing:
- Load in before an event should be pushed (easiest way to do this would be to use a holiday's time spent event, since those start at 8:00 PM. So you can load in a little earlier. Alternatively, you can use console and adjust the conditional to be `"True"` for an event that would be pushed (again, like a time spent event)
- Go to the `I'm feeling...` menu
- Once within the time range for the event, ensure that when using any mood, the mood is shown first and only after that, the event which was supposed to show will show.