### PR TITLE
Default ex_props to None

### DIFF
--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -5904,7 +5904,7 @@ init -2 python:
                     (Default: None)
                 ex_props - dict of additional properties to apply to this
                     sprite object.
-                    (Default: empty dict)
+                    (Default: None)
             """
             self.__sp_type = -1
             self.name = name
@@ -5919,6 +5919,7 @@ init -2 python:
             if type(pose_map) != MASPoseMap:
                 raise Exception("PoseMap is REQUIRED")
 
+            #sets the ex_props to an empty dict if ex_props is None
             if ex_props is None:
                 self.ex_props = {}
             else:
@@ -6093,7 +6094,7 @@ init -2 python:
                     (Default: None)
                 ex_props - dict of additional properties to apply to this
                     sprite object.
-                    (Default: empty dict)
+                    (Default: None)
             """
             super(MASSpriteFallbackBase, self).__init__(
                 name,
@@ -6234,7 +6235,7 @@ init -2 python:
                     (Default: None)
                 ex_props - dict of additional properties to apply to this
                     sprite object.
-                    (Default: empty dict)
+                    (Default: None)
                 arm_split - MASPoseMap object for determining arm splits. See
                     property list above for more info.
                 dlg_data - tuple of the following format:
@@ -6411,7 +6412,7 @@ init -2 python:
                     (Default: None)
                 ex_props - dict of additional properties to apply to this
                     sprite object.
-                    (Default: empty dict)
+                    (Default: None)
             """
             super(MASHair, self).__init__(
                 name,
@@ -6532,7 +6533,7 @@ init -2 python:
                     (Default: None)
                 ex_props - dict of additional properties to apply to this
                     sprite object.
-                    (Default: empty dict)
+                    (Default: None)
                 pose_arms - MASPoseMap object represneting the arm layers
                     for poses. If None is passed, we assume use the base
                     layers as a guide

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -5878,7 +5878,7 @@ init -2 python:
                 stay_on_start=False,
                 entry_pp=None,
                 exit_pp=None,
-                ex_props={}
+                ex_props=None
             ):
             """
             MASSpriteBase constructor
@@ -5914,11 +5914,15 @@ init -2 python:
             self.pose_map = pose_map
             self.entry_pp = entry_pp
             self.exit_pp = exit_pp
-            self.ex_props = ex_props
             self.is_custom = False
 
             if type(pose_map) != MASPoseMap:
                 raise Exception("PoseMap is REQUIRED")
+
+            if ex_props is None:
+                self.ex_props = {}
+            else:
+                self.ex_props = ex_props
 
 
         def __eq__(self, other):
@@ -6061,7 +6065,7 @@ init -2 python:
                 fallback=False,
                 entry_pp=None,
                 exit_pp=None,
-                ex_props={}
+                ex_props=None
             ):
             """
             MASSpriteFallbackBase constructor
@@ -6187,7 +6191,7 @@ init -2 python:
                 exit_pp=None,
                 acs_type=None,
                 mux_type=None,
-                ex_props={},
+                ex_props=None,
                 arm_split=None,
                 dlg_data=None,
             ):
@@ -6377,7 +6381,7 @@ init -2 python:
                 entry_pp=None,
                 exit_pp=None,
                 split=None,
-                ex_props={}
+                ex_props=None
             ):
             """
             MASHair constructor
@@ -6494,7 +6498,7 @@ init -2 python:
                 hair_map={},
                 entry_pp=None,
                 exit_pp=None,
-                ex_props={},
+                ex_props=None,
                 pose_arms=None
             ):
             """


### PR DESCRIPTION
Currently, empty dicts in the constructors of objects will keep the same instance over all objects created from the constructor. Meaning if any of them are changed, all of them change.

This defaults the `ex_props` of the constructors to `None` and sets it to an empty dict if it's `None` in the MASSpriteBase constructor.

## Testing
- Verify that only the intended `ex_props` are applied to the objects.
- Verify that everything still works.