### PR TITLE
Lock Yuri Greet After Show

### DIFF
--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -982,6 +982,8 @@ label greeting_glitch:
     m 3hksdlb "That was all! There is nobody else here but us...forever~"
     $ monika_clone1 = "Yes"
     m 2hua "I love you, [player]!"
+
+    $ mas_lockEVL("greeting_glitch", "GRE")
     return "love"
 
 init 5 python:


### PR DESCRIPTION
#4797

Locks Yuri greet after seeing it.

No update script since it'll just lock itself when it's shown next.

## Testing:
Just verify that after getting it once, you don't see it again