### PR TITLE
No Unlock rule for song pool delegate

### DIFF
--- a/Monika After Story/game/script-songs.rpy
+++ b/Monika After Story/game/script-songs.rpy
@@ -92,7 +92,8 @@ init 5 python:
             pool=True,
             conditional="store.mas_songs.hasUnlockedSongs()",
             action=EV_ACT_UNLOCK,
-            aff_range=(mas_aff.NORMAL,None)
+            aff_range=(mas_aff.NORMAL,None),
+            rules={"no unlock": None}
         )
     )
 

--- a/Monika After Story/game/script-songs.rpy
+++ b/Monika After Story/game/script-songs.rpy
@@ -171,18 +171,18 @@ init 5 python:
     )
 
 label monika_sing_song_random:
-    #Unlock pool delegate
-    $ mas_unlockEVL("monika_sing_song_pool", "EVE")
-
     #We only want short songs in random. Long songs should be unlocked by default or have another means to unlock
     #Like a "preview" version of it which unlocks the full song in the pool delegate
     if mas_songs.hasRandomSongs():
         python:
+            #Unlock pool delegate
+            mas_unlockEVL("monika_sing_song_pool", "EVE")
+
             rand_song = renpy.random.choice(mas_songs.getRandomSongs())
             pushEvent(rand_song, skipeval=True, notify=True)
             mas_unlockEVL(rand_song, "SNG")
 
-            # unlock the long version of the song
+            #Unlock the long version of the song
             mas_unlockEVL(rand_song+"_long","SNG")
 
     #We have no songs! let's pull back the shown count for this and derandom

--- a/Monika After Story/game/script-songs.rpy
+++ b/Monika After Story/game/script-songs.rpy
@@ -90,8 +90,6 @@ init 5 python:
             prompt="Can you sing me a song?",
             category=["music"],
             pool=True,
-            conditional="store.mas_songs.hasUnlockedSongs()",
-            action=EV_ACT_UNLOCK,
             aff_range=(mas_aff.NORMAL,None),
             rules={"no unlock": None}
         )
@@ -173,6 +171,9 @@ init 5 python:
     )
 
 label monika_sing_song_random:
+    #Unlock pool delegate
+    $ mas_unlockEVL("monika_sing_song_pool", "EVE")
+
     #We only want short songs in random. Long songs should be unlocked by default or have another means to unlock
     #Like a "preview" version of it which unlocks the full song in the pool delegate
     if mas_songs.hasRandomSongs():

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -376,8 +376,7 @@ label v0_10_8(version="v0_10_8"):
         if song_pool_ev:
             song_pool_ev.conditional = None
             song_pool_ev.action = None
-            if not mas_songs.hasUnlockedSongs():
-                song_pool_ev.unlocked = False
+            song_pool_ev.unlocked = mas_songs.hasUnlockedSongs()
 
     return
 

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -371,8 +371,13 @@ label v0_3_1(version=version): # 0.3.1
 #0.10.8
 label v0_10_8(version="v0_10_8"):
     python:
-        if not mas_songs.hasUnlockedSongs():
-            mas_lockEVL("monika_sing_song_pool", "EVE")
+        #Fix the song pool delegate
+        song_pool_ev = mas_getEV("monika_sing_song_pool")
+        if song_pool_ev:
+            song_pool_ev.conditional = None
+            song_pool_ev.action = None
+            if not mas_songs.hasUnlockedSongs():
+                song_pool_ev.unlocked = False
 
     return
 

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -368,6 +368,14 @@ label v0_3_1(version=version): # 0.3.1
     return
 
 # non generic updates go here
+#0.10.8
+label v0_10_8(version="v0_10_8"):
+    python:
+        if not mas_songs.hasUnlockedSongs():
+            mas_lockEVL("monika_sing_song_pool", "EVE")
+
+    return
+
 #0.10.7
 label v0_10_7(version="v0_10_7"):
     python:

--- a/Monika After Story/game/updates_topics.rpy
+++ b/Monika After Story/game/updates_topics.rpy
@@ -65,6 +65,7 @@ label vv_updates_topics:
 
         # versions
         # use the v#_#_# notation so we can work with labels
+        vv0_10_8 = "v0_10_8"
         vv0_10_7 = "v0_10_7"
         vv0_10_6 = "v0_10_6"
         vv0_10_5 = "v0_10_5"
@@ -115,6 +116,7 @@ label vv_updates_topics:
         # update this dict accordingly to every new version
         # k:old version number -> v:new version number
         # some version changes skip some numbers because no major updates
+        #updates.version_updates[vv0_10_7] = vv0_10_8
         updates.version_updates[vv0_10_6] = vv0_10_7
         updates.version_updates[vv0_10_5] = vv0_10_6
         updates.version_updates[vv0_10_4] = vv0_10_5


### PR DESCRIPTION
Songs pool delegate would unlock on its own because it's a pool topic so the algo keeps trying to find things to unlock. 

The pool delegate for songs didn't have a `"no unlock"` rule and it was unlocked before any songs were seen. This fixes that, and locks it again if it shouldn't be unlocked.

## Testing:
- Verify that if no songs are unlocked, the pool delegate does not unlock
- Verify that if the pool delegate is unlocked and there are no unlocked songs, the update script will lock it