### PR TITLE
Adding selector configuration for disabling a selector

### DIFF
--- a/Monika After Story/game/dev/dev_selector.rpy
+++ b/Monika After Story/game/dev/dev_selector.rpy
@@ -261,3 +261,55 @@ label dev_selector_acs_ribbons_test:
 
     return
 
+
+init 5 python:
+    addEvent(
+        Event(
+            persistent.event_database,
+            eventlabel="dev_selector_hair_disabled",
+            category=["dev"],
+            prompt="TEST SELECTOR (disabling hair bc clothes)",
+            pool=True,
+            unlocked=True
+        )
+    )
+
+label dev_selector_hair_disabled:
+    python:
+        hdown_sel = store.mas_selspr.get_sel_hair(mas_hair_down)
+        hdown_sel_lstat = hdown_sel.unlocked
+        hdown_sel.unlocked = True
+        hdown_sel.disable_type = store.mas_selspr.DISB_HAIR_BC_CLOTH
+
+        unlock_map = {}
+        sorted_hair = store.mas_selspr.HAIR_SEL_SL
+        for item in sorted_hair:
+            unlock_map[item.name] = item.unlocked
+            item.unlocked = True
+
+        mailbox = store.mas_selspr.MASSelectableSpriteMailbox(
+            "Which hairstyle would you like me to wear?"
+        )
+        sel_map = {}
+
+    m 1eua "first reset outfit"
+    $ current_state = monika_chr.save_state(True, True, True)
+    $ monika_chr.reset_outfit()
+    $ monika_chr.remove_all_acs()
+
+    m 1eua "I will disable hair down for no reason"
+
+    call mas_selector_sidebar_select_hair(sorted_hair, mailbox=mailbox, select_map=sel_map)
+
+    # undo unlocks
+    python:
+        for item in sorted_hair:
+            item.unlocked = unlock_map[item.name]
+
+        hdown_sel.unlocked = hdown_sel_lstat
+
+    m 6eua "now restore outfit"
+    $ monika_chr.restore(current_state)
+    m 1eua "done"
+
+    return

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -1420,6 +1420,12 @@ init -5 python in mas_sprites:
                 temp_storage["hair.ribbon"] = prev_ribbon
 
             moni_chr.wear_acs(ACS_MAP[desired_ribbon])
+
+        # if current hair is incompatible, swap to def. 
+        # NOTE: we will enforce def has a hairstyle that all clothing
+        #   items MUST work with.
+        if not is_clotheshair_compatible(new_cloth, moni_chr.hair):
+            moni_chr.reset_hair(False)
     
     
     def hair_exit_pre_change(temp_space, moni_chr, prev_hair, new_hair):

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -338,6 +338,21 @@ init -100 python in mas_sprites:
     # v: ignored
     # marks that a hair style is a twintails style
 
+    EXP_H_RQCP = "required-clothes-prop"
+    # v: string
+    # marks that a hair style requires clothes with the value'd prop to be worn
+
+    EXP_H_EXCLCP = "excluded-clothes-props"
+    # v: list of strings
+    # marks that a hair style requires clothes with none of hte value'd props
+    # to be worn
+
+    # ---- CLOTHES ----
+
+    EXP_C_BRS = "bare-right-shoulder"
+    # v: ignored
+    # marks that a clothing item has a bare right shoulder
+
     # --- default exprops ---
     DEF_EXP_TT_EXCL = [EXP_H_TT]
 
@@ -1511,17 +1526,44 @@ init -5 python in mas_sprites:
         IN:
             hair - hair to check
             acs - acs to check
