### PR TITLE
Updater Links

### DIFF
--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -35,7 +35,8 @@ init -1 python:
 
     _TXT_FINISHED_UPDATING = (
         "The updates have been installed. Please reopen Monika After Story.\n\n"
-        "See the patch notes and get spritepacks {a=https://github.com/Monika-After-Story/MonikaModDev/releases/latest}{i}{u}here{/u}{/i}{/a}.\n"
+        "Get spritepacks {a=http://monikaafterstory.com/releases.html}{i}{u}from our website{/u}{/i}{/a}.\n"
+        "See the patch notes {a=https://github.com/Monika-After-Story/MonikaModDev/releases/latest}{i}{u}here{/u}{/i}{/a}.\n"
         "Confused about some features? Take a look at our {a=https://github.com/Monika-After-Story/MonikaModDev/wiki}{i}{u}wiki page{/u}{/i}{/a}."
     )
 

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -33,7 +33,11 @@ init -1 python:
         "and offer some comments based on what you're doing."
     )
 
-
+    _TXT_FINISHED_UPDATING = (
+        "The updates have been installed. Please reopen Monika After Story.\n\n"
+        "See the patch notes and get spritepacks {a=https://github.com/Monika-After-Story/MonikaModDev/releases/latest}{i}{u}here{/u}{/i}{/a}.\n"
+        "Confused about some features? Take a look at our {a=https://github.com/Monika-After-Story/MonikaModDev/wiki}{i}{u}wiki page{/u}{/i}{/a}."
+    )
 
 
 init python in mas_layout:
@@ -1974,7 +1978,7 @@ screen updater:
                 elif u.state == u.FINISHING:
                     text _("Finishing up.")
                 elif u.state == u.DONE:
-                    text _("The updates have been installed. Please reopen Monika After Story.")
+                    text _(_TXT_FINISHED_UPDATING)
                 elif u.state == u.DONE_NO_RESTART:
                     text _("The updates have been installed.")
                 elif u.state == u.CANCELLED:

--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -921,6 +921,8 @@ label mas_updater_rpy_issue:
             $ mas_rmallEVL("monika_rpy_files")
 
             m 2dsc "Now let me just run the updater.{w=0.5}.{w=0.5}.{nw}"
+            window hide
+
             #Run the updater
             jump update_now
 


### PR DESCRIPTION
closes #5417 

Adds links to the latest releases page and the wiki page.

Adding a direct link to the latest spritepack zip isn't quite as possible, but ideally linking to the latest release w/ patch notes should suffice as the zip is a scroll down

## Testing:
- Verify that links work correctly
- Verify links show
- Verify that updating with rpy files doesn't keep the window showing up during the updater screen (oops, that happened for a while)