### PR TITLE
birthdate year fix

### DIFF
--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -930,6 +930,7 @@ init -875 python in mas_delact:
 #        13: _mas_f14_monika_vday_cliches_reset,
 #        14: _mas_f14_monika_vday_chocolates_reset,
 #        15: _mas_f14_monika_vday_origins_reset,
+        16: _mas_birthdate_bad_year_fix,
     }
 
 

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -2083,3 +2083,61 @@ label mas_blazerless_intro:
         m 3eka "But if you miss my blazer, just ask and I'll put it back on."
 
     return "no_unlock"
+
+# fixes a rare case for unstable players that were able to confirm a birthdate with an invalid year
+label mas_birthdate_year_redux:
+    $ prev_bday = persistent._mas_player_bday
+    m 2eksdld "Uh [player]..."
+    m 2rksdlc "I have something to ask you, and it's kind of embarrassing..."
+    m 2eksdlc "You know when you told me your birthdate?"
+    m 2rksdld "Well, I think I messed up the year you were born somehow."
+    m 2eksdla "So, if you wouldn't mind telling me again..."
+    # fall thru
+
+label mas_birthdate_year_redux_select:
+    python:
+        end_year = datetime.date.today().year - 5
+        beg_year = end_year - 95
+
+        yearrange = range(beg_year,end_year)
+        yearrange.reverse()
+
+        yearmenu=[]
+        for y in yearrange:
+            yearmenu.append([str(y),y,False,False])
+
+    show monika 2eua at t21
+    $ renpy.say(m,"What year were you born?", interact=False)
+    call screen mas_gen_scrollable_menu(yearmenu,(evhand.UNSE_X, evhand.UNSE_Y, evhand.UNSE_W, 500), evhand.UNSE_XALIGN)
+
+    show monika 3eua at t11
+    m "Okay [player], you were born in [_return]?{nw}"
+    $ _history_list.pop()
+    menu:
+        m "Okay [player], you were born in [_return]?{fast}"
+
+        "Yes.":
+            m "Are you {i}sure{/i} you were born in [_return]?{nw}"
+            $ _history_list.pop()
+            menu:
+                m "Are you {i}sure{/i} you were born in [_return]?{fast}"
+
+                "Yes.":
+                    m 3hua "Okay, then it's settled!"
+                    $ persistent._mas_player_bday = datetime.date(_return,prev_bday.month,prev_bday.day)
+                    $ store.mas_player_bday_event.correct_pbday_mhs(selected_date)
+                    $ store.mas_history.saveMHSData()
+                    $ renpy.save_persistent()
+
+                "No.":
+                    call mas_birthdate_year_redux_no
+
+        "No.":
+            call mas_birthdate_year_redux_no
+
+    return
+
+label mas_birthdate_year_redux_no:
+    m 2ekd "Oh, okay..."
+    m 2eka "Try again, [player]."
+    jump mas_birthdate_year_redux_select

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -2084,6 +2084,21 @@ label mas_blazerless_intro:
 
     return "no_unlock"
 
+init -876 python in mas_delact:
+
+    def _mas_birthdate_bad_year_fix_action(ev=None):
+        store.queueEvent("mas_birthdate_year_redux")
+        return True
+
+    def _mas_birthdate_bad_year_fix():
+        return store.MASDelayedAction.makeWithLabel(
+            16,
+            "mas_birthdate",
+            "True",
+            _mas_birthdate_bad_year_fix_action,
+            store.MAS_FC_IDLE_ONCE
+        )
+
 # fixes a rare case for unstable players that were able to confirm a birthdate with an invalid year
 label mas_birthdate_year_redux:
     m 2eksdld "Uh [player]..."

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -2086,7 +2086,6 @@ label mas_blazerless_intro:
 
 # fixes a rare case for unstable players that were able to confirm a birthdate with an invalid year
 label mas_birthdate_year_redux:
