### PR TITLE
Extra consumables cleanup

### DIFF
--- a/Monika After Story/game/script-farewells.rpy
+++ b/Monika After Story/game/script-farewells.rpy
@@ -1021,7 +1021,7 @@ label bye_going_somewhere_iowait:
 
             #Show Monika again
             call mas_transition_from_emptydesk("monika 1ekc")
-
+            call mas_dockstat_abort_post_show
             jump bye_going_somewhere_leavemenu
 
         "Nothing.":
@@ -1053,6 +1053,7 @@ label bye_going_somewhere_rtg:
 
 
     call mas_transition_from_emptydesk("monika 1ekc")
+    call mas_dockstat_abort_post_show
 
     # otherwise, we failed, so monika should tell player
     m 1ekc "Oh no..."

--- a/Monika After Story/game/zz_consumables.rpy
+++ b/Monika After Story/game/zz_consumables.rpy
@@ -1404,8 +1404,11 @@ label mas_consumables_remove_thermos:
     $ thermos = monika_chr.get_acs_of_type("thermos-mug")
     call mas_transition_to_emptydesk
 
-    #Remove the current thermos
-    $ monika_chr.remove_acs(thermos)
+    python:
+        renpy.pause(3.0, hard=True)
+        #Remove the current thermos
+        monika_chr.remove_acs(thermos)
+        renpy.pause(2.0, hard=True)
 
     call mas_transition_from_emptydesk("monika 1eua")
 

--- a/Monika After Story/game/zz_consumables.rpy
+++ b/Monika After Story/game/zz_consumables.rpy
@@ -1197,17 +1197,18 @@ label mas_consumables_generic_get(consumable):
         m 1eua "I'm going to get a [consumable.container] of [consumable.disp_name]."
         m 1eua "Hold on a moment."
 
+    #We want to take plush with
+    if (
+        consumable.consumable_type == store.mas_consumables.TYPE_FOOD
+        and monika_chr.is_wearing_acs(mas_acs_quetzalplushie)
+    ):
+        $ mas_acs_quetzalplushie.keep_on_desk = False
+
     #Monika is off screen
     call mas_transition_to_emptydesk
 
     #Wrap these statements so we can properly add/remove the consumable
     python:
-        if (
-            consumable.consumable_type == store.mas_consumables.TYPE_FOOD
-            and monika_chr.is_wearing_acs(mas_acs_quetzalplushie)
-        ):
-            mas_acs_quetzalplushie.keep_on_desk = False
-
         renpy.pause(1.0, hard=True)
         consumable.acs.keep_on_desk = False
         monika_chr.remove_acs(mas_acs_quetzalplushie)

--- a/Monika After Story/game/zz_consumables.rpy
+++ b/Monika After Story/game/zz_consumables.rpy
@@ -1202,8 +1202,15 @@ label mas_consumables_generic_get(consumable):
 
     #Wrap these statements so we can properly add/remove the consumable
     python:
+        if (
+            consumable.consumable_type == store.mas_consumables.TYPE_FOOD
+            and monika_chr.is_wearing_acs(mas_acs_quetzalplushie)
+        ):
+            mas_acs_quetzalplushie.keep_on_desk = False
+
         renpy.pause(1.0, hard=True)
         consumable.acs.keep_on_desk = False
+        monika_chr.remove_acs(mas_acs_quetzalplushie)
         monika_chr.wear_acs(consumable.acs)
         renpy.pause(4.0, hard=True)
 

--- a/Monika After Story/game/zz_dockingstation.rpy
+++ b/Monika After Story/game/zz_dockingstation.rpy
@@ -2210,13 +2210,25 @@ label mas_dockstat_first_time_goers:
     m 1eua "Anyway..."
     return
 
+label mas_dockstat_abort_post_show:
+    #Call this label to re-set anything needed when aborting dockstat farewells (error or by user)
+    #After Monika has returned to her desk
+    python:
+        #Restore the drink and make sure it's kept on desk again
+        _curr_drink = MASConsumable._getCurrentDrink()
+        if _curr_drink and _curr_drink.portable():
+            _curr_drink.acs.keep_on_desk = True
+
+    return
+
 label mas_dockstat_abort_gen:
     # call this label to abort monika gen promise
     # we should abort the promise (this lets spaceroom idle abort, as well)
-    $ store.mas_dockstat.abort_gen_promise = True
+    python:
+        store.mas_dockstat.abort_gen_promise = True
 
