### PR TITLE
Properly remove undo action rules

### DIFF
--- a/Monika After Story/game/event-rules.rpy
+++ b/Monika After Story/game/event-rules.rpy
@@ -836,7 +836,7 @@ init python:
                 True if we are past the stored end date and we need to
             """
             #NOTE: This should be used AFTER init 7
-            _start_date, _end_date = persistent._mas_undo_action_rules.get(ev.eventlabel)
+            _start_date, _end_date = persistent._mas_undo_action_rules.get(ev.eventlabel, (None, None))
 
             #Check for invalid data
             if not ev or not _start_date or not _end_date:
@@ -868,18 +868,13 @@ init python:
             return False
 
         @staticmethod
-        def check_persistent_rules(per_rules):
+        def check_persistent_rules():
             """
             Applies rules from persistent dict
 
             NOTE: uses mas_getEV
-
-            IN:
-                per_rules - persistent dict/list to get rules from
             """
-            remove_list = list()
-
-            for ev_label in per_rules:
+            for ev_label in persistent._mas_undo_action_rules.keys():
                 ev = mas_getEV(ev_label)
                 #Since we can have differing returns, we store this to use later
                 should_undo = MASUndoActionRule.evaluate_rule(ev)
@@ -888,13 +883,9 @@ init python:
                 if ev is not None and should_undo:
                     Event._undoEVAction(ev)
 
-                #We ended up getting a none, so we need to add the ev to a list of ons we need to remove
+                #If this is None, we need to pop due to bad data
                 elif should_undo is None:
-                    remove_list.append(ev)
-
-            #Now we go thru the items in remove list and remove their rules
-            for ev in remove_list:
-                MASUndoActionRule.remove_rule(ev)
+                    persistent._mas_undo_action_rules.pop(ev_label)
 
     class MASStripDatesRule(object):
         """

--- a/Monika After Story/game/event-rules.rpy
+++ b/Monika After Story/game/event-rules.rpy
@@ -836,14 +836,12 @@ init python:
                 True if we are past the stored end date and we need to
             """
             #NOTE: This should be used AFTER init 7
-            dates = persistent._mas_undo_action_rules.get(ev.eventlabel)
+            _start_date, _end_date = persistent._mas_undo_action_rules.get(ev.eventlabel)
 
-            if not ev or not dates:
-                #This ev doesn't exist and/or it doesn't exist in the rules dict, so no point checking this
-                return False
-
-            #Since these exist, let's unpack for easy usage
-            _start_date, _end_date = dates
+            #Check for invalid data
+            if not ev or not _start_date or not _end_date:
+                #This ev doesn't exist and/or it doesn't exist in the rules dict. We should set this to be removed
+                return None
 
             #Need to turn
             _now = datetime.datetime.now()

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1709,7 +1709,7 @@ label ch30_hour:
 label ch30_day:
     python:
         #Undo ev actions if needed
-        MASUndoActionRule.check_persistent_rules(persistent._mas_undo_action_rules)
+        MASUndoActionRule.check_persistent_rules()
         #And also strip dates
         MASStripDatesRule.check_persistent_rules(persistent._mas_strip_dates_rules)
 
@@ -2007,7 +2007,7 @@ label ch30_reset:
                 persistent.event_list.pop(index)
 
     #Now we undo actions for evs which need them undone
-    $ MASUndoActionRule.check_persistent_rules(persistent._mas_undo_action_rules)
+    $ MASUndoActionRule.check_persistent_rules()
     #And also strip dates
     $ MASStripDatesRule.check_persistent_rules(persistent._mas_strip_dates_rules)
 


### PR DESCRIPTION
Undo action rule removal as of 0.10.4 caused a dictionary changed size during iteration traceback due to poor placement of the remove_rule function call.

This fixes that and also runs a check to make sure we don't test on bad data if we have it in there for any reason.