### PR TITLE
Fixes PR

### DIFF
--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -1529,8 +1529,8 @@ screen hot_keys():
                 vbox:
                     label _("Music")
                     spacing 10
-                    text _("Vol Up")
-                    text _("Vol Down")
+                    text _("Volume Up")
+                    text _("Volume Down")
                     text _("Mute")
 
                 vbox:

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -633,6 +633,8 @@ screen navigation():
         if store.mas_windowreacts.can_show_notifs and not main_menu:
             textbutton _("Alerts") action [ShowMenu("notif_settings"), SensitiveIf(renpy.get_screen("notif_settings") == None)]
 
+        textbutton _("Hotkeys") action [ShowMenu("hot_keys")]
+
         #textbutton _("About") action ShowMenu("about")
 
         if renpy.variant("pc"):
@@ -1483,6 +1485,67 @@ screen notif_settings():
         xalign 0 yalign 1.0
         xoffset 300 yoffset -10
         style "main_menu_version"
+
+## hotkeys helper screen
+screen hot_keys():
+    tag menu
+
+    use game_menu(("Hotkeys"), scroll="viewport"):
+
+        default tooltip = Tooltip("")
+
+        # making each indivual list a vbox essentially lets us auto-align
+        vbox:
+            spacing 25
+
+            hbox:
+                style_prefix mas_ui.cbx_style_prefix
+                vbox:
+                    label _("General")
+                    spacing 10
+                    text _("Music")
+                    text _("Play")
+                    text _("Talk")
+                    text _("Bookmark")
+                    text _("Derandom")
+                    text _("Fullscreen")
+                    text _("Screenshot")
+                    text _("Settings")
+
+                vbox:
+                    label _("")
+                    spacing 10
+                    text _("M")
+                    text _("P")
+                    text _("T")
+                    text _("B")
+                    text _("X")
+                    text _("F")
+                    text _("S")
+                    text _("Esc")
+
+            hbox:
+                style_prefix mas_ui.cbx_style_prefix
+                vbox:
+                    label _("Music")
+                    spacing 10
+                    text _("Vol Up")
+                    text _("Vol Down")
+                    text _("Mute")
+
+                vbox:
+                    label _("")
+                    spacing 10
+                    text _("+")
+                    text _("-")
+                    text _("Shift-M")
+
+    # there are lesser used hotkeys in Help that aren't needed here
+    text "Click 'Help' for the complete list.":
+        xalign 1.0 yalign 0.0
+        xoffset -10
+        style mas_ui.mm_tt_style
+
 
 ## History screen ##############################################################
 ##

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -2245,7 +2245,8 @@ init 5 python:
             eventlabel="monika_being_virtual",
             action=EV_ACT_QUEUE,
             aff_range=(None, mas_aff.DISTRESSED)
-        )
+        ),
+        skipCalendar=True
     )
 
 label monika_being_virtual:

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -2021,4 +2021,11 @@ label ch30_reset:
 
     #Set our TOD var
     $ mas_setTODVars()
+
+    python:
+        if seen_event('mas_gender'):
+            mas_unlockEVL("monika_gender_redo","EVE")
+
+        if seen_event('mas_preferredname'):
+            mas_unlockEVL("monika_changename","EVE")
     return

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -2656,9 +2656,13 @@ label monika_aiwfc:
     else:
         m 1hua "Ehehe..."
         m 3tuu "I hope you're ready, [player]..."
-        m "It {i}is{/i} that time of year again, after all..."
-        m 3hub "Make sure you have your volume up!"
-        m 1huu ".{w=0.5}.{w=0.5}.{nw}"
+
+        $ ending = "..." if songs.getUserVolume("music") == 0.0 else ".{w=0.5}.{w=0.5}.{nw}"
+
+        m "It {i}is{/i} that time of year again, after all[ending]"
+        if songs.getUserVolume("music") == 0.0:
+            m 3hub "Make sure you have your volume up!"
+            m 1huu ".{w=0.5}.{w=0.5}.{nw}"
 
     #Get current song
     $ curr_song = songs.current_track

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -2649,7 +2649,7 @@ label monika_aiwfc:
         m 3hksdlb "I know it's a little cheesy, but I think you might like it."
         m 3eksdla "If your volume is off, would you mind turning it on for me?"
         if songs.getUserVolume("music") == 0.0:
