### PR TITLE
Greeting Type Overrides

### DIFF
--- a/Monika After Story/game/event-rules.rpy
+++ b/Monika After Story/game/event-rules.rpy
@@ -14,7 +14,6 @@ init -1 python:
     EV_RULE_FAREWELL_RANDOM = "farewell_random"
     EV_RULE_AFF_RANGE = "affection_range"
     EV_RULE_PRIORITY = "rule_priority"
-    EV_RULE_GR_OVR_TYPE = "rule_gr_override_type"
 
 
     # special constants for numerical repeat rules
@@ -383,7 +382,8 @@ init -1 python:
                 ev=None,
                 skip_visual=False,
                 random_chance=0,
-                setup_label=None
+                setup_label=None,
+                override_type=False
             ):
             """
             IN:
@@ -399,6 +399,9 @@ init -1 python:
                 setup_label - label to call right after this greeting is
                     selected. This happens before post_greeting_check.
                     (Default: None)
+                override_type - True will let this greeting override type
+                    checks during selection, False will not
+                    (Default: False)
 
             RETURNS:
                 a dict containing the specified rules
@@ -417,7 +420,8 @@ init -1 python:
                 EV_RULE_GREET_RANDOM: (
                     skip_visual,
                     random_chance,
-                    setup_label
+                    setup_label,
+                    override_type,
                 )
             }
 
@@ -462,6 +466,22 @@ init -1 python:
             # Evaluate randint with a chance of 1 in random_chance
             return renpy.random.randint(1,random_chance) == 1
 
+        @staticmethod
+        def should_override_type(ev=None, rule=None):
+            """
+            IN:
+                ev - the event to evaluate, gets priority
+                rule - the MASGreetingRule to evaluate
+
+            RETURNS: True if the rule should override types, false if not
+            """
+            if ev:
+                rule = ev.rules.get(EV_RULE_GREET_RANDOM, None)
+
+            if rule is not None and len(rule) > 3:
+                return rule[3]
+
+            return False
 
         @staticmethod
         def should_skip_visual(event=None, rule=None):
@@ -692,49 +712,6 @@ init -1 python:
                 is found
             """
             return ev.rules.get(EV_RULE_PRIORITY, MASPriorityRule.DEF_PRIORITY)
-
-
-    class MASGreetingTypeOverrideRule(object):
-        """
-        Static class used in creationof greeting type override rules.
-        Greeting type override rules should be set in greetings that need
-        to override type rules despite not having a type.
-
-        These rules are just bool flags.
-        """
-
-        @staticmethod
-        def create_rule(should_override, ev=None):
-            """
-            IN:
-                should_override - True if we want to override greeting
-                    types, false if not
-                ev - Event to add this rule to. This will replace
-                    existing: (Default: None)
-
-            RETURNS: created rule
-            """
-            rule = {EV_RULE_GR_OVR_TYPE: bool(should_override)}
-
-            if ev:
-                ev.rules.update(rule)
-
-            return rule
-
-        @staticmethod
-        def should_override(ev):
-            """
-            Checks if this event should override gr types.
-
-            IN:
-                ev - event to check override status
-
-            RETURNS: True if the event should override, false otherwise
-            """
-            if ev is not None:
-                return ev.rules.get(EV_RULE_GR_OVR_TYPE, False)
-
-            return False
 
 
 init python:

--- a/Monika After Story/game/event-rules.rpy
+++ b/Monika After Story/game/event-rules.rpy
@@ -14,6 +14,7 @@ init -1 python:
     EV_RULE_FAREWELL_RANDOM = "farewell_random"
     EV_RULE_AFF_RANGE = "affection_range"
     EV_RULE_PRIORITY = "rule_priority"
+    EV_RULE_GR_OVR_TYPE = "rule_gr_override_type"
 
 
     # special constants for numerical repeat rules
