### PR TITLE
Fixed MASButtonDisplayable rendering

### DIFF
--- a/Monika After Story/game/chess.rpy
+++ b/Monika After Story/game/chess.rpy
@@ -535,9 +535,9 @@ init:
                 self.BUTTON_Y_SPACING = 10
 
                 # hotkey button displayables
-                button_idle = Image(mas_getTimeFile("mod_assets/hkb_idle_background.png"))
-                button_hover = Image(mas_getTimeFile("mod_assets/hkb_hover_background.png"))
-                button_no = Image(mas_getTimeFile("mod_assets/hkb_disabled_background.png"))
+                button_idle = Frame(mas_getTimeFile("mod_assets/buttons/generic/idle_bg.png"), Borders(5, 5, 5, 5))
+                button_hover = Frame(mas_getTimeFile("mod_assets/buttons/generic/hover_bg.png"), Borders(5, 5, 5, 5))
+                button_no = Frame(mas_getTimeFile("mod_assets/buttons/generic/insensitive_bg.png"), Borders(5, 5, 5, 5))
 
                 # hotkey button text
                 # idle style/ disabled style:

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -1785,7 +1785,7 @@ python early:
             # pull out the current button back and text and render them
             render_text, render_back = self._button_states[self._state]
             render_text = renpy.render(render_text, width, height, st, at)
-            render_back = renpy.render(render_back, width, height, st, at)
+            render_back = renpy.render(render_back, self.width, self.height, st, at)
 
             # what is the text's with and height
             rt_w, rt_h = render_text.get_size()

--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -128,9 +128,9 @@ init -1 python:
             )
 
             # button backs
-            button_idle = Image(mas_getTimeFile("mod_assets/hkb_idle_background.png"))
-            button_hover = Image(mas_getTimeFile("mod_assets/hkb_hover_background.png"))
-            button_disabled = Image(mas_getTimeFile("mod_assets/hkb_disabled_background.png"))
+            button_idle = Frame(mas_getTimeFile("mod_assets/buttons/generic/idle_bg.png"), Borders(5, 5, 5, 5))
+            button_hover = Frame(mas_getTimeFile("mod_assets/buttons/generic/hover_bg.png"), Borders(5, 5, 5, 5))
+            button_disabled = Frame(mas_getTimeFile("mod_assets/buttons/generic/insensitive_bg.png"), Borders(5, 5, 5, 5))
 
             # ok button text
             button_text_ok_idle = Text(

--- a/Monika After Story/game/zz_graphicsmenu.rpy
+++ b/Monika After Story/game/zz_graphicsmenu.rpy
@@ -68,15 +68,9 @@ init -1 python:
             )
 
             # button backs
-            button_idle = Image(
-                "gui/button/scrollable_menu_dark_idle_background.png" if store.mas_globals.dark_mode else "gui/button/scrollable_menu_idle_background.png"
-            )
-            button_hover = Image(
-                "gui/button/scrollable_menu_dark_hover_background.png" if store.mas_globals.dark_mode else "gui/button/scrollable_menu_hover_background.png"
-            )
-            button_disable = Image(
-                "gui/button/scrollable_menu_dark_disable_background.png" if store.mas_globals.dark_mode else "gui/button/scrollable_menu_disable_background.png"
-            )
+            button_idle = Frame(mas_getTimeFile("mod_assets/buttons/generic/idle_bg.png"), Borders(5, 5, 5, 5))
+            button_hover = Frame(mas_getTimeFile("mod_assets/buttons/generic/hover_bg.png"), Borders(5, 5, 5, 5))
+            button_disable = Frame(mas_getTimeFile("mod_assets/buttons/generic/insensitive_bg.png"), Borders(5, 5, 5, 5))
 
             # Auto button
             button_text_auto_idle = Text(

--- a/Monika After Story/game/zz_pianokeys.rpy
+++ b/Monika After Story/game/zz_pianokeys.rpy
@@ -2345,9 +2345,9 @@ init 810 python:
             self.lyrical_bar = Image(self.ZZPK_LYR_BAR)
 
             # button shit
-            button_idle = Image(mas_getTimeFile("mod_assets/hkb_idle_background.png"))
-            button_hover = Image(mas_getTimeFile("mod_assets/hkb_hover_background.png"))
-            button_disabled = Image(mas_getTimeFile("mod_assets/hkb_disabled_background.png"))
+            button_idle = Frame(mas_getTimeFile("mod_assets/buttons/generic/idle_bg.png"), Borders(5, 5, 5, 5))
+            button_hover = Frame(mas_getTimeFile("mod_assets/buttons/generic/hover_bg.png"), Borders(5, 5, 5, 5))
+            button_disabled = Frame(mas_getTimeFile("mod_assets/buttons/generic/insensitive_bg.png"), Borders(5, 5, 5, 5))
 
             # button text
             button_done_text_idle = Text(


### PR DESCRIPTION
Smallest possible change, so any custom button will now support frames.
Any other user of this class is unaffected. If an instance of the `Image` class is passed as a background, then it still being drawn as usual.