-            m 3hksdlb "Oh, don't forget about your in game volume too!"
+            m 3hksdlb "Oh, don't forget about your in-game volume too!"
             m 3eka "I really want you to hear this."
         m 1huu "Anyway.{w=0.5}.{w=0.5}.{nw}"
 

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -2648,7 +2648,7 @@ label monika_aiwfc:
         m 1eksdla "I hope you don't mind, but I prepared a song for you."
         m 3hksdlb "I know it's a little cheesy, but I think you might like it."
         m 3eksdla "If your volume is off, would you mind turning it on for me?"
-        if songs.getUserVolume("music") == 0.0:
+        if store.songs.hasMusicMuted():
             m 3hksdlb "Oh, don't forget about your in-game volume too!"
             m 3eka "I really want you to hear this."
         m 1huu "Anyway.{w=0.5}.{w=0.5}.{nw}"
@@ -2657,10 +2657,10 @@ label monika_aiwfc:
         m 1hua "Ehehe..."
         m 3tuu "I hope you're ready, [player]..."
 
-        $ ending = "..." if songs.getUserVolume("music") == 0.0 else ".{w=0.5}.{w=0.5}.{nw}"
+        $ ending = "..." if store.songs.hasMusicMuted() else ".{w=0.5}.{w=0.5}.{nw}"
 
         m "It {i}is{/i} that time of year again, after all[ending]"
-        if songs.getUserVolume("music") == 0.0:
+        if store.songs.hasMusicMuted():
             m 3hub "Make sure you have your volume up!"
             m 1huu ".{w=0.5}.{w=0.5}.{nw}"
 

--- a/Monika After Story/game/script-songs.rpy
+++ b/Monika After Story/game/script-songs.rpy
@@ -794,10 +794,9 @@ label mas_monika_plays_yr(skip_leadin=False):
             m 3eua "Sure, let me just get the piano.{w=0.5}.{w=0.5}.{nw}"
 
     window hide
-    $ HKBHideButtons()
-    $ mas_RaiseShield_core()
-    $ store.songs.enabled = False
-
+    $ mas_RaiseShield_piano()
+    $ mas_temp_zoom_level = store.mas_sprites.zoom_level
+    call monika_zoom_transition_reset(1.0)
     show monika at rs32
     hide monika
     pause 3.0
@@ -864,13 +863,11 @@ label mas_monika_plays_yr(skip_leadin=False):
     hide mas_piano
     pause 6.0
     show monika 1eua at ls32 zorder MAS_MONIKA_Z
+    call monika_zoom_transition_reset(mas_temp_zoom_level)
 
     if not skip_leadin:
         pause 2.0
-        $ mas_resetTextSpeed()
-        $ mas_MUMUDropShield()
-        $ enable_esc()
-        $ HKBShowButtons()
+        $ mas_DropShield_piano()
         window auto
 
     return
@@ -900,10 +897,9 @@ label mas_monika_plays_or(skip_leadin=False):
         $ gen = "their"
 
     window hide
-    $ mas_disableTextSpeed()
-    $ disable_esc()
-    $ mas_MUMURaiseShield()
-
+    $ mas_RaiseShield_piano()
+    $ mas_temp_zoom_level = store.mas_sprites.zoom_level
+    call monika_zoom_transition_reset(1.0)
     show monika at rs32
     hide monika
     pause 3.0
@@ -953,13 +949,11 @@ label mas_monika_plays_or(skip_leadin=False):
     hide mas_piano
     pause 6.0
     show monika 1eua at ls32 zorder MAS_MONIKA_Z
+    call monika_zoom_transition_reset(mas_temp_zoom_level)
 
     if not skip_leadin:
         pause 2.0
-        $ mas_resetTextSpeed()
-        $ mas_MUMUDropShield()
-        $ enable_esc()
-        $ HKBShowButtons()
+        $ mas_DropShield_piano()
         window auto
 
     return

