### PR TITLE
Restart Blacklist Prop in AddEvent

### DIFF
--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -1020,17 +1020,7 @@ init -1 python in evhand:
     LAST_SEEN_DELTA = datetime.timedelta(hours=6)
 
     # restart topic blacklist
-    # TODO: consider an addEvent param instead
-    RESTART_BLKLST = [
-        "mas_crashed_start",
-        "monika_affection_nickname",
-        "mas_coffee_finished_brewing",
-        "mas_coffee_finished_drinking",
-        "monikaroom_will_change",
-        "monika_hair_select",
-        "monika_clothes_select",
-        "monika_rain_holdme",
-    ]
+    RESTART_BLKLST = []
 
     # idle topic whitelist
     IDLE_WHITELIST = [
@@ -1291,6 +1281,7 @@ init python:
             event,
             eventdb=None,
             skipCalendar=False,
+            restartBlacklist=False,
             code="EVE"
         ):
         #
@@ -1335,6 +1326,10 @@ init python:
         # NOTE: this covers time travel
         if not store.evhand.isYearsetBlacklisted(event.eventlabel):
             Event._verifyAndSetDatesEV(event)
+
+        # check whether we should add the event in the restart blacklist
+        if restartBlacklist:
+            evhand.RESTART_BLKLST.append(event.eventlabel)
 
         # now this event has passsed checks, we can add it to the db
         eventdb.setdefault(event.eventlabel, event)

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -1867,7 +1867,8 @@ init 5 python:
             unlocked=True,
             rules={"no unlock": None},
             aff_range=(mas_aff.AFFECTIONATE, None)
-        )
+        ),
+        restartBlacklist=True
     )
 
 default persistent._mas_called_moni_a_bad_name = False

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1192,6 +1192,7 @@ init 5 python:
             unlocked=False,
             rules=ev_rules,
         ),
+        restartBlacklist=True,
         code="GRE"
     )
 

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -739,6 +739,7 @@ init 5 python:
             category=[store.mas_greetings.TYPE_CRASHED],
             rules=ev_rules,
         ),
+        restartBlacklist=True,
         code="GRE"
     )
 
@@ -1320,7 +1321,8 @@ init 5 python:
             eventlabel="mas_coffee_finished_brewing",
             show_in_idle=True,
             rules={"skip alert": None}
-        )
+        ),
+        restartBlacklist=True
     )
 
 
@@ -1378,7 +1380,8 @@ init 5 python:
             eventlabel="mas_coffee_finished_drinking",
             show_in_idle=True,
             rules={"skip alert": None}
-        )
+        ),
+        restartBlacklist=True
     )
 
 

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -1824,7 +1824,8 @@ init 5 python:
             unlocked=False,
             rules={"no unlock":None},
             aff_range=(mas_aff.HAPPY, None)
-        )
+        ),
+        restartBlacklist=True
     )
 
 

--- a/Monika After Story/game/zz_selector.rpy
+++ b/Monika After Story/game/zz_selector.rpy
@@ -3282,7 +3282,8 @@ init 5 python:
             unlocked=False,
             rules={"no unlock": None},
             aff_range=(mas_aff.UPSET, mas_aff.NORMAL)
-        )
+        ),
+        restartBlacklist=True
     )
 
 label monika_event_clothes_select:
@@ -3456,7 +3457,8 @@ init 5 python:
             pool=True,
             unlocked=False,
             rules={"no unlock": None}
-        )
+        ),
+        restartBlacklist=True
     )
 
 label monika_ribbon_select:
@@ -3518,7 +3520,8 @@ init 5 python:
             unlocked=False,
             rules={"no unlock": None},
             aff_range=(mas_aff.HAPPY, None)
-        )
+        ),
+        restartBlacklist=True
     )
 
 label monika_hairclip_select:
@@ -3562,7 +3565,8 @@ init 5 python:
             unlocked=False,
             rules={"no unlock": None},
             aff_range=(mas_aff.HAPPY, None)
-        )
+        ),
+        restartBlacklist=True
     )
 
 label monika_hairflower_select:
@@ -3612,7 +3616,8 @@ init 5 python:
             unlocked=False,
             rules={"no unlock": None},
             aff_range=(mas_aff.HAPPY, None)
-        )
+        ),
+        restartBlacklist=True
     )
 
 label monika_choker_select:

--- a/Monika After Story/game/zz_selector.rpy
+++ b/Monika After Story/game/zz_selector.rpy
@@ -3196,7 +3196,8 @@ init 5 python:
             pool=True,
             unlocked=True,
             aff_range=(mas_aff.HAPPY, None)
-        )
+        ),
+        restartBlacklist=True
     )
 
 default persistent._mas_setting_ocb = False
@@ -3410,7 +3411,8 @@ init 5 python:
             pool=True,
             unlocked=False,
             rules={"no unlock": None}
-        )
+        ),
+        restartBlacklist=True
     )
 
 label monika_hair_select:


### PR DESCRIPTION
Adds a `restartBlacklist` prop in `addEvent` allowing us to add an event in the restart blacklist without having to edit the list itself.