-    # attempt to abort the promise
-    $ store.mas_dockstat.abortGenPromise()
+        #Attempt to abort the promise
+        store.mas_dockstat.abortGenPromise()
 
     #FALL THROUGH
 

--- a/Monika After Story/game/zz_dockingstation.rpy
+++ b/Monika After Story/game/zz_dockingstation.rpy
@@ -2216,7 +2216,7 @@ label mas_dockstat_abort_post_show:
     python:
         #Restore the drink and make sure it's kept on desk again
         _curr_drink = MASConsumable._getCurrentDrink()
-        if _curr_drink and _curr_drink.portable():
+        if _curr_drink and _curr_drink.portable:
             _curr_drink.acs.keep_on_desk = True
 
     return

--- a/Monika After Story/game/zz_reactions.rpy
+++ b/Monika After Story/game/zz_reactions.rpy
@@ -2580,6 +2580,14 @@ label mas_reaction_gift_chocolates:
             #We want this to show up where she accepts the chocs
             #Same as before, we don't want these to show up if we're already eating
             if not MASConsumable._getCurrentFood():
+                #If we have the plush out, we should show the middle one here
+                if not (mas_isF14() or mas_isD25Season()):
+                    if monika_chr.is_wearing_acs(mas_acs_quetzalplushie):
+                        $ monika_chr.wear_acs(mas_acs_center_quetzalplushie)
+
+                else:
+                    $ monika_chr.remove_acs(store.mas_acs_quetzalplushie)
+
                 $ monika_chr.wear_acs(mas_acs_heartchoc)
 
             $ mas_giftCapGainAff(3 if mas_isSpecialDay() else 1)
@@ -2636,7 +2644,21 @@ label mas_remove_choc:
     m 1hua "..."
     m 3hksdlb "Ahaha! I should probably put these away for now..."
     m 1rksdla "If I leave them here much longer there won't be any left to enjoy later!"
-    $ monika_chr.remove_acs(mas_acs_heartchoc)
+
+    $ mas_acs_heartchoc.keep_on_desk = False
+    call mas_transition_to_emptydesk
+
+    python:
+        renpy.pause(1, hard=True)
+        monika_chr.remove_acs(mas_acs_heartchoc)
+
+        if monika_chr.is_wearing_acs(mas_acs_center_quetzalplushie):
+            monika_chr.wear_acs(mas_acs_quetzalplushie)
+
+        renpy.pause(3, hard=True)
+
+    call mas_transition_from_emptydesk("monika 1eua")
+    m 1eua "So what else did you want to do today?"
     return
 
 label mas_reaction_gift_clothes_orcaramelo_bikini_shell:

--- a/Monika After Story/game/zz_reactions.rpy
+++ b/Monika After Story/game/zz_reactions.rpy
@@ -2645,7 +2645,6 @@ label mas_remove_choc:
     m 3hksdlb "Ahaha! I should probably put these away for now..."
     m 1rksdla "If I leave them here much longer there won't be any left to enjoy later!"
 
-    $ mas_acs_heartchoc.keep_on_desk = False
     call mas_transition_to_emptydesk
 
     python:

--- a/Monika After Story/game/zz_reactions.rpy
+++ b/Monika After Story/game/zz_reactions.rpy
@@ -2651,13 +2651,14 @@ label mas_remove_choc:
     python:
         renpy.pause(1, hard=True)
         monika_chr.remove_acs(mas_acs_heartchoc)
-
-        if monika_chr.is_wearing_acs(mas_acs_center_quetzalplushie):
-            monika_chr.wear_acs(mas_acs_quetzalplushie)
-
         renpy.pause(3, hard=True)
 
     call mas_transition_from_emptydesk("monika 1eua")
+
+    #Now move the plush
+    if monika_chr.is_wearing_acs(mas_acs_center_quetzalplushie):
+        $ monika_chr.wear_acs(mas_acs_quetzalplushie)
+
     m 1eua "So what else did you want to do today?"
     return
 

--- a/Monika After Story/game/zz_spriteobjects.rpy
+++ b/Monika After Story/game/zz_spriteobjects.rpy
@@ -1409,9 +1409,7 @@ init -1 python:
         ),
         stay_on_start=False,
         acs_type="chocs",
