### PR TITLE
Ribbon helper fix

### DIFF
--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -2168,8 +2168,8 @@ label mas_lupd_v0_8_10:
         if persistent._mas_o31_seen_costumes is not None:
             if persistent._mas_o31_seen_costumes.get("marisa", False):
                 mas_selspr.unlock_clothes(mas_clothes_marisa)
-            if persistent._mas_o31_seen_costumes.get("rin", False):
-                mas_selspr.unlock_clothes(mas_clothes_rin)
+            #if persistent._mas_o31_seen_costumes.get("rin", False):
+            #    mas_selspr.unlock_clothes(mas_clothes_rin)
 
         # save the selectables we just unlocked
         mas_selspr.save_selectables()

--- a/Monika After Story/game/zz_reactions.rpy
+++ b/Monika After Story/game/zz_reactions.rpy
@@ -2372,30 +2372,8 @@ label _mas_reaction_ribbon_helper(label):
 label mas_reaction_new_ribbon:
     python:
         def _ribbon_prepare_hair():
-            if monika_chr.hair.hasprop("ribbon"):
-                # first check for ribbon prop
-                return
-
-            # no ribbon prop means we should change
-            if (
-                    monika_chr.clothes == mas_clothes_rin
-                ):
-                if mas_isD25Outfit():
-                    monika_chr.change_outfit(
-                        mas_clothes_santa,
-                        mas_hair_def,
-                        False
-                    )
-
-                else:
-                    monika_chr.change_outfit(
-                        mas_clothes_def,
-                        mas_hair_def,
-                        False
-                    )
-
-            else:
-                # otherwise, just change hair
+            #If current hair doesn't support ribbons, we should change hair
+            if not monika_chr.hair.hasprop("ribbon"):
                 monika_chr.change_hair(mas_hair_def, False)
 
     $ mas_giftCapGainAff(3)


### PR DESCRIPTION
Ribbon helper checked for Rin explicitly, but as of #5447, `mas_clothes_rin` is no longer a defined variable causing crashes.

Adjusted ribbon helper so its logic is cleaner and removed other references to `mas_clothes_rin`

## Testing:
- Verify gifting ribbons works properly when wearing both, hair which can have ribbons and cannot have ribbons.