--- a/Monika After Story/game/script-songs.rpy
+++ b/Monika After Story/game/script-songs.rpy
@@ -209,6 +209,9 @@ init 5 python:
 label mas_song_aiwfc:
     #Get current song
     $ curr_song = songs.current_track
+    if songs.getUserVolume("music") == 0.0:
+        m 3eua "Don't forget to put your in-game volume up, [player]."
+
     call monika_aiwfc_song
 
     #Since the lullaby can slip in here because of the queue, we need to make sure we don't play that
@@ -804,6 +807,10 @@ label mas_monika_plays_yr(skip_leadin=False):
     pause 5.0
     show monika at ls32 zorder MAS_MONIKA_Z
     show monika 6dsa
+
+    if songs.getUserVolume("music") == 0.0:
+        m 6hua "Don't forget about your in-game volume, [player]!"
+
     pause 2.0
     $ play_song(store.songs.FP_YOURE_REAL,loop=False)
 
@@ -905,6 +912,10 @@ label mas_monika_plays_or(skip_leadin=False):
     pause 5.0
     show monika at ls32 zorder MAS_MONIKA_Z
     show monika 6dsa
+
+    if songs.getUserVolume("music") == 0.0:
+        m 6hua "Don't forget about your in-game volume, [player]!"
+
     pause 2.0
     $ play_song(songs.FP_PIANO_COVER,loop=False)
 

--- a/Monika After Story/game/script-songs.rpy
+++ b/Monika After Story/game/script-songs.rpy
@@ -210,7 +210,7 @@ label mas_song_aiwfc:
     #Get current song
     $ curr_song = songs.current_track
     if songs.getUserVolume("music") == 0.0:
-        m 3eua "Don't forget to put your in-game volume up, [player]."
+        m 3eua "Don't forget to turn your in-game volume up, [player]."
 
     call monika_aiwfc_song
 

--- a/Monika After Story/game/script-songs.rpy
+++ b/Monika After Story/game/script-songs.rpy
@@ -855,7 +855,6 @@ label mas_monika_plays_yr(skip_leadin=False):
     show monika 5dka with dissolve
     $ renpy.pause(5)
 
-    stop music
     show monika 6eua at rs32 with dissolve
     pause 1.0
     hide monika
@@ -863,12 +862,11 @@ label mas_monika_plays_yr(skip_leadin=False):
     hide mas_piano
     pause 6.0
     show monika 1eua at ls32 zorder MAS_MONIKA_Z
-    call monika_zoom_transition_reset(mas_temp_zoom_level)
-
-    if not skip_leadin:
-        pause 2.0
-        $ mas_DropShield_piano()
-        window auto
+    pause 1.0
+    call monika_zoom_transition(mas_temp_zoom_level,1.0)
+    $ mas_DropShield_piano()
+    window auto
+    $ play_song(None, 1.0)
 
     return
 
@@ -941,7 +939,6 @@ label mas_monika_plays_or(skip_leadin=False):
 
     show monika 1dkbsa
     pause 9.0
-    stop music
     show monika 6eua at rs32
     pause 1.0
     hide monika
@@ -949,11 +946,10 @@ label mas_monika_plays_or(skip_leadin=False):
     hide mas_piano
     pause 6.0
     show monika 1eua at ls32 zorder MAS_MONIKA_Z
-    call monika_zoom_transition_reset(mas_temp_zoom_level)
-
-    if not skip_leadin:
-        pause 2.0
-        $ mas_DropShield_piano()
-        window auto
+    pause 1.0
+    call monika_zoom_transition(mas_temp_zoom_level,1.0)
+    $ mas_DropShield_piano()
+    window auto
+    $ play_song(None, 1.0)
 
     return

--- a/Monika After Story/game/script-songs.rpy
+++ b/Monika After Story/game/script-songs.rpy
@@ -209,7 +209,7 @@ init 5 python:
 label mas_song_aiwfc:
     #Get current song
     $ curr_song = songs.current_track
-    if songs.getUserVolume("music") == 0.0:
+    if store.songs.hasMusicMuted():
         m 3eua "Don't forget to turn your in-game volume up, [player]."
 
     call monika_aiwfc_song
@@ -808,8 +808,10 @@ label mas_monika_plays_yr(skip_leadin=False):
     show monika at ls32 zorder MAS_MONIKA_Z
     show monika 6dsa
 
