### PR TITLE
allow generic gifts to react multiple times per day

### DIFF
--- a/Monika After Story/game/zz_reactions.rpy
+++ b/Monika After Story/game/zz_reactions.rpy
@@ -266,6 +266,9 @@ init -1 python in mas_filereacts:
                 # keep stats for today
                 _register_received_gift("mas_reaction_gift_generic")
 
+                # always pop generic reacts
+                store.persistent._mas_filereacts_reacted_map.pop(mas_gift)
+
 
         generic_reacts.extend(sprite_object_reacts)
 


### PR DESCRIPTION
#4905 

pops generic reactions from the reacted map. 

# Testing
1. make a generic gift (not spritepack)
2. launch game/verify monika reacts to the gift
3. remake the generic gift
4. verify monika reacts to the gift again