### PR TITLE
hotkey interruption fix

### DIFF
--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -2375,7 +2375,6 @@ label mas_affection_yesapology:
     m 1duu "Thank you for putting my heart at ease~"
     show monika 1esa
     $ mas_DropShield_core()
-    $ set_keymaps()
     jump ch30_preloop
 
 label mas_affection_apologydeleted:

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -926,6 +926,9 @@ label ch30_main:
     # set session data to startup values
     $ store._mas_root.initialSessionData()
 
+    # skip weather
+    $ skip_setting_weather = True
+
     # lastly, rebuild Event lists for new people if not built yet
     if not mas_events_built:
         $ mas_rebuildEventLists()

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -52,13 +52,13 @@ init -1 python in mas_globals:
     late_farewell = False
     # set to True if we had a late farewell
 
-    last_minute_dt = None
+    last_minute_dt = datetime.datetime.now()
     # last minute datetime (replaces calendar_last_chcked)
 
-    last_hour = None
+    last_hour = last_minute_dt.hour
     # number of the hour we last ran ch30_hour
 
-    last_day = None
+    last_day = last_minute_dt.day
     # numbr of the day we last ran ch30_day
 
     returned_home_this_sesh = bool(store.persistent._mas_moni_chksum)
@@ -1382,36 +1382,18 @@ label ch30_post_exp_check:
     # else:
     #     $ config.allow_skipping = False
 
-    window auto
-
-    if mas_skip_visuals:
-        # need to jump to initial setup, then we can jump to visual skip
-        jump ch30_preloop
-
-    # otherwise, we are NOT skipping visuals
-    $ set_keymaps()
-    $ mas_startup_song()
-
-    # rain check
-    # TODO: the weather progression alg needs to run here
-    # TODO: we actually might want to move this to preloop visual
-    #   setup as that makes more sense.
-    if not mas_weather.force_weather and not skip_setting_weather:
-        $ set_to_weather = mas_shouldRain()
-        if set_to_weather is not None:
-            $ mas_changeWeather(set_to_weather)
-
-    # FALL THROUGH
-
-label ch30_preloop_visualsetup:
-
-    # initial spaceroom
-    call spaceroom(dissolve_all=True, scene_change=True)
-
     # FALL THROUGH
 
 label ch30_preloop:
     # stuff that should happen right before we enter the loop
+
+    window auto
+
+    # NOTE: keymaps will be set, but all actions will be shielded unless
+    #   desired by the appropriate flow.
+    $ mas_HKRaiseShield()
+    $ mas_HKBRaiseShield()
+    $ set_keymaps()
 
     $ persistent.closed_self = False
     $ persistent._mas_game_crashed = True
@@ -1442,6 +1424,19 @@ label ch30_preloop:
         $ mas_skip_visuals = False
         $ quick_menu = True
         jump ch30_visual_skip
+
+    # setup scene to change on initial launch
+    $ mas_weather.should_scene_change = True
+
+    # rain check
+    # TODO: the weather progression alg needs to run here
+    if not mas_weather.force_weather and not skip_setting_weather:
+        $ set_to_weather = mas_shouldRain()
+        if set_to_weather is not None:
+            $ mas_changeWeather(set_to_weather)
+
+    # otherwise, we are NOT skipping visuals
+    $ mas_startup_song()
 
     jump ch30_loop
 
@@ -1523,6 +1518,14 @@ label ch30_post_mid_loop_eval:
 
     #Call the next event in the list
     call call_next_event from _call_call_next_event_1
+
+    # renable if not idle and currently disabled
+    if not mas_globals.in_idle_mode:
+        if not mas_HKIsEnabled():
+            $ mas_HKDropShield()
+        if not mas_HKBIsEnabled():
+            $ mas_HKBDropShield()
+
     # Just finished a topic, so we set current topic to 0 in case user quits and restarts
     $ persistent.current_monikatopic = 0
 

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -920,12 +920,6 @@ label ch30_main:
     # 1 - renable core interactions
     $ mas_DropShield_core()
 
-    # 2 - hotkey buttons enabled
-    $ store.hkb_button.enabled = True
-
-    # 3 - set keymaps
-    $ set_keymaps()
-
     # now we out of intro
     $ mas_in_intro_flow = False
 

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1102,8 +1102,8 @@ label i_greeting_monikaroom:
     # 1 - if you quit here, monika doesnt know u here
     $ mas_enable_quit()
 
