### PR TITLE
Additional Aff Logging

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -3562,6 +3562,7 @@ init -990 python in mas_utils:
 
     mas_log_open = mas_log.open()
     mas_log.raw_write = True
+    mas_log.write("VERSION: {0}\n".format(store.persistent.version_number))
 
 
 init -100 python in mas_utils:

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -1872,19 +1872,14 @@ init 20 python:
                     0.5 * time_difference.days
                 )
                 if new_aff < affection.AFF_TIME_CAP:
-                    if (
-                            time_difference >= datetime.timedelta(
-                                days=(365 * 10)
-                            )
-                        ):
-                        # 10 years later is an end-game situation
+                    #We can only lose so much here
+                    store.mas_affection.txt_audit("ABS", "capped loss")
+                    mas_setAffection(affection.AFF_TIME_CAP)
+
+                    #If over 10 years, then we need to FF
+                    if time_difference >= datetime.timedelta(days=(365 * 10)):
                         store.mas_affection.txt_audit("ABS", "10 year diff")
                         mas_loseAffection(200)
-
-                    else:
-                        # otherwise, you cant lose past a certain amount
-                        store.mas_affection.txt_audit("ABS", "capped loss")
-                        mas_setAffection(affection.AFF_TIME_CAP)
 
                 else:
                     store.mas_affection.txt_audit("ABS", "she missed you")


### PR DESCRIPTION
#5534 

# Key Changes
* version added to aff log and mas log
* all loading variations are logged differently (backup, no backup, normal)
* all absence losses are logged differently (10yr, capped, normal)
* number of backup mismatches are now logged when `RESTORE` occurs

# Testing
* verify version appears in aff log and mas log
* verify loading is logged accordingly
* verify absences are logged accordingly