### PR TITLE
Muxtype the rose with headset

### DIFF
--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -312,7 +312,13 @@ init -100 python in mas_sprites:
     DEF_MUX_RB = ["ribbon", "bow", "twin-ribbons"]
     # default mux types for ribbon-based items.
 
-    DEF_MUX_HS = ["headset", "headphones", "earphones", "headband"]
+    DEF_MUX_HS = [
+        "headset",
+        "headphones",
+        "earphones",
+        "headband",
+        "left-hair-flower-ear"
+    ]
     # default mux types for headset-based items
 
     DEF_MUX_HB = ["headband", "headset", "headphones"]
@@ -320,6 +326,15 @@ init -100 python in mas_sprites:
 
     DEF_MUX_LHC = ["left-hair-clip"]
     # default mux types for left hair clip-based items
+
+    DEF_MUX_LHFE = [
+        "headset",
+        "headphones",
+        "earphones",
+        "left-hair-flower-ear",
+        "left-hair-flower"
+    ]
+    # default mux tyoes for left hair flower-baesd items
 
     # maps ACS types to their ACS template
     ACS_DEFS = {
@@ -354,7 +369,14 @@ init -100 python in mas_sprites:
         ),
         "left-hair-flower": ACSTemplate(
             "left-hair-flower",
-            mux_type=["left-hair-flower"],
+            mux_type=["left-hair-flower", "left-hair-flower-ear"],
+            ex_props={
+                "left-hair-strand-eye-level": True
+            }
+        ),
+        "left-hair-flower-ear": ACSTemplate(
+            "left-hair-flower-ear",
+            mux_type=DEF_MUX_LHFE,
             ex_props={
                 "left-hair-strand-eye-level": True
             }

--- a/Monika After Story/game/zz_selector.rpy
+++ b/Monika After Story/game/zz_selector.rpy
@@ -3440,8 +3440,17 @@ label monika_ribbon_select:
 #        use_remover = not monika_chr.is_wearing_hair_with_exprop("force-ribbon")
 
         use_acs = store.mas_selspr.filter_acs(True, group="ribbon")
+        
+        # make sure ot use ribbon for remover type
+        use_acs.append(store.mas_selspr.create_selectable_remover(
+            "ribbon",
+            "ribbon",
+            "Basic Hair Band"
+        ))
 
-        mailbox = store.mas_selspr.MASSelectableSpriteMailbox("Which hair tie would you like me to use?")
+        mailbox = store.mas_selspr.MASSelectableSpriteMailbox(
+            "Which hair tie would you like me to use?"
+        )
         sel_map = {}
 
     m 1eua "Sure [player]!"
@@ -3451,7 +3460,7 @@ label monika_ribbon_select:
 #        $ monika_chr.reset_outfit(False)
 
 
-    call mas_selector_sidebar_select_acs(use_acs, mailbox=mailbox, select_map=sel_map, add_remover=True, remover_name="Basic Hair Band")
+    call mas_selector_sidebar_select_acs(use_acs, mailbox=mailbox, select_map=sel_map, add_remover=True)
 
     if not _return:
         m 1eka "Oh, alright."
@@ -3524,6 +3533,13 @@ init 5 python:
 label monika_hairflower_select:
     python:
         use_acs = store.mas_selspr.filter_acs(True, group="left-hair-flower")
+
+        # since left-hair-flower group can have mutpile types, force using
+        #   left-hair-flower type for muxing
+        use_acs.append(store.mas_selspr.create_selectable_remover(
+            "left-hair-flower",
+            "left-hair-flower"
+        ))
 
         mailbox = store.mas_selspr.MASSelectableSpriteMailbox(
             "Which flower would you like me to put in my hair?"

--- a/Monika After Story/game/zz_spriteobjects.rpy
+++ b/Monika After Story/game/zz_spriteobjects.rpy
@@ -1191,9 +1191,10 @@ init -1 python:
             default="0",
             p5="5"
         ),
-        acs_type="left-hair-flower",
+        acs_type="left-hair-flower-ear",
         mux_type=[
-            "left-hair-flower",
+            "left-hair-flower-ear",
+            "left-hair-flower"
         ],
         ex_props={
             "left-hair-strand-eye-level": True,


### PR DESCRIPTION
#4940 

# Key changes
* mux types the ear rose with headsets. This also changes the acs type to `left-hair-flower-ear`. 
**NOTE: because this changes the acs type, if any place referenced the rose via acs type, it needs to be updated.**
* the hair flower selector remover will use mux types from `left-hair-flower`. 
* the ribbon selector remover will mux types from `ribbon`.

# Testing
* verify that the ear rose and the miku headset cannot be worn together. Try console commands or outfit mode miku to get the headset. The rose has a selector so you can unlock it manually to use the selector with the rose or wear it in console.
* verify ribbon selector still works