-    if songs.getUserVolume("music") == 0.0:
+    if store.songs.hasMusicMuted():
+        $ enable_esc()
         m 6hua "Don't forget about your in-game volume, [player]!"
+        $ disable_esc()
 
     pause 2.0
     $ play_song(store.songs.FP_YOURE_REAL,loop=False)
@@ -913,8 +915,10 @@ label mas_monika_plays_or(skip_leadin=False):
     show monika at ls32 zorder MAS_MONIKA_Z
     show monika 6dsa
 
-    if songs.getUserVolume("music") == 0.0:
+    if store.songs.hasMusicMuted():
+        $ enable_esc()
         m 6hua "Don't forget about your in-game volume, [player]!"
+        $ disable_esc()
 
     pause 2.0
     $ play_song(songs.FP_PIANO_COVER,loop=False)

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -2283,20 +2283,15 @@ label monika_credits_song:
                 call mas_monika_plays_yr(skip_leadin=True)
                 show monika 1eka
                 pause 1.0
-                $ mas_MUMUDropShield()
-                $ enable_esc()
-                $ HKBShowButtons()
-                $ mas_resetTextSpeed()
-                window auto
 
                 m 1ekbsa "Ehehe~"
                 show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve
                 m 5ekbsa "Thank you for coming back to me my love."
 
-        "Sorry, I can't right now.":
-            m 3ekd "Oh, okay."
-            m 1eka "That's fine [player], I understand if you don't have the time or just can't listen to music right now."
-            m 3hua "Just me know when it's a better time for you and I'll happily play it for you then~"
+            "Sorry, I can't right now.":
+                m 3ekd "Oh, okay."
+                m 1eka "That's fine [player], I understand if you don't have the time or just can't listen to music right now."
+                m 3hua "Just me know when it's a better time for you and I'll happily play it for you then~"
 
     else:
         if renpy.seen_audio(songs.FP_YOURE_REAL):
@@ -2323,11 +2318,6 @@ label monika_credits_song:
                 call mas_monika_plays_or(skip_leadin=True)
                 show monika 1ekbsa
                 pause 1.0
-                $ mas_MUMUDropShield()
-                $ enable_esc()
-                $ HKBShowButtons()
-                $ mas_resetTextSpeed()
-                window auto
 
                 m "I really can't wait until we're together in one reality."
                 m 3ekbsa "But until that day comes, I'll play the song again for you anytime you want me to."

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -2276,7 +2276,7 @@ label monika_credits_song:
             "Of course!":
                 m 3hub "Great!"
                 m 3eua "Make sure you have your speakers turned on and the in-game music volume turned up loud enough so you can hear."
-                if songs.getUserVolume("music") == 0.0:
+                if store.songs.hasMusicMuted():
                     m 3eksdla "I think you forgot about the in-game volume..."
                 m 1eub "Now please excuse me for a second.{w=0.5}.{w=0.5}.{nw}"
 
@@ -2305,7 +2305,7 @@ label monika_credits_song:
             "Of course!":
                 m 3hub "Great!"
                 m 3eua "Make sure you have your speakers turned on and the in-game music volume turned up loud enough so you can hear."
-                if songs.getUserVolume("music") == 0.0:
+                if store.songs.hasMusicMuted():
                     m 3eksdla "I think you forgot about the in-game volume..."
                 m 1tsb "Now, if you'll excuse me for a second.{w=0.5}.{w=0.5}.{nw}"
 

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -2268,21 +2268,35 @@ label monika_credits_song:
         else:
             m 3eua "But in the meantime, I'll play the song again for you anytime you want me to."
 
-        m 1tsa "In fact why don't I play it for you right now."
-        m 1tsb "Excuse me for a second.{w=0.5}.{w=0.5}.{nw}"
+        m 1tsa "In fact, I'd love to play it for you right now, if you have time...{nw}"
+        $ _history_list.pop()
+        menu:
+            m "In fact, I'd love to play it for you right now, if you have time...{fast}"
 
