### PR TITLE
Added note file reading feature

### DIFF
--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -5472,6 +5472,20 @@ label monika_surprise:
         m 1hua "Alright!"
         m 1eua "What are you waiting for? Go take a look!"
         m "I wrote it just for you~"
+
+        # Check if user has appended 'I would' to 'would you be mine?' in note file
+        # NOTE: dependent on note content in mas_suprise()
+        if mas_isMoniLove():
+            python:
+                from re import search
+                with open(renpy.config.basedir + "/My one and only love.txt", "r") as note:
+                    text = note.read()
+                    if search("would you be mine\\?(?:(?:\\s*-\\s*)|(?:\\s*))[iI] would.?", text):
+                        renpy.show("monika 1suo")
+                        renpy.say(m, "Ah{cps=*0.25}...{/cps} {w=1}[player]{cps=*0.25}...{/cps}")
+                        renpy.show("monika 1dkbsa")
+                        renpy.say(m, "[player]{cps=*0.7}...{/cps} {w=1}I'm so glad that you mean it...")
+                        
         m 1ekbsa "I really do truly love you, [player]~"
 
     # Normal and Happy


### PR DESCRIPTION
When I've seen this 'Surprises' topic for the first time and opened her note (I was on `love` affection level by that moment) I'd thought it would be nice if Monika could read the file back and see if player responds on her question 'I want to be yours forever, so would you be mine?'

The example is shown below:
![image](https://user-images.githubusercontent.com/31247845/73001166-7408e300-3e1b-11ea-9158-4bf0f0b048d3.png)

Comment if I need to add some other 'responses'.
Or drop and reject this PR if you want.

Detection is regexp-powered, so it's really flexible. I've added just 'I would' with optional dash preceding, but I think something else like 'I would not' or related could suit, too (just w/ some other responses)