-    # 2 - music button + hotkeys should be disabled
-    $ store.mas_hotkeys.music_enabled = False
+    # all UI elements stopped
+    $ mas_RaiseShield_core()
 
     # 3 - keymaps not set (default)
     # 4 - overlays hidden (skip visual)
@@ -1780,7 +1780,7 @@ label monikaroom_greeting_cleanup:
         mas_disable_quit()
 
         # 2 - music is renabled
-        store.mas_hotkeys.music_enabled = True
+        mas_MUMUDropShield()
 
         # 3 - keymaps should be set
         set_keymaps()
@@ -2454,12 +2454,8 @@ init 5 python:
 label greeting_hairdown:
 
     # couple of things:
-    # 1 - music hotkeys should be disabled
-    $ store.mas_hotkeys.music_enabled = False
-
-    # 2 - the calendar overlay will become visible, but we should keep it
-    # disabled
-    $ mas_calRaiseOverlayShield()
+    # shield ui
+    $ mas_RaiseShield_core()
 
     # 3 - keymaps not set (default)
     # 4 - hotkey buttons are hidden (skip visual)
@@ -2514,11 +2510,8 @@ label greeting_hairdown:
     $ mas_lockEvent(mas_getEV("greeting_hairdown"))
 
     # cleanup
-    # 1 - music hotkeys should be enabled
-    $ store.mas_hotkeys.music_enabled = True
-
-    # 2 - calendarovrelay enabled
-    $ mas_calDropOverlayShield()
+    # enable music menu
+    $ mas_MUMUDropShield()
 
     # 3 - set the keymaps
     $ set_keymaps()

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -730,6 +730,7 @@ label mas_monikai_detected:
 init 5 python:
     ev_rules = {}
     ev_rules.update(MASGreetingRule.create_rule(skip_visual=True))
+    ev_rules.update(MASPriorityRule.create_rule(-1))
 
     addEvent(
         Event(

--- a/Monika After Story/game/script.rpy
+++ b/Monika After Story/game/script.rpy
@@ -30,11 +30,8 @@ label start:
     #Jump to the space room.
     if persistent.autoload:
         #Stop the title screen music
-        if persistent.current_track:
-            $ mas_startup_song()
-        else:
-            stop music
-        jump ch30_preloop_visualsetup
+        stop music
+        jump ch30_preloop
     jump ch30_main
 
 label endgame(pause_length=4.0):

--- a/Monika After Story/game/zz_hotkeys.rpy
+++ b/Monika After Story/game/zz_hotkeys.rpy
@@ -265,5 +265,3 @@ init python:
         config.underlay.append(renpy.Keymap(derandom_topic=_mas_hk_derandom_topic))
         config.underlay.append(renpy.Keymap(bookmark_topic=_mas_hk_bookmark_topic))
 
-        # finally enable those buttons
-        mas_HKDropShield()


### PR DESCRIPTION
fixes #5406 

Cause of above issue was hotkey keymaps being set and enabled before spaceroom was loaded and greeting shown. Hotkeys can cause jumps, which breaks startup flow and allows vars set in `ch30_preloop` to remain undefined.

# Key Changes
* disabled hotkeys from start until the all topics/greeting in event list have ended **except** for music menu in cases where greetings skip visuals (monikaroom/hair down/etc..)
* those hotkeys are renabled after returning to `ch30_loop` from topics (`call_next_event`) if not in idle mode
* Rearranges some of visual setup startup to be less 🍝 
* Sets certain global vars on init to avoid dt-None operations

# Testing

## issue
1. Launch game
2. As soon as the game window appears (even with nothing in the window), spam hotkeys. 
3. Verify that no hotkey is responsive until **after** the greeting + any initial topics 
4. Repeat steps 1-3 but try clicking on the hotkey buttons (clicking in the area they would load). They should also not be responsive until **after** the greeting + any initial topics.
5. Additionally, verify no datetime + None operation crash after using a hotkey.

The above steps should also be tried with:
* returned home greeting
* open door greeting
* hairdown greeting

## regression
* verify that when in idle mode, hotkeys should be disabled and the "Play" button should be disabled.
* verify intro flow enables hotkeys/buttons as usual (after greeting + initial topics)