+
+        RETURNS: True if hair+acs is compatible, False if not
         """
         # first check for required hair prop
         req_hair_prop = acs.getprop(EXP_A_RQHP, None)
         if req_hair_prop is not None and not hair.hasprop(req_hair_prop):
             return False
 
-        # then chceck exclusions
+        # then check exclusions
         excl_hair_props = acs.getprop(EXP_A_EXCLHP, None)
         if excl_hair_props is not None:
             for excl_hair_prop in excl_hair_props:
                 if hair.hasprop(excl_hair_prop):
+                    return False
+
+        return True
+
+
+    def is_clotheshair_compatible(clothes, hair):
+        """
+        Checks if the given clothes is compatible with the given hair
+
+        IN:
+            clothes - clothes to check
+            hair - hair to check
+
+        RETURNS: True if clothes+hair is comaptible, False if not
+        """
+        # first check for required clothes prop
+        req_cloth_prop = hair.getprop(EXP_H_RQCP, None)
+        if req_cloth_prop is not None and not clothes.hasprop(req_cloth_prop):
+            return False
+
+        # then check exclusions
+        excl_cloth_props = hair.getprop(EXP_H_EXCLCP, None)
+        if excl_cloth_props is not None:
+            for excl_cloth_prop in excl_cloth_props:
+                if clothes.hasprop(excl_cloth_prop):
                     return False
 
         return True

--- a/Monika After Story/game/zz_selector.rpy
+++ b/Monika After Story/game/zz_selector.rpy
@@ -605,10 +605,9 @@ init -10 python in mas_selspr:
     disable_sel_dlg_quips = {
         DISB_NONE: None,
         DISB_HAIR_BC_CLOTH: [
-            (
-                "I cannot change my hair to that style because it is "
-                "incompatible with my clothes."
-            ),
+            "That hairstyle doesn't really work with my clothes.",
+            "I don't think this hairstyle really works with this outfit.",
+            "That hairstyle doesn't really work with this outfit."
         ],
     }
 

--- a/Monika After Story/game/zz_selector.rpy
+++ b/Monika After Story/game/zz_selector.rpy
@@ -2594,8 +2594,9 @@ init -1 python:
 #                            renpy.redraw(self, 0)
 
             # apply hover dialogue logic if not selected
-            if not self.selected and not self.locked:
-                self._hover()
+            # NOTE: keep around in case of accessibility concerns.
+            #if not self.selected and not self.locked:
+            #    self._hover()
 
             if self.end_interaction:
                 self.end_interaction = False

--- a/Monika After Story/game/zz_selector.rpy
+++ b/Monika After Story/game/zz_selector.rpy
@@ -2094,15 +2094,16 @@ init -1 python:
                 renpy.play(gui.hover_sound, channel="sound")
 
                 # send out hover dlg
-                if self.selectable.hover_dlg is not None:
-                    self._send_hover_text()
-                    self.end_interaction = True
-
-                else:
-                    self.mailbox.send_disp_fast()
-
-                # always reset on a hover
-                self.end_interaction = True
+                # NOTE: keep in case we want hover text again
+#                if self.selectable.hover_dlg is not None:
+#                    self._send_hover_text()
+#                    self.end_interaction = True
+#
+#                else:
+#                    self.mailbox.send_disp_fast()
+#
+#                # always reset on a hover
+#                self.end_interaction = True
 
 
         def _hypen_render_split(self, line, lines_list, st, at, tokens=None):
@@ -2594,9 +2595,8 @@ init -1 python:
 #                            renpy.redraw(self, 0)
 
             # apply hover dialogue logic if not selected
-            # NOTE: keep around in case of accessibility concerns.
-            #if not self.selected and not self.locked:
-            #    self._hover()
+            if not self.selected and not self.locked:
+                self._hover()
 
             if self.end_interaction:
                 self.end_interaction = False

--- a/Monika After Story/game/zz_spritejsons.rpy
+++ b/Monika After Story/game/zz_spritejsons.rpy
@@ -1611,16 +1611,17 @@ init 189 python in mas_sprites_json:
 
         # now for list based
         if "hover_dlg" in select_info:
-            if not _validate_iterstr(
-                select_info,
-                save_obj,
-                "hover_dlg",
-                False,
-                True,
-                msg_log,
-                indent_lvl + 1
-            ):
-                return False
+            select_info.pop("hover_dlg")
+#            if not _validate_iterstr(
+#                select_info,
+#                save_obj,
+#                "hover_dlg",
+#                False,
+#                True,
+#                msg_log,
+#                indent_lvl + 1
+#            ):
+#                return False
 
         if "select_dlg" in select_info:
             if not _validate_iterstr(


### PR DESCRIPTION
# Key Changes
* Adds a configuration option with selector objects that allows them to be appear disabled in a selector
* Disables all hover dialogue in selectors (includes spritejson parsing)
* Removed unused hair dialogue labels (`monika_hair_down` and `monika_hair_ponytail`)

## Disabled selector UI/UX
A disabled selector will appear grey. The thumbnail will continue to be the same as if it were an active selector.

Clicking a disabled selector will trigger the `gui.activate_sound_glitch` sound and show a disabled text quip based on the type of disabled mode the selector is in (More on that below). This text quip will always be shown `{fast}`. A disabled selector cannot be selected and will not react when hovered.

## Disabled selector mechanics
Each `MASSelectableImageButtonDisplayable` accepts a `disable_type` in its constructor. The `disable_type` is a type that specifies which disable dialogue should be shown. The list of available dialogue is in `mas_selspr.disable_sel_dlg_quips`.

There are currently two types of `disable_type` constants:
* `DISB_NONE` - item is not disabled
* `DISB_HAIR_BC_CLOTH` - hair item is disabled because of current clothes

`disable_type` for `MASSelectableImageButtonDisplayable` is set using a `MASSelectableSprite`'s `disable_type`, which is a new, non-constructable property for each selector item. This property should only be set in selector labels to mark if a selector should be disabled. This property will not be saved and should not be set manually outside of selector labels. Examples of usage are in `monika_hair_select`.

## Other changes
* dev label for testing disabled selectors (`TEST SELECTOR (disabling hair bc clothes)`)

## Ignorable changes
* exprops `required-clothes-prop`, `excluded-clothes-props`, `bare-right-shoulder` - these will be tested with NewMarisa changes
* function `mas_sprites.is_clotheshair_compatible` - will be tested with NewMarisa changes

# Testing

### Disabled selectors
* Use the new dev label to test disabled selector
* feel free to add/change dialogue shown when clicking a disabled selector

### Disabled hover dlg
* verify that no hover dialogue is shown when hovering over selectors (`marisa`/`rin` clothes are a good test)
* verify that spj logs do **not** show warnings for `hover_dlg` properties in sprite jsons nor do they show errors for invalid `hover_dlg` properties