-    $ prev_bday = persistent._mas_player_bday
     m 2eksdld "Uh [player]..."
     m 2rksdlc "I have something to ask you, and it's kind of embarrassing..."
     m 2eksdlc "You know when you told me your birthdate?"
@@ -2124,8 +2123,8 @@ label mas_birthdate_year_redux_select:
 
                 "Yes.":
                     m 3hua "Okay, then it's settled!"
-                    $ persistent._mas_player_bday = datetime.date(_return,prev_bday.month,prev_bday.day)
-                    $ store.mas_player_bday_event.correct_pbday_mhs(selected_date)
+                    $ persistent._mas_player_bday = persistent._mas_player_bday.replace(year=_return)
+                    $ store.mas_player_bday_event.correct_pbday_mhs(persistent._mas_player_bday)
                     $ store.mas_history.saveMHSData()
                     $ renpy.save_persistent()
 

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -431,7 +431,7 @@ label v0_10_6(version="v0_10_6"):
 
         # add a delayed action to push birthday fix if required
         birthdate_ev = mas_getEV("mas_birthdate")
-        bday = mas_player_bday_curr()
+        bday = persistent._mas_player_bday
         if (
                 birthdate_ev is not None
                 and birthdate_ev.last_seen is not None

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -429,6 +429,23 @@ label v0_10_6(version="v0_10_6"):
                     if year not in years_list:
                         persistent._mas_history_archives[year]["player_bday.saw_surprise"] = True
 
+        # add a delayed action to push birthday fix if required
+        birthdate_ev = mas_getEV("mas_birthdate")
+        bday = mas_player_bday_curr()
+        if (
+                birthdate_ev is not None
+                and birthdate_ev.last_seen is not None
+                and bday is not None
+        ):
+            seen_year = birthdate_ev.last_seen.year
+
+            # if you havent seen 090, then you are unaffected
+            # if ur birthdate is normal (not less than 5 years of age from the
+            #   time the date could have been set), then you're
+            #   probably unaffected
+            if renpy.seen_label("v0_9_0") and seen_year - bday.year < 5:
+                mas_addDelayedAction(16)
+
     return
 
 #0.10.5

--- a/Monika After Story/game/updates_topics.rpy
+++ b/Monika After Story/game/updates_topics.rpy
@@ -114,7 +114,7 @@ label vv_updates_topics:
         # update this dict accordingly to every new version
         # k:old version number -> v:new version number
         # some version changes skip some numbers because no major updates
-        #updates.version_updates[vv_0_10_5] = vv0_10_6
+        #updates.version_updates[vv0_10_5] = vv0_10_6
         updates.version_updates[vv0_10_4] = vv0_10_5
         updates.version_updates[vv0_10_3] = vv0_10_4
         updates.version_updates[vv0_10_2] = vv0_10_3


### PR DESCRIPTION
#5214

During the first unstable build (82) that included the player birthday event code, it was possible to confirm a birthdate with an invalid year. This will check if the player has an invalid birthdate year, and if so, have the player change it to the correct year.

~~The event itself is being committed first. The update script will be added later and testing instructions will be added at that time.~~

The criteria for triggering the dialogue is having seen the `v0_9_0` update script label and having a bad bdate.

# Testing
**NOTE:** calling the update label will work, but the birthdate selection dialogue will not trigger until a relaunch, so its better to do the standard update instructions:

1. launch game without changes
2. ensure that `persistent._mas_player_bday` and the `last_seen` property of the `mas_birthdate` event are within 5 years of each other.
3. ensure that your persistent has `v0_9_0` seen: (`persistent._seen_ever["v0_9_0"] = True`)
4. ensure that your persistent's `version_number` is set to 0.10.5 or earlier
5. close game and add changes
6. uncomment lines 68 and 117 in `updates_topics.rpy` 
7. change the `version` in `options.rpy` to `0.10.6`
8. launch game.
9. verify that after the greeting, the birthdate reselection dialogue is triggered
10. verify that selecting a year updates `persistent._mas_player_bday` appropriately.