### PR TITLE
Stop folder reactions

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -2651,25 +2651,6 @@ init -990 python in mas_utils:
         trydel(old_path)
 
 
-    def is_folder(fpath):
-        """
-        Checks if the given path is actually a folder.
-
-        IN:
-            fpath - path to check
-
-        RETURNS: True if the fpath is a folder, false if not, None if we dont
-            really know.
-        """
-        try:
-            stat_data = os.stat(fpath)
-            return stat.S_ISDIR(stat_data.st_mode) > 0
-        
-        except Exception as e:
-            writelog(_mas__faildir.format(fpath, repr(e)))
-            return None
-
-
     def tryparsedt(_datetime, default=None, sep=" "):
         """
         Trys to parse a datetime isoformat string into a datetime object

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -2434,6 +2434,7 @@ init -999 python:
 init -990 python in mas_utils:
     import store
     import os
+    import stat
     import shutil
     import datetime
     import codecs
@@ -2446,6 +2447,7 @@ init -990 python in mas_utils:
     # LOG messges
     _mas__failrm = "[ERROR] Failed remove: '{0}' | {1}\n"
     _mas__failcp = "[ERROR] Failed copy: '{0}' -> '{1}' | {2}\n"
+    _mas__faildir = "[ERROR] Failed to check if dir: {0} | {1}\n"
 
     # bad text dict
     BAD_TEXT = {
@@ -2647,6 +2649,26 @@ init -990 python in mas_utils:
 
         # and delete the current file
         trydel(old_path)
+
+
+    def is_folder(fpath):
+        """
+        Checks if the given path is actually a folder.
+
+        IN:
+            fpath - path to check
+
+        RETURNS: True if the fpath is a folder, false if not, None if we dont
+            really know.
+        """
+        try:
+            stat_data = os.stat(fpath)
+            return stat.S_ISDIR(stat_data.st_mode) > 0
+        
+        except Exception as e:
+            writelog(_mas__faildir.format(fpath, repr(e)))
+            return None
+
 
     def tryparsedt(_datetime, default=None, sep=" "):
         """

--- a/Monika After Story/game/zz_dockingstation.rpy
+++ b/Monika After Story/game/zz_dockingstation.rpy
@@ -309,6 +309,7 @@ init -45 python:
         def getPackageList(self, ext_filter=""):
             """
             Gets a list of the packages in the docking station.
+            We also ensure that the item retrieved is not a folder.
 
             IN:
                 ext_filter - extension filter to use when getting list.
@@ -329,6 +330,7 @@ init -45 python:
                 package
                 for package in os.listdir(self.station)
                 if package.endswith(ext_filter)
+                and self.mas_utils.is_folder(package) is False
             ]
 
 
@@ -962,10 +964,10 @@ init -45 python:
 
             return None
 
-
         def __check_access(self, package_path, check_read):
             """
-            Checks access of the file at package_path
+            Checks access of the file at package_path.
+            Also ensures that the file is not actually is folder.
 
             NOTE:
                 will log exceptions
@@ -987,6 +989,7 @@ init -45 python:
             try:
                 file_ok = os.access(package_path, os.F_OK)
                 read_ok = os.access(package_path, os.R_OK)
+                not_dir = self.mas_utils.is_folder(package_path) is False
 
             except Exception as e:
                 mas_utils.writelog(self.ERR.format(
@@ -999,17 +1002,12 @@ init -45 python:
                 return self.__bad_check_read(check_read)
 
             if check_read:
-                if not (file_ok and read_ok):
+                if not (file_ok and read_ok and not_dir):
                     return None
 
-            else:
-                if not file_ok:
-                    return False
+            return file_ok and not_dir
 
-            return True
-
-
-        def __bad_check_read(check_read):
+        def __bad_check_read(self, check_read):
             """
             Returns an appropriate failure value givne the check_read value
 

--- a/Monika After Story/game/zz_dockingstation.rpy
+++ b/Monika After Story/game/zz_dockingstation.rpy
@@ -330,7 +330,7 @@ init -45 python:
                 package
                 for package in os.listdir(self.station)
                 if package.endswith(ext_filter)
-                and self.mas_utils.is_folder(package) is False
+                and not os.path.isdir(self._trackPackage(package))
             ]
 
 
@@ -989,7 +989,7 @@ init -45 python:
             try:
                 file_ok = os.access(package_path, os.F_OK)
                 read_ok = os.access(package_path, os.R_OK)
-                not_dir = self.mas_utils.is_folder(package_path) is False
+                not_dir = not os.path.isdir(package_path)
 
             except Exception as e:
                 mas_utils.writelog(self.ERR.format(


### PR DESCRIPTION
#4930 

# Key changes
* `MASDockingStation.__check_access` returns false if path is a folder.
* `MASDockingStation.getPackageList` only returns list of files 

# Testing
1. make a folder with a name that ends in `.gift` in the `characters/` folder
2. launch the game. 
3. verify monika does not react to the folder