### PR TITLE
Added Fade out to playsong

### DIFF
--- a/Monika After Story/game/script-stories.rpy
+++ b/Monika After Story/game/script-stories.rpy
@@ -853,7 +853,7 @@ label mas_scary_story_setup:
     $ are_masks_changing = mas_current_weather != mas_weather_rain
     $ mas_is_raining = True
 
-    stop music fadeout 1.0
+    $ play_song(None, fadeout=1.0)
     pause 1.0
 
     $ mas_temp_m_flag = morning_flag

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -1846,9 +1846,11 @@ label monika_holdme_prep(lullaby=True, no_music=True):
             # from the music menu after the 30 minute mark
             $ songs.current_track = store.songs.FP_MONIKA_LULLABY
             $ songs.selected_track = store.songs.FP_MONIKA_LULLABY
+
     # stop the music without starting the timer
     elif not lullaby and no_music:
         $ play_song(None, fadeout=1.0)
+
     # just play the lullaby
     elif lullaby and not no_music:
         $ play_song(store.songs.FP_MONIKA_LULLABY)
@@ -1856,7 +1858,8 @@ label monika_holdme_prep(lullaby=True, no_music=True):
     # stop music when a song other than lullaby is playing but don't clear selected track
     # this way the lullaby will play only if the user has clicked the no music button
     if songs.current_track is not None and songs.current_track != store.songs.FP_MONIKA_LULLABY:
-        stop music fadeout 1.0
+        $ play_song(None, fadeout=1.0)
+
     # hide ui and disable hotkeys
     $ HKBHideButtons()
     $ store.songs.enabled = False
@@ -1884,7 +1887,8 @@ label monika_holdme_reactions:
     
     # stop the timer if the holding time is less than 30 minutes
     if elapsed_time <= datetime.timedelta(minutes=30):
-        stop music
+        $ play_song(None, fadeout=1.0)
+
     if elapsed_time > datetime.timedelta(minutes=30):
         call monika_holdme_long
 
@@ -2059,7 +2063,7 @@ label monika_holdme_long:
     m "..."
     menu:
         "{i}Wake Monika up.{/i}":
-            stop music fadeout 5.0
+            $ play_song(None, fadeout=5.0)
             if mas_isMoniLove():
                 m 6dubfa "...{w=1}Mmm~"
                 m 6dkbfu "[player]...{w=1}warm~"
@@ -2074,6 +2078,7 @@ label monika_holdme_long:
                 m 5hubfb "I'd do the same for you, after all~"
                 m 5tsbfu "Who knows if I'll ever let go when I finally get the chance..."
                 m 5hubfu "Ehehe~"
+
             elif mas_isMoniEnamored():
                 m 6dkbfa "...{w=1}Hm?"
                 m 6tsbfa "[player]..."
@@ -2084,6 +2089,7 @@ label monika_holdme_long:
                 m 1hubfb "So I have to blame you for that, ahaha!"
                 m 3rkbfsdla "Could...{w=0.7}we do that again sometime?"
                 m 1ekbfu "It...{w=1}felt nice~"
+
             elif mas_isMoniAff():
                 m 6dubsa "Mm...{w=1}hm?"
                 m 1wubfsdld "Oh!{w=1} [player]?"
@@ -2095,6 +2101,7 @@ label monika_holdme_long:
                 show monika 5eubfu at t11 zorder MAS_MONIKA_Z with dissolve
                 m 5eubfu "You're so sweet, [player]~"
                 m 5hubfa "Hopefully you enjoyed that as much as I did~"
+
             #happy
             else:
                 m 6dubsc "...{w=1}Hm?"
@@ -2109,18 +2116,23 @@ label monika_holdme_long:
                 m 3ekbfb "I still enjoyed it, mind you!"
                 m 1rkbsa "It really was nice, but I'm still getting used to being held by you like this, ahaha..."
                 m 1hubfa "Anyway, it was nice of you to let me nap, [player], ehehe~"
+
         "{i}Let her rest on you.{/i}":
             call monika_holdme_prep(False,False)
             if mas_isMoniLove():
                 m 6dubfd "{cps=*0.5}[player]~{/cps}"
                 m 6dubfb "{cps=*0.5}Love...{w=0.7}you~{/cps}"
+
             elif mas_isMoniEnamored():
                 m 6dubfa "{cps=*0.5}[player]...{/cps}"
+
             elif mas_isMoniAff():
                 m "{cps=*0.5}Mm...{/cps}"
+
             #happy
             else:
                 m "..."
+
             call monika_holdme_start
             jump monika_holdme_long
     return
@@ -10431,7 +10443,7 @@ label monika_grad_speech_ignored_lock:
 
 label monika_grad_speech:
     # clear selected track
-    stop music fadeout 1.0
+    $ play_song(None, fadeout=1.0)
     $ songs.current_track = songs.FP_NO_SONG
     $ songs.selected_track = songs.FP_NO_SONG
     #play some grad music

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -1848,7 +1848,7 @@ label monika_holdme_prep(lullaby=True, no_music=True):
             $ songs.selected_track = store.songs.FP_MONIKA_LULLABY
     # stop the music without starting the timer
     elif not lullaby and no_music:
-        stop music fadeout 1.0
+        $ play_song(None, fadeout=1.0)
     # just play the lullaby
     elif lullaby and not no_music:
         $ play_song(store.songs.FP_MONIKA_LULLABY)

--- a/Monika After Story/game/zz_music_selector.rpy
+++ b/Monika After Story/game/zz_music_selector.rpy
@@ -1042,7 +1042,7 @@ init python:
             songs.setUserVolume(songs.music_volume, "music")
 
 
-    def play_song(song, fadein=0.0, loop=True, set_per=False):
+    def play_song(song, fadein=0.0, loop=True, set_per=False, fadeout=0.0):
         #
         # literally just plays a song onto the music channel
         # Also sets the currentt track
@@ -1055,14 +1055,15 @@ init python:
         #   set_per - True if we should set persistent track, False if not
         if song is None:
             song = songs.FP_NO_SONG
-            renpy.music.stop(channel="music")
+            renpy.music.stop(channel="music", fadeout=fadeout)
         else:
             renpy.music.play(
                 song,
                 channel="music",
                 loop=loop,
                 synchro_start=True,
-                fadein=fadein
+                fadein=fadein,
+                fadeout=fadeout
             )
 
         songs.current_track = song


### PR DESCRIPTION
# key changes
* adds a fade out param to the `play_song` function
* changes hold me to use the `play_song` function when stopping music

feel free to add commits with `stop music` conversions as you see fit. just update testing instructions too.

# Testing
* verify places that use `play_song` work fine. (like selecting music/None). 
* verify hold me flow that stops music (`monika_rain`) stops music correctly with a 1s fadeout
- verify holdme long (30 mins) fades lullaby out w/ a 5 second fadeout (call `monika_holdme_long`)
- verify that scary stories will stop music with a 1 second fadeout
- verify that grad speech will stop music w/ a 1 second fadeout