### PR TITLE
getVolume fix

### DIFF
--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -2606,7 +2606,7 @@ label monika_aiwfc:
         m 1eksdla "I hope you don't mind, but I prepared a song for you."
         m 3hksdlb "I know it's a little cheesy, but I think you might like it."
         m 3eksdla "If your volume is off, would you mind turning it on for me?"
-        if songs.getVolume("music") == 0.0:
+        if songs.getUserVolume("music") == 0.0:
             m 3hksdlb "Oh, don't forget about your in game volume too!"
             m 3eka "I really want you to hear this."
         m 1huu "Anyway.{w=0.5}.{w=0.5}.{nw}"
@@ -2651,8 +2651,18 @@ label monika_aiwfc_song:
     $ disable_esc()
     $ mas_MUMURaiseShield()
 
-    $ play_song(None, 1.0)
+    # always unmute the music channel (or at least attempt to)
+    # TODO: there should probably be handling for sayori name case.
+    if songs.getVolume("music") == 0.0:
+        if songs.music_volume > 0.0:
+            $ mute_music()
+        else:
+            $ renpy.music.set_volume(1.0, channel="music")
+
+    # save background sound for later
     $ amb_vol = songs.getVolume("backsound")
+
+    $ play_song(None, 1.0)
     $ renpy.music.set_volume(0.0, 1.0, "background")
     $ renpy.music.set_volume(0.0, 1.0, "backsound")
 

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -2654,10 +2654,7 @@ label monika_aiwfc_song:
     # always unmute the music channel (or at least attempt to)
     # TODO: there should probably be handling for sayori name case.
     if songs.getVolume("music") == 0.0:
-        if songs.music_volume > 0.0:
-            $ mute_music()
-        else:
-            $ renpy.music.set_volume(1.0, channel="music")
+        $ renpy.music.set_volume(1.0, channel="music")
 
     # save background sound for later
     $ amb_vol = songs.getVolume("backsound")

--- a/Monika After Story/game/zz_music_selector.rpy
+++ b/Monika After Story/game/zz_music_selector.rpy
@@ -69,9 +69,8 @@ init -1 python in songs:
             direct = -1
 
         # volume checks
-        new_vol = _sanitizeVolume(getVolume(channel)+(direct*vol_bump))
-
-        renpy.music.set_volume(new_vol, channel=channel)
+        new_vol = _sanitizeVolume(getUserVolume(channel)+(direct*vol_bump))
+        setUserVolume(new_vol, channel)
 
 
     def getVolume(channel):
@@ -98,7 +97,10 @@ init -1 python in songs:
 
         RETURNS: value of the user slider for the audio channel (double/float)
         """
-        return renpy.audio.audio.get_channel(channel).actual_volume
+        return renpy.game.preferences.volumes.get(
+            renpy.audio.audio.get_channel(channel).mixer,
+            0.0
+        )
 
 
     def getPlayingMusicName():
@@ -1024,7 +1026,7 @@ init python:
             mute_enabled - True means we are allowed to mute.
                 False means we are not
         """
-        curr_volume = songs.getVolume("music")
+        curr_volume = songs.getUserVolume("music")
         # sayori cannot mute
         if (
                 curr_volume > 0.0 
@@ -1035,9 +1037,9 @@ init python:
                 and mute_enabled
             ):
             songs.music_volume = curr_volume
-            renpy.music.set_volume(0.0, channel="music")
+            songs.setUserVolume(0.0, "music")
         else:
-            renpy.music.set_volume(songs.music_volume, channel="music")
+            songs.setUserVolume(songs.music_volume, "music")
 
 
     def play_song(song, fadein=0.0, loop=True, set_per=False):


### PR DESCRIPTION
#5073 

### Cause
**There are three types of volumes:**
* preference volume - mixer slider in settings
* `chan_volume` - channel-specific volume with no known access/modification functions
* `context.secondary_volume` - volume that gets changed when using `set_volume`. for clarity, this will be referred to as channel volume

The `set_volume` function always [set secondary volume](https://github.com/renpy/renpy/blob/6.99.12.4.2187/renpy/audio/music.py#L411).
`getVolume` was changed to return `actual_volume`, which is a combination of `chan_volume` and the slider setting. Thus, music-selector based functions relying on the actual channel volume stopped working.

# Key Changes
* revert `songs.getVolume` back to returning `context.secondary_volume`
* new function `songs.getUserVolume` which returns the preference-based volume.
* new function `songs.setUserVolume` which allows for setting the preference-based volume. the existing `set_volume` functions should be used for normal channel-based volume setting.
* muting music and volume adjustment hotkeys have been changed to affect the volume-slider (preference-based volume) instead of channel volume.

**NOTE:** since we don't do anything with `chan_volume`, the secondary volume and preference-based volume should be enough to manipulate volume levels. 

**NOTE:** as a reminder:
* use `songs.getVolume` and `renpy.<audio/sound/music>.set_volume` to change volumes that the user cannot change
* use `songs.getUserVolume` and `songs.setUserVolume` to change volumes that the user **can** change.

# Testing
* verify muting (Shift+M) mutes and unmutes as it used too. this should affect the slider, but it won't be live (aka muting while the game  menu is open will not update it right away)
* verify volume adjustment hotkeys (+/-) change volume. this should affect the slider, but it wont be live (aka adjusting while the game menu is open will not update it right away)
* verify the aiwfc song (and its d25 lead-up) still works. 