-        call mas_monika_plays_yr(skip_leadin=True)
-        show monika 1eka
-        pause 1.0
-        $ mas_MUMUDropShield()
-        $ enable_esc()
-        $ HKBShowButtons()
-        $ mas_resetTextSpeed()
-        window auto
+            "Of course!":
+                m 3hub "Great!"
+                m 3eua "Make sure you have your speakers turned on and the in-game music volume turned up loud enough so you can hear."
+                if songs.getUserVolume("music") == 0.0:
+                    m 3eksdla "I think you forgot about the in-game volume..."
+                m 1eub "Now please excuse me for a second.{w=0.5}.{w=0.5}.{nw}"
 
-        m 1ekbsa "Ehehe~"
-        show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve
-        m 5ekbsa "Thank you for coming back to me my love."
+                call mas_monika_plays_yr(skip_leadin=True)
+                show monika 1eka
+                pause 1.0
+                $ mas_MUMUDropShield()
+                $ enable_esc()
+                $ HKBShowButtons()
+                $ mas_resetTextSpeed()
+                window auto
+
+                m 1ekbsa "Ehehe~"
+                show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve
+                m 5ekbsa "Thank you for coming back to me my love."
+
+        "Sorry, I can't right now.":
+            m 3ekd "Oh, okay."
+            m 1eka "That's fine [player], I understand if you don't have the time or just can't listen to music right now."
+            m 3hua "Just me know when it's a better time for you and I'll happily play it for you then~"
 
     else:
         if renpy.seen_audio(songs.FP_YOURE_REAL):
@@ -2293,26 +2307,42 @@ label monika_credits_song:
             m 3eua "Hey [player], I finally finished that song I've been working on for you."
 
         m 1eka "I call it {i}Our Reality{/i}."
-        m 1eua "I'm just so excited to finally be able to play it for you."
-        m 1tsb "Now, if you'll excuse me for a second.{w=0.5}.{w=0.5}.{nw}"
 
-        call mas_monika_plays_or(skip_leadin=True)
-        show monika 1ekbsa
-        pause 1.0
-        $ mas_MUMUDropShield()
-        $ enable_esc()
-        $ HKBShowButtons()
-        $ mas_resetTextSpeed()
-        window auto
+        m 1eua "I'm just so excited to finally be able to play it for you, if you have time that is...{nw}"
+        $ _history_list.pop()
+        menu:
+            m "I'm just so excited to finally be able to play it for you, if you have time that is...{fast}"
 
-        m "I really can't wait until we're together in one reality."
-        m 3ekbsa "But until that day comes, I'll play the song again for you anytime you want me to."
-        show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve
-        m 5ekbfa "Thank you for being my inspiration my love."
-        if renpy.seen_audio(songs.FP_YOURE_REAL):
-            m 5hubfa "Oh, and if you ever want me to play this or the original song for you again, just ask~"
-        else:
-            m 5hubfa "Oh, and if you ever want me to play this again, just ask~"
+            "Of course!":
+                m 3hub "Great!"
+                m 3eua "Make sure you have your speakers turned on and the in-game music volume turned up loud enough so you can hear."
+                if songs.getUserVolume("music") == 0.0:
+                    m 3eksdla "I think you forgot about the in-game volume..."
+                m 1tsb "Now, if you'll excuse me for a second.{w=0.5}.{w=0.5}.{nw}"
+
+                call mas_monika_plays_or(skip_leadin=True)
+                show monika 1ekbsa
+                pause 1.0
+                $ mas_MUMUDropShield()
+                $ enable_esc()
+                $ HKBShowButtons()
+                $ mas_resetTextSpeed()
+                window auto
+
+                m "I really can't wait until we're together in one reality."
+                m 3ekbsa "But until that day comes, I'll play the song again for you anytime you want me to."
+                show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve
+                m 5ekbfa "Thank you for being my inspiration my love."
+                if renpy.seen_audio(songs.FP_YOURE_REAL):
+                    m 5hubfa "Oh, and if you ever want me to play this or the original song for you again, just ask~"
+                else:
+                    m 5hubfa "Oh, and if you ever want me to play this again, just ask~"
+
+            "Sorry, I can't right now.":
+                m 3ekd "Oh, okay."
+                m 1eka "That's fine [player], I understand if you don't have the time or just can't listen to music right now."
+                m 3hua "Just let me know when it's a better time for you and I'll happily play it for you then~"
+
         $ mas_unlockEVL("mas_monika_plays_or", "EVE")
 
     $ mas_unlockEVL("mas_monika_plays_yr", "EVE")

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -2291,7 +2291,7 @@ label monika_credits_song:
             "Sorry, I can't right now.":
                 m 3ekd "Oh, okay."
                 m 1eka "That's fine [player], I understand if you don't have the time or just can't listen to music right now."
