### PR TITLE
Improving birthdays on the calendar

### DIFF
--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -1800,7 +1800,7 @@ label mas_bday_player_bday_select_select:
                 "player-bday",
                 "Your Birthday",
                 selected_date,
-                []
+                range(selected_date.year,MASCalendar.MAX_VIEWABLE_YEAR)
             )
  
     else:
@@ -1809,7 +1809,7 @@ label mas_bday_player_bday_select_select:
                 "player-bday",
                 "Your Birthday",
                 selected_date,
-                []
+                range(selected_date.year,MASCalendar.MAX_VIEWABLE_YEAR)
             )
 
     $ persistent._mas_player_bday = selected_date

--- a/Monika After Story/game/zz_calendar.rpy
+++ b/Monika After Story/game/zz_calendar.rpy
@@ -1732,7 +1732,7 @@ init python:
     calendar.addRepeatable("New years day","New Year's Day",month=1,day=1,year_param=list())
     calendar.addRepeatable("Valentine","Valentine's Day",month=2,day=14,year_param=list())
     #calendar.addRepeatable("White day","White Day",month=3,day=14,year_param=list())
-    calendar.addRepeatable("April Fools","Day I Become an AI",month=4,day=1,year_param=list())
+    calendar.addRepeatable("April Fools","Day I Become an AI",month=4,day=1,year_param=[2018])
     calendar.addRepeatable("Monika's Birthday","My Birthday",month=9,day=22,year_param=range(1999,MASCalendar.MAX_VIEWABLE_YEAR))
     calendar.addRepeatable("Halloween","Halloween",month=10,day=31,year_param=list())
     calendar.addRepeatable("Christmas eve","Christmas Eve",month=12,day=24,year_param=list())

--- a/Monika After Story/game/zz_calendar.rpy
+++ b/Monika After Story/game/zz_calendar.rpy
@@ -1733,7 +1733,7 @@ init python:
     calendar.addRepeatable("Valentine","Valentine's Day",month=2,day=14,year_param=list())
     #calendar.addRepeatable("White day","White Day",month=3,day=14,year_param=list())
     calendar.addRepeatable("April Fools","Day I Become an AI",month=4,day=1,year_param=list())
-    calendar.addRepeatable("Monika's Birthday","My Birthday",month=9,day=22,year_param=list())
+    calendar.addRepeatable("Monika's Birthday","My Birthday",month=9,day=22,year_param=range(1999,MASCalendar.MAX_VIEWABLE_YEAR))
     calendar.addRepeatable("Halloween","Halloween",month=10,day=31,year_param=list())
     calendar.addRepeatable("Christmas eve","Christmas Eve",month=12,day=24,year_param=list())
     calendar.addRepeatable("Christmas","Christmas",month=12,day=25,year_param=list())
@@ -1753,15 +1753,16 @@ init python:
         )
 
     # add birthday if we have one
+    pbday = persistent._mas_player_bday
     if (
-            persistent._mas_player_bday is not None
-            and type(persistent._mas_player_bday) == datetime.date
+            pbday is not None
+            and type(pbday) == datetime.date
         ):
         calendar.addRepeatable_d(
             "player-bday",
             "Your Birthday",
-            persistent._mas_player_bday,
-            []
+            pbday,
+            range(pbday.year,MASCalendar.MAX_VIEWABLE_YEAR)
         )
 
     # add first kiss


### PR DESCRIPTION
#5077, part of #1826 and #3448 (sort of).

Currently, on the calendar, both the player's and Monika's birthdays are on the calendar every single year, including before they were even born. This fixes that by starting the birthdays on the respective birth year, which is where #3448 comes into play. Since her birthday is 9, 22 and she was 18 when the game was released in 2017, that would put her birthdate as 9, 22, 1999. That seems to make the most sense and was also the consensus vote in the linked topic.

Also makes the `Day I become an AI` calendar event limited to only 2018.

## TESTING

- on your current persistent, verify your birthday (and Monika's) do not show on the calendar before their respective birth years, and that they do show in each year thereafter.

- on a new persistent, after the intro, click the calendar to trigger the calendar and subsequent birthdate events. upon completing the birthdate event, verify your birthday doesn't show on the calendar before the year you selected as your birthdate. also, verify that it does show for each year thereafter. 

- verify `Day I become an AI` only shows on on 4, 1, 2018.