### PR TITLE
Small fix for MASFilterableSprite

### DIFF
--- a/Monika After Story/game/sprite-chart-matrix.rpy
+++ b/Monika After Story/game/sprite-chart-matrix.rpy
@@ -88,7 +88,8 @@ python early:
 
             # render and blit
             render = renpy.render(new_img, width, height, st, at)
-            rv = renpy.Render(width, height)
+            rw, rh = render.get_size()
+            rv = renpy.Render(rw, rh)
             rv.blit(render, (0, 0))
 
             # save


### PR DESCRIPTION
Right now `MASFilterableSprite` renders its image on the entire screen. This means that it makes a huge displayable. That doesn't matter unless you want to make events with that displayable. Then the user is able to interact with that displayable from any point of the screen (because it's bigger than the actual image is). This will set the render's size to its image's size so the displayable will behave as you expect it to.