### PR TITLE
Delay queued topics on load

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -930,6 +930,7 @@ python early:
             #   full_copy - True means we create a new dict with deepcopies of
             #       the events. False will only copy references
             #       (Default: False)
+            #       DEPRECATEDE
             #
             #   FILTERING RULES: (recommend to use **kwargs)
             #   NOTE: None means we ignore that filtering rule
@@ -1257,7 +1258,7 @@ python early:
 
 
         @staticmethod
-        def checkEvents(ev_dict, rebuild_ev=True, on_load=False):
+        def checkEvents(ev_dict, rebuild_ev=True):
             """
             This acts as a combination of both checkConditoinal and
             checkCalendar
@@ -1273,31 +1274,19 @@ python early:
                 # TODO: same TODO as in checkConditionals.
                 #   indexing would be smarter.
 
-                #If not on_load, then we let all pass
-                #Otherwise, if on_load and the event has a push/queue action, we need to make sure the rule is part of the ev
-                #Also, we need to make sure if it's on_load but it's valid to process, we should
-                if (
-                    not on_load
-                    or (
-                        on_load
-                        and ev.action in [EV_ACT_PUSH, EV_ACT_QUEUE]
-                        and "postgreet" in ev.rules
+                if Event._checkEvent(ev, _now):
+                    # perform action
+                    Event._performAction(
+                        ev,
+                        unlock_time=_now,
+                        rebuild_ev=rebuild_ev
                     )
-                    or on_load and ev.action not in [EV_ACT_PUSH, EV_ACT_QUEUE]
-                ):
-                    if Event._checkEvent(ev, _now):
-                        # perform action
-                        Event._performAction(
-                            ev,
-                            unlock_time=_now,
-                            rebuild_ev=rebuild_ev
-                        )
 
-                        # check if we should repeat
-                        if not ev.prepareRepeat(True):
-                            # no repeats
-                            ev.conditional = None
-                            ev.action = None
+                    # check if we should repeat
+                    if not ev.prepareRepeat(True):
+                        # no repeats
+                        ev.conditional = None
+                        ev.action = None
 
             return
 

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -1257,7 +1257,7 @@ python early:
 
 
         @staticmethod
-        def checkEvents(ev_dict, rebuild_ev=True):
+        def checkEvents(ev_dict, rebuild_ev=True, on_load=False):
             """
             This acts as a combination of both checkConditoinal and
             checkCalendar
@@ -1272,6 +1272,14 @@ python early:
             for ev_label,ev in ev_dict.iteritems():
                 # TODO: same TODO as in checkConditionals.
                 #   indexing would be smarter.
+
+                #If this is on load and the event action is a push/queue without post greet, we skip its eval here
+                if (
+                    on_load
+                    and ev.action in [EV_ACT_PUSH, EV_ACT_QUEUE]
+                    and "postgreet" not in ev.rules
+                ):
+                    continue
 
                 if Event._checkEvent(ev, _now):
                     # perform action

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -1273,27 +1273,31 @@ python early:
                 # TODO: same TODO as in checkConditionals.
                 #   indexing would be smarter.
 
-                #If this is on load and the event action is a push/queue without post greet, we skip its eval here
+                #If not on_load, then we let all pass
+                #Otherwise, if on_load and the event has a push/queue action, we need to make sure the rule is part of the ev
+                #Also, we need to make sure if it's on_load but it's valid to process, we should
                 if (
-                    on_load
-                    and ev.action in [EV_ACT_PUSH, EV_ACT_QUEUE]
-                    and "postgreet" not in ev.rules
-                ):
-                    continue
-
-                if Event._checkEvent(ev, _now):
-                    # perform action
-                    Event._performAction(
-                        ev,
-                        unlock_time=_now,
-                        rebuild_ev=rebuild_ev
+                    not on_load
+                    or (
+                        on_load
+                        and ev.action in [EV_ACT_PUSH, EV_ACT_QUEUE]
+                        and "postgreet" in ev.rules
                     )
+                    or on_load and ev.action not in [EV_ACT_PUSH, EV_ACT_QUEUE]
+                ):
+                    if Event._checkEvent(ev, _now):
+                        # perform action
+                        Event._performAction(
+                            ev,
+                            unlock_time=_now,
+                            rebuild_ev=rebuild_ev
+                        )
 