-        mux_type=[store.mas_sprites.EXP_A_LD],
-        entry_pp=store.mas_sprites._acs_heartchoc_entry,
-        exit_pp=store.mas_sprites._acs_heartchoc_exit,
+        mux_type=store.mas_sprites.DEF_MUX_LD,
         keep_on_desk=True
     )
     store.mas_sprites.init_acs(mas_acs_heartchoc)
@@ -2265,85 +2263,6 @@ init -1 python:
 ### accessory name
 # <var>
 # <var comment>
-
-### COFFEE MUG
-
-default persistent._mas_acs_enable_coffee = False
-# True enables coffee, False disables coffee
-
-default persistent._mas_coffee_been_given = False
-# True means user has given monika coffee before, False means no
-
-default persistent._mas_coffee_brew_time = None
-# datetime that coffee startd brewing. None if coffe not brewing
-
-default persistent._mas_coffee_cup_done = None
-# datetime that monika will finish her coffee. None means she isnt drinking any
-
-default persistent._mas_coffee_cups_drank = 0
-# number of cups of coffee monika has drank
-
-define mas_coffee.BREW_LOW = 2*60
-# lower bound of seconds it takes to brew some coffee
-
-define mas_coffee.BREW_HIGH = 4*60
-# upper bound of seconds it takes to brew some coffee
-
-define mas_coffee.DRINK_LOW = 10 * 60
-# lower bound of seconds it takes for monika to drink coffee
-
-define mas_coffee.DRINK_HIGH = 2 * 3600
-# upper bound of seconds it takes for monika to drink coffee
-
-define mas_coffee.BREW_CHANCE = 80
-# percent chance out of 100 that we are brewing coffee during the appropriate
-# times
-
-define mas_coffee.DRINK_CHANCE = 80
-# percent chance out of 100 that we are drinking coffee during the appropriate
-# times
-
-define mas_coffee.COFFEE_TIME_START = 5
-# hour that coffee time begins (inclusive)
-
-define mas_coffee.COFFEE_TIME_END =  12
-# hour that coffee time ends (exclusive)
-
-define mas_coffee.BREW_DRINK_SPLIT = 9
-# hour between the coffee times where brewing turns to drinking
-# from COFFEE_TIME_START to this time, brew chance is used
-# from this time to COFFEE_TIME_END, drink chance is used
-
-### HOT CHOCOLATE MUG ###
-
-# NOTE: please use consumable framework when ever that is created
-# NOTE: so we dont get dum things, use _mas_c for all future consumable-based
-#   calculations. Everything will get replcaed with a more concrete storage
-#   system in the future, anyway.
-
-default persistent._mas_acs_enable_hotchoc = False
-# True enables hot chocolate, False disables
-
-default persistent._mas_c_hotchoc_been_given = False
-# True means the user has given monika hotchoc before, False means no
-
-default persistent._mas_c_hotchoc_brew_time = None
-# datetime that hot choco started being made. None if not being made
-
-default persistent._mas_c_hotchoc_cup_done = None
-# datetime that monika will finish her hotchoc. MNone means she is not drining
-
-default persistent._mas_c_hotchoc_cups_drank = 0
-# number of cups of hotchoc monika has drank
-
-define mas_coffee.HOTCHOC_TIME_START = 19
-# hour that hotchoc time begins (inclusive)
-
-define mas_coffee.HOTCHOC_TIME_END = 22
-# hour that hotchoc time ends (exclusive)
-
-define mas_coffee.HOTCHOC_BREW_DRINK_SPLIT = 21
-# similar to coffee split, but for hotchocolate
 
 ### QUETZAL PLUSHIE ###
 default persistent._mas_acs_enable_quetzalplushie = False

--- a/Monika After Story/game/zz_spriteobjects.rpy
+++ b/Monika After Story/game/zz_spriteobjects.rpy
@@ -1410,7 +1410,7 @@ init -1 python:
         stay_on_start=False,
         acs_type="chocs",
         mux_type=store.mas_sprites.DEF_MUX_LD,
-        keep_on_desk=True
+        keep_on_desk=False
     )
     store.mas_sprites.init_acs(mas_acs_heartchoc)
 


### PR DESCRIPTION
Missed some things in #5323. This PR just does a bit of cleanup on those missed parts.

## Testing:
- Verify chocolates reaction works properly with quetzal out (now that the mux type for chocolates has been fixed)
- Verify that if Monika gets a food type while the plush is out, Monika takes the plush with her when she goes to get it and doesn't return with the plush
- Verify that `keep_on_desk` is set back to `True` for portable drinks when cancelling a dockstat farewell