### PR TITLE
Clean up new day checks

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -5065,6 +5065,40 @@ init 2 python:
         eighteenth_bday = mas_utils.add_years(persistent._mas_player_bday, 18)
         return _date >= eighteenth_bday
 
+    def mas_timePastSince(timekeeper, passed_time, _now=None):
+        """
+        Checks if a certain amount of time has passed since the time in the timekeeper
+        IN:
+            timekeeper - variable holding the time since last event
+            passed_time - datetime.timedelta of the amount of time passed
+            _now - time to check against (If none, now is assumed, (Default: None))
+        OUT:
+            boolean:
+                - True if it has been passed_time units past timekeeper
+                - False otherwise
+        """
+        if timekeeper is None:
+            return True
+
+        elif _now is None:
+            _now = datetime.datetime.now()
+
+        #If our timekeeper is holding a datetime.date, we need to convert it to a datetime.datetime
+        if not isinstance(timekeeper, datetime.datetime):
+            timekeeper = datetime.datetime.combine(timekeeper, datetime.time())
+
+        return timekeeper + passed_time <= _now
+
+    def mas_pastOneDay(timekeeper, _now=None):
+        """
+        One day time past version of mas_timePastSince()
+
+        IN:
+            timekeeper - variable holding the time since last event
+            _now - time to check against (Default: None)
+        """
+        return mas_timePastSince(timekeeper, datetime.timedelta(days=1), _now)
+
 # Music
 define audio.t1 = "<loop 22.073>bgm/1.ogg"  #Main theme (title)
 define audio.t2 = "<loop 4.499>bgm/2.ogg"   #Sayori theme

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -5069,9 +5069,16 @@ init 2 python:
         """
         Checks if a certain amount of time has passed since the time in the timekeeper
         IN:
-            timekeeper - variable holding the time since last event
-            passed_time - datetime.timedelta of the amount of time passed
-            _now - time to check against (If none, now is assumed, (Default: None))
+            timekeeper:
+                variable holding the time we last checked whatever it restricts
+                (can be datetime.datetime or datetime.date)
+
+            passed_time:
+                datetime.timedelta of the amount of time which should
+                have passed since the last check in order to return True
+
+            _now:
+                time to check against (If none, now is assumed, (Default: None))
         OUT:
             boolean:
                 - True if it has been passed_time units past timekeeper

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -1638,7 +1638,7 @@ init 20 python:
             amount = _mas_getGoodExp()
 
         # is it a new day?
-        if persistent._mas_affection.get("freeze_date") is None or datetime.date.today() > persistent._mas_affection["freeze_date"]:
+        if mas_pastOneDay(persistent._mas_affection.get("freeze_date")):
             persistent._mas_affection["freeze_date"] = datetime.date.today()
             persistent._mas_affection["today_exp"] = 0
             mas_UnfreezeGoodAffExp()

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1706,6 +1706,13 @@ label ch30_day:
 
         if mas_isO31() and not persistent._mas_o31_in_o31_mode:
             pushEvent("mas_holiday_o31_returned_home_relaunch", skipeval=True)
+
+        #If the map isn't empty and it's past the last reacted date, let's empty it now
+        if (
+            persistent._mas_filereacts_reacted_map
+            mas_pastOneDay(persistent._mas_filereacts_last_reacted_date)
+        ):
+            persistent._mas_filereacts_reacted_map = dict()
     return
 
 
@@ -1925,6 +1932,12 @@ label ch30_reset:
     python:
         if persistent._mas_filereacts_just_reacted:
             queueEvent("mas_reaction_end")
+
+        #If the map isn't empty and it's past the last reacted date, let's empty it now
+        if (
+            persistent._mas_filereacts_reacted_map
+            mas_pastOneDay(persistent._mas_filereacts_last_reacted_date)
+        ):
 
     # set any prompt variants for acs that can be removed here
     python:

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1710,7 +1710,7 @@ label ch30_day:
         #If the map isn't empty and it's past the last reacted date, let's empty it now
         if (
             persistent._mas_filereacts_reacted_map
-            mas_pastOneDay(persistent._mas_filereacts_last_reacted_date)
+            and mas_pastOneDay(persistent._mas_filereacts_last_reacted_date)
         ):
             persistent._mas_filereacts_reacted_map = dict()
     return
@@ -1936,8 +1936,9 @@ label ch30_reset:
         #If the map isn't empty and it's past the last reacted date, let's empty it now
         if (
             persistent._mas_filereacts_reacted_map
-            mas_pastOneDay(persistent._mas_filereacts_last_reacted_date)
+            and mas_pastOneDay(persistent._mas_filereacts_last_reacted_date)
         ):
+            persistent._mas_filereacts_reacted_map = dict()
 
     # set any prompt variants for acs that can be removed here
     python:

--- a/Monika After Story/game/zz_reactions.rpy
+++ b/Monika After Story/game/zz_reactions.rpy
@@ -171,7 +171,7 @@ init -1 python in mas_filereacts:
             return []
 
         # is it a new day?
-        if store.persistent._mas_filereacts_last_reacted_date is None or store.persistent._mas_filereacts_last_reacted_date != datetime.date.today():
+        if store.mas_pastOneDay(store.persistent._mas_filereacts_last_reacted_date):
             store.persistent._mas_filereacts_last_reacted_date = datetime.date.today()
             store.persistent._mas_filereacts_reacted_map = dict()
 

--- a/Monika After Story/game/zz_weather.rpy
+++ b/Monika After Story/game/zz_weather.rpy
@@ -97,7 +97,7 @@ init python in mas_weather:
     def shouldRainToday():
 
         #Is it a new day? If so, we should see if it should rain today
-        if not store.persistent._mas_date_last_checked_rain or store.persistent._mas_date_last_checked_rain < datetime.date.today():
+        if store.mas_pastOneDay(store.persistent._mas_date_last_checked_rain):
             store.persistent._mas_date_last_checked_rain = datetime.date.today()
 
             #Now we roll


### PR DESCRIPTION
**NOTE:** based to content because other topics will need the methods added.

(closes #4915)

# Additions:
## `mas_timePastSince()`:
Generic time past check, takes in a timekeeping variable, a timedelta, and now. True if past timedelta from timekeeper, False otherwise.

## `mas_pastOneDay()`:
Specific one day check for `mas_timePastSince()` since we use this fairly commonly.

# Changes:
- Reacted map now clears daily if needed
- Cleaned up daily checks to use the `mas_pastOneDay()` check.

# Testing:
1. Make sure methods work (throw in some testcases, mixing between passing in a `datetime.datetime` or `datetime.date` as the timekeeper, make sure the right output is gotten
2. Make sure affection unfreezes correctly still, likewise weather begins checking properly again (no AWC)
3. Make sure filereacts reacted map gets cleared on a new sesh on the day after gifting, as well as in the same sesh (ch30_day run)
4. Verify no crashes