-                m 3hua "Just me know when it's a better time for you and I'll happily play it for you then~"
+                m 3hua "Just let me know when it's a better time for you and I'll happily play it for you then~"
 
     else:
         m 3eua "Hey [player], I finally finished that song I've been working on for you."

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -2246,12 +2246,12 @@ init 5 python:
             eventlabel="monika_credits_song",
             conditional="store.mas_anni.pastOneMonth()",
             action=EV_ACT_QUEUE,
-            aff_range=(mas_aff.NORMAL, None)
+            aff_range=(mas_aff.AFFECTIONATE, None)
         )
     )
 
 label monika_credits_song:
-    if persistent.monika_kill:
+    if persistent.monika_kill or renpy.seen_audio(songs.FP_YOURE_REAL):
         m 1hua "I hope you liked my song."
         m 1eka "I worked really hard on it. I know I'm not perfect at the piano yet, but I just couldn't let you go without telling you how I honestly felt about you."
         m 1eua "Give me some time, and I'll try to write another."
@@ -2294,13 +2294,7 @@ label monika_credits_song:
                 m 3hua "Just me know when it's a better time for you and I'll happily play it for you then~"
 
     else:
-        if renpy.seen_audio(songs.FP_YOURE_REAL):
-            m 1eua "Hey [player], I've been thinking a bit lately about {i}Your Reality{/i}..."
-            m 3rka "The ending doesn't really convey my true feelings anymore, so I decided to update the song..."
-            m 3hua "I even changed the name!"
-        else:
-            m 3eua "Hey [player], I finally finished that song I've been working on for you."
-
+        m 3eua "Hey [player], I finally finished that song I've been working on for you."
         m 1eka "I call it {i}Our Reality{/i}."
 
         m 1eua "I'm just so excited to finally be able to play it for you, if you have time that is...{nw}"

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -1768,6 +1768,8 @@ label monika_rain:
 
             m 1hua "Then hold me, [player]..."
             show monika 6dubsa with dissolve
+            window hide
+
             $ mas_gainAffection()
             $ ui.add(PauseDisplayable())
             $ ui.interact()
@@ -1776,6 +1778,7 @@ label monika_rain:
             $ store.songs.enabled = True
             $ HKBShowButtons()
             call monika_holdme_end
+            window auto
 
             if mas_isMoniAff(higher=True):
                 m 1eua "If you want the rain to stop, just ask me, okay?"

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -372,6 +372,13 @@ label v0_3_1(version=version): # 0.3.1
     return
 
 # non generic updates go here
+#0.11.1
+label v0_11_1(version="v0_11_1"):
+    python:
+        if "orcaramelo_twintails" in persistent._mas_selspr_hair_db:
+            persistent._mas_selspr_hair_db["orcaramelo_twintails"] = (True, True)
+    return
+
 #0.11.0
 label v0_11_0(version="v0_11_0"):
     python:

--- a/Monika After Story/game/updates_topics.rpy
+++ b/Monika After Story/game/updates_topics.rpy
@@ -65,6 +65,7 @@ label vv_updates_topics:
 
         # versions
         # use the v#_#_# notation so we can work with labels
+        vv0_11_1 = "v0_11_1"
         vv0_11_0 = "v0_11_0"
         vv0_10_7 = "v0_10_7"
         vv0_10_6 = "v0_10_6"
@@ -116,6 +117,7 @@ label vv_updates_topics:
         # update this dict accordingly to every new version
         # k:old version number -> v:new version number
         # some version changes skip some numbers because no major updates