-                    # check if we should repeat
-                    if not ev.prepareRepeat(True):
-                        # no repeats
-                        ev.conditional = None
-                        ev.action = None
+                        # check if we should repeat
+                        if not ev.prepareRepeat(True):
+                            # no repeats
+                            ev.conditional = None
+                            ev.action = None
 
             return
 

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1321,7 +1321,7 @@ label ch30_post_exp_check:
     $ mas_checkReactions()
 
     # run actiosn for events that are based on conditional or clock
-    $ Event.checkEvents(evhand.event_database)
+    $ Event.checkEvents(evhand.event_database, on_load=True)
 
     #Checks to see if affection levels have met the criteria to push an event or not.
     $ mas_checkAffection()

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1320,18 +1320,15 @@ label ch30_post_exp_check:
     # file reactions
     $ mas_checkReactions()
 
-    # run actiosn for events that are based on conditional or clock
-    # startup should skip events that have a push/queue action, unless 
-    # they have the postgreet rule
+    #All pushed events will have priority on load. Queued events will be pushed to the first idle loop
+    #random/unlock/pool actions are also evaluated here
     python:
         startup_events = {}
         for evl in evhand.event_database:
             ev = evhand.event_database[evl]
-            if Event._filterEvent(ev, action=(EV_ACT_PUSH, EV_ACT_QUEUE)):
-                if "postgreet" in ev.rules:
-                    startup_events[evl] = ev
-            else:
+            if not ev.action == EV_ACT_QUEUE:
                 startup_events[evl] = ev
+
         Event.checkEvents(startup_events)
 
     #Checks to see if affection levels have met the criteria to push an event or not.

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1321,7 +1321,18 @@ label ch30_post_exp_check:
     $ mas_checkReactions()
 
     # run actiosn for events that are based on conditional or clock
-    $ Event.checkEvents(evhand.event_database, on_load=True)
+    # startup should skip events that have a push/queue action, unless 
+    # they have the postgreet rule
+    python:
+        startup_events = {}
+        for evl in evhand.event_database:
+            ev = evhand.event_database[evl]
+            if Event._filterEvent(ev, action=(EV_ACT_PUSH, EV_ACT_QUEUE)):
+                if "postgreet" in ev.rules:
+                    startup_events[evl] = ev
+            else:
+                startup_events[evl] = ev
+        Event.checkEvents(startup_events)
 
     #Checks to see if affection levels have met the criteria to push an event or not.
     $ mas_checkAffection()

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1326,7 +1326,7 @@ label ch30_post_exp_check:
         startup_events = {}
         for evl in evhand.event_database:
             ev = evhand.event_database[evl]
-            if not ev.action == EV_ACT_QUEUE:
+            if ev.action != EV_ACT_QUEUE:
                 startup_events[evl] = ev
 
         Event.checkEvents(startup_events)


### PR DESCRIPTION
Changed queued events to not be processed on load. They are deferred to the first idle loop.

This allows us to stop machine-gunning topics immediately after a greet.
(It effectively acts as the `skipeval` param for `pushEvent`)

NOTE: `EV_ACT_POOL`, `EV_ACT_UNLOCK`, `EV_ACT_PUSH`, and `EV_ACT_RANDOM` will all be processed on load.

### TODO:
- [x] Add existing topics to be pushed immediately if need be (Done on alt branch)

### Testing:
You can test w/ holidays for this.
- Verify that loading in within the time range and/or with conditions met for an event which hasn't run yet
- Verify that if it is an event with a push action, it is shown immediately after the greet.
- Verify that if an event has a queued action, it isn't shown immediately.
- Verify that events which are pooled/unlocked/random'd by their actions are done immediately on load too.
- Verify with multiple events with different actions, they should function as you'd expect (by the above criteria)