@@ -691,6 +692,49 @@ init -1 python:
                 is found
             """
             return ev.rules.get(EV_RULE_PRIORITY, MASPriorityRule.DEF_PRIORITY)
+
+
+    class MASGreetingTypeOverrideRule(object):
+        """
+        Static class used in creationof greeting type override rules.
+        Greeting type override rules should be set in greetings that need
+        to override type rules despite not having a type.
+
+        These rules are just bool flags.
+        """
+
+        @staticmethod
+        def create_rule(should_override, ev=None):
+            """
+            IN:
+                should_override - True if we want to override greeting
+                    types, false if not
+                ev - Event to add this rule to. This will replace
+                    existing: (Default: None)
+
+            RETURNS: created rule
+            """
+            rule = {EV_RULE_GR_OVR_TYPE: bool(should_override)}
+
+            if ev:
+                ev.rules.update(rule)
+
+            return rule
+
+        @staticmethod
+        def should_override(ev):
+            """
+            Checks if this event should override gr types.
+
+            IN:
+                ev - event to check override status
+
+            RETURNS: True if the event should override, false otherwise
+            """
+            if ev is not None:
+                return ev.rules.get(EV_RULE_GR_OVR_TYPE, False)
+
+            return False
 
 
 init python:

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1127,6 +1127,7 @@ init 5 python:
             )
         )
         ev_rules.update(MASPriorityRule.create_rule(50))
+        ev_rules.update(MASGreetingTypeOverrideRule.create_rule(True))
 
         # TODO: should we have this limited to aff levels?
 

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -9,8 +9,6 @@
 #       MASNumericalRepeatRule - repeat every x time
 #       MASPriorityRule - priority of this event. if not given, we assume
 #           the default priority (which is also the lowest)
-#       MASGreetingTypeOverrideRule - signals that this greeting overrides
-#           the type check
 
 # PRIORITY RULES:
 #   Special, moni wants/debug greetings should have negative priority.
@@ -69,7 +67,7 @@ init -1 python in mas_greetings:
 
     # High priority types
     # These types ALWAYS override greeting priority rules
-    # These CANNOT be override with GreetingTypeOverrideRules
+    # These CANNOT be override with GreetingTypeRules
     HP_TYPES = [
         TYPE_GO_SOMEWHERE,
         TYPE_GENERIC_RET,
@@ -137,7 +135,7 @@ init -1 python in mas_greetings:
                 # but does not have the current type
                     return False
 
-            elif not store.MASGreetingTypeOverrideRule.should_override(ev):
+            elif not store.MASGreetingRule.should_override_type(ev):
                 # greeting does not have types, but the type is not high
                 # priority so if the greeting doesnt alllow
                 # type override then it cannot be used
@@ -1123,11 +1121,11 @@ init 5 python:
         ev_rules.update(
             MASGreetingRule.create_rule(
                 skip_visual=True,
-                random_chance=opendoor.chance
+                random_chance=opendoor.chance,
+                override_type=True
             )
         )
         ev_rules.update(MASPriorityRule.create_rule(50))
-        ev_rules.update(MASGreetingTypeOverrideRule.create_rule(True))
 
         # TODO: should we have this limited to aff levels?
 
@@ -2470,11 +2468,12 @@ label greeting_timeconcern_day:
 
 init 5 python:
     ev_rules = {}
-    ev_rules.update(
-        MASGreetingRule.create_rule(skip_visual=True, random_chance=5)
-    )
+    ev_rules.update(MASGreetingRule.create_rule(
+        skip_visual=True,
+        random_chance=5,
+        override_type=True
+    ))
     ev_rules.update(MASPriorityRule.create_rule(45))
-    ev_rules.update(MASGreetingTypeOverrideRule.create_rule(True))
 
     addEvent(
         Event(
@@ -3073,8 +3072,8 @@ label greeting_siat:
 init 5 python:
     if not mas_cannot_decode_islands:
         ev_rules = {}
+        ev_rules.update(MASGreetingRule.create_rule(override_type=True))
         ev_rules.update(MASPriorityRule.create_rule(40))
-        ev_rules.update(MASGreetingTypeOverrideRule.create_rule(True))
 
         addEvent(
             Event(


### PR DESCRIPTION
#4933 

# Key changes
* added `override_type` param to `MASGreetingRule` that allows a greeting to override type checks
* `HP_TYPES` - list of types in `mas_greetings` that **cannot be overridden**. 
* hairdown, ourreality, and monikaroom have been set to override types

## greeting selection alg changes
* If we are selecting a greeting with a normal greeting type, greetings that evaluate `MASGreetingRule.should_override_type` to True will be included in the greeting selection pool even if they do not have a matching type. if an `HP_TYPES` greeting type is used, greetings with the rule are excluded from the selection pool like normal.

# Testing
* verify that greetings still work
* verify that the 3 special greetings override type-greetings, except for returned home and long absensce greetings.
* you can use the greeting sampler (Dev / SAMPLE GRE) to test if greetings are being selected from correctly. examples:
    * If a non-high priority type is set and special greetings are unlocked, you should get a mix of special greetings and the type greeting, or just special greetings depending on other greeting rules.
    * if a non-high priority type is set and special greetings are **not** unlocked, you should only get the type greeting.
    * If a high priority type is set and special greetings are unlocked, you should only get the type greeting.

**NOTE:** monikaroom greeting is often always unlocked, so that will likely appear in gre sampler results even if you say no to the special greetings unlock prompt.