### PR TITLE
Single quotes no longer break notifications on Linux

### DIFF
--- a/Monika After Story/game/zz_windowreacts.rpy
+++ b/Monika After Story/game/zz_windowreacts.rpy
@@ -277,6 +277,11 @@ init python:
             title: notification title
             body: notification body
         """
+        # Single quotes have to be escaped.
+        # Since single quoting in POSIX shell doesn't allow escaping,
+        # we have to close the quotation, insert a literal single quote and reopen the quotation.
+        body  = body.replace("'", "'\\''")
+        title = title.replace("'", "'\\''") # better safe than sorry
         os.system("notify-send '{0}' '{1}' -u low".format(title,body))
 
     def display_notif(title, body, group=None, skip_checks=False):


### PR DESCRIPTION
Call to the notify-send command with a notification that contains `'` would cause the command to fail and the notification wouldn't show. I fixed that

It's very likely that the same thing applies to Macs, but I don't have a Mac so I can't be sure