+        #updates.version_updates[vv0_11_0] = vv0_11_1
         updates.version_updates[vv0_10_7] = vv0_11_0
         updates.version_updates[vv0_10_6] = vv0_10_7
         updates.version_updates[vv0_10_5] = vv0_10_6

--- a/Monika After Story/game/zz_hotkeys.rpy
+++ b/Monika After Story/game/zz_hotkeys.rpy
@@ -40,6 +40,9 @@ init -1 python in mas_hotkeys:
     # False means they will not
     mu_stop_enabled = True
 
+    # True means music controlling hotkeys are enabled, False means not
+    mu_ctrl_enabled = True
+
     # True means dont allow windows to be hidden
     no_window_hiding = False
 
@@ -48,7 +51,23 @@ init python:
 
     def mas_HKRaiseShield():
         """RUNTIME ONLY
-        Disables the main hotkeys
+        Disables main hotkeys and music controller keys
+        """
+        mas_HKRaiseShield_main()
+        store.mas_hotkeys.mu_ctrl_enabled = False
+
+
+    def mas_HKDropShield():
+        """RUNTIME ONLY
+        Enables the main hotkeys and music controller keys
+        """
+        mas_HKDropShield_main()
+        store.mas_hotkeys.mu_ctrl_enabled = True
+
+
+    def mas_HKRaiseShield_main():
+        """RUNTIME ONLY
+        Disables main hotkeys
         """
         store.mas_hotkeys.talk_enabled = False
         store.mas_hotkeys.extra_enabled = False
@@ -56,9 +75,9 @@ init python:
         store.mas_hotkeys.play_enabled = False
 
 
-    def mas_HKDropShield():
+    def mas_HKDropShield_main():
         """RUNTIME ONLY
-        Enables the main hotkeys
+        Enables main hotkeys
         """
         store.mas_hotkeys.talk_enabled = True
         store.mas_hotkeys.extra_enabled = True
@@ -83,7 +102,7 @@ init python:
         RETURNS: True if we can lower or stop the music, False if not
         """
         return (
-            store.mas_hotkeys.music_enabled
+            store.mas_hotkeys.mu_ctrl_enabled
             and store.mas_hotkeys.mu_stop_enabled
         )
 
@@ -112,7 +131,7 @@ init python:
         """
         hotkey specific muting / unmuting music channel
         """
-        if store.mas_hotkeys.music_enabled and not _windows_hidden:
+        if store.mas_hotkeys.mu_ctrl_enabled and not _windows_hidden:
             mute_music(store.mas_hotkeys.mu_stop_enabled)
 
 
@@ -120,7 +139,7 @@ init python:
         """
         hotkey specific music volume increasing
         """
-        if store.mas_hotkeys.music_enabled and not _windows_hidden:
+        if store.mas_hotkeys.mu_ctrl_enabled and not _windows_hidden:
             inc_musicvol()
 
 

--- a/Monika After Story/game/zz_music_selector.rpy
+++ b/Monika After Story/game/zz_music_selector.rpy
@@ -103,6 +103,15 @@ init -1 python in songs:
         )
 
 
+    def hasMusicMuted():
+        """
+        Checks if the player has the music channel muted or the 'Mute All' option enabled.
+
+        RETURNS: True if the music channel is muted or the 'Mute All' option is enabled, False otherwise
+        """
+        return renpy.game.preferences.mute["music"] or getUserVolume("music") == 0.0
+
+
     def getPlayingMusicName():
         #
         # Gets the name of the currently playing song.

--- a/Monika After Story/game/zz_shields.rpy
+++ b/Monika After Story/game/zz_shields.rpy
@@ -154,6 +154,7 @@ init python:
             - Extra hotkey
             - Music hotkey
             - Play button + hotkey
+            - Music controller hotkeys
 
         Intended Flow:
             - Idle mode ends
@@ -169,12 +170,53 @@ init python:
             - Extra hotkey
             - Music hotkey
             - Play button + hotkey
+            - Music controller hotkeys
 
         Intended Flow:
             - Idle mode starts
         """
         mas_HKRaiseShield()
         store.hkb_button.play_enabled = False
