### PR TITLE
Greeting Type Timeouts

### DIFF
--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -77,6 +77,12 @@ init -999 python in mas_ev_data_ver:
         return isinstance(val, str) or isinstance(val, unicode)
 
 
+    def _verify_td(val, allow_none=True):
+        if val is None:
+            return allow_none
+        return _verify_item(val, datetime.timedelta, allow_none)
+
+
     def _verify_tuli(val, allow_none=True):
         if val is None:
             return allow_none

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1209,6 +1209,11 @@ label mas_ch30_post_holiday_check:
     # greeting selection
     python:
 
+        # greeting timeout check
+        persistent._mas_greeting_type = store.mas_greetings.checkTimeout(
+            persistent._mas_greeting_type
+        )
+
         # we select a greeting depending on the type that we should select
         sel_greeting_ev = store.mas_greetings.selectGreeting(
             persistent._mas_greeting_type

--- a/Monika After Story/game/script-farewells.rpy
+++ b/Monika After Story/game/script-farewells.rpy
@@ -1283,8 +1283,6 @@ default persistent._mas_pm_ate_late_times = 0
 
 
 label bye_prompt_eat:
-    #Since everything but snack uses the same time, we'll set it here
-    $ persistent._mas_greeting_type_timeout = datetime.timedelta(hours=3)
     $ _now = datetime.datetime.now().time()
 
     if mas_isMNtoSR(_now):
@@ -1310,9 +1308,14 @@ label bye_prompt_eat:
             m 4ekc "You should really go to bed, you know."
             m 4eud "...Try to go straight to bed when you're finished."
             m 2euc "Anyway, I guess I'll see you tomorrow..."
+
+        #NOTE: Due to the greet of this having an 18 hour limit, we use a 20 hour cap
+        $ persistent._mas_greeting_type_timeout = datetime.timedelta(hours=20)
         $ persistent.mas_late_farewell = True
 
     else:
+        #NOTE: Since everything but snack uses the same time, we'll set it here
+        $ persistent._mas_greeting_type_timeout = datetime.timedelta(hours=3)
         menu:
             "Breakfast.":
                 if mas_isSRtoN(_now):

--- a/Monika After Story/game/script-farewells.rpy
+++ b/Monika After Story/game/script-farewells.rpy
@@ -398,6 +398,7 @@ label bye_prompt_to_class:
     # TODO:
     # can monika join u at schools?
     $ persistent._mas_greeting_type = store.mas_greetings.TYPE_SCHOOL
+    $ persistent._mas_greeting_type_timeout = datetime.timedelta(hours=20)
     return 'quit'
 
 init 5 python:
@@ -454,6 +455,7 @@ label bye_prompt_to_work:
     # TODO:
     # can monika join u at work
     $ persistent._mas_greeting_type = store.mas_greetings.TYPE_WORK
+    $ persistent._mas_greeting_type_timeout = datetime.timedelta(hours=20)
     return 'quit'
 
 init 5 python:
@@ -623,7 +625,7 @@ label bye_prompt_sleep:
 
     # TODO:
     #   join monika sleeping?
-
+    $ persistent._mas_greeting_type_timeout = datetime.timedelta(hours=13)
     $ persistent._mas_greeting_type = store.mas_greetings.TYPE_SLEEP
     return 'quit'
 
@@ -1058,7 +1060,6 @@ label bye_going_somewhere_rtg:
             m 2wub "Really? Are you sure? Even though it's my own fault I can't go with you..."
             m 1eka "...Thank you, [player]. That means more to me than you could possibly understand."
             $ mas_gainAffection()
-
     return
 
 
@@ -1244,7 +1245,10 @@ label bye_prompt_game:
         m 1eka "Going off to play another game, [player]?"
         m 3hub "Good luck and have fun!"
         m 3eka "Don't forget to come back soon~"
+
     $ persistent._mas_greeting_type = store.mas_greetings.TYPE_GAME
+    #24 hour time cap because greeting handles up to 18 hours
+    $ persistent._mas_greeting_type_timeout = datetime.timedelta(days=1)
     return 'quit'
 
 init 5 python:
@@ -1279,7 +1283,10 @@ default persistent._mas_pm_ate_late_times = 0
 
 
 label bye_prompt_eat:
+    #Since everything but snack uses the same time, we'll set it here
+    $ persistent._mas_greeting_type_timeout = datetime.timedelta(hours=3)
     $ _now = datetime.datetime.now().time()
+
     if mas_isMNtoSR(_now):
         $ persistent._mas_pm_ate_late_times += 1
         if mas_isMoniNormal(higher=True):
@@ -1428,6 +1435,9 @@ label bye_prompt_eat:
                     else:
                         m 2euc "Feeling hungry?"
                         m 2eud "Enjoy your snack."
+
+                #Snack gets a shorter time than full meal
+                $ persistent._mas_greeting_type_timeout = datetime.timedelta(minutes=30)
     $ persistent._mas_greeting_type = store.mas_greetings.TYPE_EAT
     return 'quit'
 
@@ -1474,4 +1484,5 @@ label bye_prompt_housework:
     else:
         m 6ckc "..."
     $ persistent._mas_greeting_type = store.mas_greetings.TYPE_CHORES
+    $ persistent._mas_greeting_type_timeout = datetime.timedelta(hours=5)
     return 'quit'


### PR DESCRIPTION
#4933 

Added timeout option to make certain greeting types reset.

# Key changes
* new persistent `persistent._mas_greeting_type_timeout` - can either be a datetime or timedelta.
     * if `datetime`, then if the current time is passed that `datetime`, we clear the greeting type
     * if `timedelta`, then the last session end is added to the timedelta, and if the current time is passed that result, we clear the greeting type
* certain greeting types have been added to a tuple (`NTO_TYPES`), which are types that **cannot be cleared via timeouts**
* `mas_greetings.checkTimeout` - checks the greeting type timout var as well as type overrides and returns the appropriate greeting type we will use 

To use the timeout option, a farewell must set the timeout var to either a datetime or timedelta. 

# TODO
- [x] set timeouts for greetings that need them

# Testing
* verify greetings still work
* verify that if a type times out, the greetings associated with that type are not shown 
* verify that even if timeout is set for an `NTO_TYPE`, greetings associated with that type are always shown.