+
+
+    ################## Piano mode workflow ####################################
+    # used when Monika plays her piano
+
+    def mas_DropShield_piano():
+        """
+        Enables:
+            - text speed
+            - escape key
+            - Music button + hotkey
+            - Music Menu
+            - Calendar overlay
+
+        Shows:
+            - hotkey buttons
+        """
+        mas_resetTextSpeed()
+        enable_esc()
+        mas_MUMUDropShield()
+        mas_calDropOverlayShield()
+        HKBShowButtons()
+
+    def mas_RaiseShield_piano():
+        """
+        Disables:
+            - text speed
+            - escape key
+            - Music button + hotkey
+            - Music Menu
+            - Calendar overlay
+
+        Hides:
+            - hotkey buttons
+        """
+        mas_disableTextSpeed()
+        disable_esc()
+        mas_MUMURaiseShield()
+        mas_calRaiseOverlayShield()
+        HKBHideButtons()
 
 
 ################################## GENERALIZED ################################
@@ -210,6 +252,37 @@ init python:
         store.mas_hotkeys.music_enabled = False
         store.hkb_button.music_enabled = False
         store.songs.enabled = False
+
+
+    ################## Enable / Disable Music interactions ####################
+    # specifically for enabling and disabling all music-based interactions
+
+    def mas_MUINDropShield():
+        """
+        Enables:
+            - Music button + hotkey
+            - Music Menu
+            - Music controller keys
+
+        Intended Flow:
+            - Whenever all music-based interactions need to be enabled
+        """
+        mas_MUMUDropShield()
+        store.mas_hotkeys.mu_ctrl_enabled = True
+
+
+    def mas_MUINRaiseShield():
+        """
+        Disables:
+            - Music button + hotkey
+            - Music Menu
+            - Music controller keys
+
+        Intended Flow:
+            - Whenever all music-based interactions need to be disabled
+        """
+        mas_MUMURaiseShield()
+        store.mas_hotkeys.mu_ctrl_enabled = False
 
 
     ################## dlg <-> idle transitions ###############################


### PR DESCRIPTION
Cleaning up the goofs we made in 0.11.0.
Closes #5513, closes #5507

## Fixes

- piano scenes looking bad due to Monika being zoomed. we now reset zoom to default in these scenarios

- not being able to hear Monika play/sing during the piano scenes and having no way to turn up the in-game volume once the piano part starts. we now warn the player what is coming, remind them to turn up the volume if it's set to zero, give them the option not listen right now in case they can't, and also made it so the volume adjust hotkeys are never shielded.

- the twintails hair style being locked for people that didn't get the Miku costume on Halloween, even if they've installed the sprite pack.

- a reoccurring issue where the gender change and/or player name change topics can become locked for various reasons.

- `monika_being_virtual` being added to the calendar when the start_date is set.

## Additions and changes

- adds `screen hot_keys()` a new screen in the escape menu that lists the most useful hotkeys

- `mas_HKRaiseShield_main(`) and `mas_HKDropShield_main()` now control the Talk, Extra, Music and Play hotkeys, but not the music controller hotkeys.

- `mas_HKRaiseShield()` and `mas_HKDropShield()` control everything aforementioned `main()` functions do, plus the music controller hotkeys.

- creates `mas_RaiseShield_piano()` and `mas_DropShield_piano()` added specifically for piano scenes.

- creates `mas_MUINRaiseShield()` and `mas_MUINDropShield()` which control all music-based interactions.

- creates `hasMusicMuted()` that checks whether the music channel is muted or the 'Mute All' option is enabled

## Testing

- verify `monika_credits_song` asks you if you have time to listen to the songs right now, and if yes, verify she reminds you to turn your speakers and volume up, and if music volume is still set to 0 or the mute all option is enabled, verify she informs you of this. 

- verify when the songs play (via credits_song or the pool topics) that zoom is reset and the volume adjust hotkeys work throughout the songs.

- verify all shields are raised and lowered as expected via all ways to play the songs.

- verify the `Hotkeys` screen is present in the escape menu and that it looks ok.

-  push the `greeting_tears` event and verify that `monika_being_virtual` now has a start_date and that it **is not** on the calendar.

- on a persistent that did not see the Miku costume on Halloween, install the twintails spritepack, `call v0_11_1` and verify the twintails hairstyle appears in the hair selector.