### PR TITLE
MASButtonDisplayable Enhancements and fixes

### DIFF
--- a/Monika After Story/game/chess.rpy
+++ b/Monika After Story/game/chess.rpy
@@ -539,53 +539,6 @@ init:
                 button_hover = Image(mas_getTimeFile("mod_assets/hkb_hover_background.png"))
                 button_no = Image(mas_getTimeFile("mod_assets/hkb_disabled_background.png"))
 
-                # hotkey button text
-                # idle style/ disabled style:
-                button_text_save_idle = Text(
-                    _("Save"),
-                    font=gui.default_font,
-                    size=gui.text_size,
-                    color=mas_globals.button_text_idle_color,
-                    outlines=[]
-                )
-                button_text_giveup_idle = Text(
-                    _("Give Up"),
-                    font=gui.default_font,
-                    size=gui.text_size,
-                    color=mas_globals.button_text_idle_color,
-                    outlines=[]
-                )
-                button_text_done_idle = Text(
-                    _("Done"),
-                    font=gui.default_font,
-                    size=gui.text_size,
-                    color=mas_globals.button_text_idle_color,
-                    outlines=[]
-                )
-
-                # hover style
-                button_text_save_hover = Text(
-                    _("Save"),
-                    font=gui.default_font,
-                    size=gui.text_size,
-                    color=mas_globals.button_text_hover_color,
-                    outlines=[]
-                )
-                button_text_giveup_hover = Text(
-                    _("Give Up"),
-                    font=gui.default_font,
-                    size=gui.text_size,
-                    color=mas_globals.button_text_hover_color,
-                    outlines=[]
-                )
-                button_text_done_hover = Text(
-                    _("Done"),
-                    font=gui.default_font,
-                    size=gui.text_size,
-                    color=mas_globals.button_text_hover_color,
-                    outlines=[]
-                )
-
                 # calculate positions
                 self.drawn_board_x = int((1280 - self.BOARD_WIDTH) / 2)
                 self.drawn_board_y=  int((720 - self.BOARD_HEIGHT) / 2)
@@ -604,10 +557,9 @@ init:
                 )
 
                 # now the actual 3 buttons
-                self._button_save = MASButtonDisplayable(
-                    button_text_save_idle,
-                    button_text_save_hover,
-                    button_text_save_idle,
+                self._button_save = MASButtonDisplayable.create_st(
+                    _("Save"),
+                    True,
                     button_idle,
                     button_hover,
                     button_no,
@@ -618,10 +570,9 @@ init:
                     hover_sound=gui.hover_sound,
                     activate_sound=gui.activate_sound
                 )
-                self._button_giveup = MASButtonDisplayable(
-                    button_text_giveup_idle,
-                    button_text_giveup_hover,
-                    button_text_giveup_idle,
+                self._button_giveup = MASButtonDisplayable.create_st(
+                    _("Give Up"),
+                    True,
                     button_idle,
                     button_hover,
                     button_no,
@@ -632,10 +583,9 @@ init:
                     hover_sound=gui.hover_sound,
                     activate_sound=gui.activate_sound
                 )
-                self._button_done = MASButtonDisplayable(
-                    button_text_done_idle,
-                    button_text_done_hover,
-                    button_text_done_idle,
+                self._button_done = MASButtonDisplayable.create_st(
+                    _("Done"),
+                    False,
                     button_idle,
                     button_hover,
                     button_no,

--- a/Monika After Story/game/chess.rpy
+++ b/Monika After Story/game/chess.rpy
@@ -579,7 +579,7 @@ init:
                     drawn_button_y_bot,
                     self.BUTTON_WIDTH,
                     self.BUTTON_HEIGHT,
-                    hover_sound=gui.activate_sound,
+                    hover_sound=gui.hover_sound,
                     activate_sound=gui.activate_sound
                 )
 

--- a/Monika After Story/game/chess.rpy
+++ b/Monika After Story/game/chess.rpy
@@ -535,9 +535,9 @@ init:
                 self.BUTTON_Y_SPACING = 10
 
                 # hotkey button displayables
-                button_idle = Image(mas_getTimeFile("mod_assets/hkb_idle_background.png"))
-                button_hover = Image(mas_getTimeFile("mod_assets/hkb_hover_background.png"))
-                button_no = Image(mas_getTimeFile("mod_assets/hkb_disabled_background.png"))
+                button_idle = Frame(mas_getTimeFile("mod_assets/buttons/generic/idle_bg.png"), Borders(5, 5, 5, 5))
+                button_hover = Frame(mas_getTimeFile("mod_assets/buttons/generic/hover_bg.png"), Borders(5, 5, 5, 5))
+                button_no = Frame(mas_getTimeFile("mod_assets/buttons/generic/insensitive_bg.png"), Borders(5, 5, 5, 5))
 
                 # calculate positions
                 self.drawn_board_x = int((1280 - self.BOARD_WIDTH) / 2)

--- a/Monika After Story/game/chess.rpy
+++ b/Monika After Story/game/chess.rpy
@@ -534,11 +534,6 @@ init:
                 self.BUTTON_X_SPACING = 10
                 self.BUTTON_Y_SPACING = 10
 
-                # hotkey button displayables
-                button_idle = Frame(mas_getTimeFile("mod_assets/buttons/generic/idle_bg.png"), Borders(5, 5, 5, 5))
-                button_hover = Frame(mas_getTimeFile("mod_assets/buttons/generic/hover_bg.png"), Borders(5, 5, 5, 5))
-                button_no = Frame(mas_getTimeFile("mod_assets/buttons/generic/insensitive_bg.png"), Borders(5, 5, 5, 5))
-
                 # calculate positions
                 self.drawn_board_x = int((1280 - self.BOARD_WIDTH) / 2)
                 self.drawn_board_y=  int((720 - self.BOARD_HEIGHT) / 2)
@@ -557,12 +552,9 @@ init:
                 )
 
                 # now the actual 3 buttons
-                self._button_save = MASButtonDisplayable.create_st(
+                self._button_save = MASButtonDisplayable.create_stb(
                     _("Save"),
                     True,
-                    button_idle,
-                    button_hover,
-                    button_no,
                     drawn_button_x,
                     drawn_button_y_top,
                     self.BUTTON_WIDTH,
@@ -570,12 +562,9 @@ init:
                     hover_sound=gui.hover_sound,
                     activate_sound=gui.activate_sound
                 )
-                self._button_giveup = MASButtonDisplayable.create_st(
+                self._button_giveup = MASButtonDisplayable.create_stb(
                     _("Give Up"),
                     True,
-                    button_idle,
-                    button_hover,
-                    button_no,
                     drawn_button_x,
                     drawn_button_y_bot,
                     self.BUTTON_WIDTH,
@@ -583,12 +572,9 @@ init:
                     hover_sound=gui.hover_sound,
                     activate_sound=gui.activate_sound
                 )
-                self._button_done = MASButtonDisplayable.create_st(
+                self._button_done = MASButtonDisplayable.create_stb(
                     _("Done"),
                     False,
-                    button_idle,
-                    button_hover,
-                    button_no,
                     drawn_button_x,
                     drawn_button_y_bot,
                     self.BUTTON_WIDTH,

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -1904,7 +1904,7 @@ python early:
             # pull out the current button back and text and render them
             render_text, render_back = self._button_states[self._state]
             render_text = renpy.render(render_text, width, height, st, at)
-            render_back = renpy.render(render_back, width, height, st, at)
+            render_back = renpy.render(render_back, self.width, self.height, st, at)
 
             # what is the text's with and height
             rt_w, rt_h = render_text.get_size()

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -1794,6 +1794,7 @@ python early:
                         - disable_back
                 **kwargs - keyword args to pass into constructor
             """
+            # determine disabled stuff
             if incl_disb_text:
                 disb_button = Text(
                     text_str,
@@ -1802,12 +1803,7 @@ python early:
                     color=mas_globals.button_text_insensitive_color,
                     outlines=[]
                 )
-                disb_back = Frame(
-                    mas_getTimeFile(
-                        "mod_assets/buttons/generic/insensitive_bg.png"
-                    ),
-                    Borders(5, 5, 5, 5)
-                )
+                disb_back = MASButtonDisplayable._gen_bg("insensitive")
             else:
                 disb_button = Null()
                 disb_back = Null()
@@ -1828,18 +1824,41 @@ python early:
                     outlines=[],
                 ),
                 disb_button,
-                Frame(
-                    mas_getTimeFile("mod_assets/buttons/generic/idle_bg.png"),
-                    Borders(5, 5, 5, 5)
-                ),
-                Frame(
-                    mas_getTimeFile("mod_assets/buttons/generic/hover_bg.png"),
-                    Borders(5, 5, 5, 5)
-                ),
+                MASButtonDisplayable._gen_bg("idle"),
+                MASButtonDisplayable._gen_bg("hover"),
                 disb_back,
                 *args,
                 **kwargs
             )
+
+        @staticmethod
+        def _gen_bg(prefix):
+            """
+            Attempts to pull choice button's Frame and build an appropraite
+                image with it using the given prefix. 
+                This is specifically for MASButtonDisplayables.
+
+            IN:
+                prefix - prefix to use in the frame
+                    do NOT append "_"
+
+            RETURNS: Frame object to use
+            """
+            gen_frame = mas_prefixFrame(
+                mas_getPropFromStyle("choice_button", "background"),
+                prefix
+            )
+
+            if gen_frame is None:
+                # backup frame in case cannot find choice
+                return Frame(
+                    mas_getTimeFile(
+                        "mod_assets/buttons/generic/{0}_bg.png".format(prefix)
+                    ),
+                    Borders(5, 5, 5, 5)
+                )
+
+            return gen_frame
 
         def disable(self):
             """

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -1688,7 +1688,6 @@ python early:
             # current state
             self._state = self._STATE_IDLE
 
-
         def _isOverMe(self, x, y):
             """
             Checks if the given x and y coodrinates are over this button.
@@ -1700,14 +1699,12 @@ python early:
                 and 0 <= (y - self.ypos) <= self.height
             )
 
-
         def _playActivateSound(self):
             """
             Plays the activate sound if we are allowed to.
             """
             if not self.disabled or self.sound_when_disabled:
                 renpy.play(self.activate_sound, channel="sound")
-
 
         def _playHoverSound(self):
             """
@@ -1716,6 +1713,133 @@ python early:
             if not self.disabled or self.sound_when_disabled:
                 renpy.play(self.hover_sound, channel="sound")
 
+        @staticmethod
+        def create_st(
+                text_str,
+                incl_disb_text,
+                *args,
+                **kwargs
+        ):
+            """
+            Creates a MASButtonDisplyable using a single text string.
+
+            Default font/textsize/colors/outlines are used here.
+
+            IN:
+                text_str - the text to use for the button
+                incl_disb_text - True if we may have a disabled state for
+                    this button, False if not
+                *args - positional args to pass into constructor.
+                    do NOT include:
+                        - idle_text
+                        - hover_text
+                        - disable_text
+                **kwargs - keyword args to pass into constructor
+
+            RETURNS: created MASButtondisplayable
+            """
+            if incl_disb_text:
+                disb_button = Text(
+                    text_str,
+                    font=gui.default_font,
+                    size=gui.text_size,
+                    color=mas_globals.button_text_insensitive_color,
+                    outlines=[]
+                )
+            else:
+                disb_button = Null()
+
+            return MASButtonDisplayable(
+                Text(
+                    text_str,
+                    font=gui.default_font,
+                    size=gui.text_size,
+                    color=mas_globals.button_text_idle_color,
+                    outlines=[]
+                ),
+                Text(
+                    text_str,
+                    font=gui.default_font,
+                    size=gui.text_size,
+                    color=mas_globals.button_text_hover_color,
+                    outlines=[],
+                ),
+                disb_button,
+                *args,
+                **kwargs
+            )
+
+        @staticmethod
+        def create_stb(
+                text_str,
+                incl_disb_text,
+                *args,
+                **kwargs
+        ):
+            """
+            Creates a MASButtonDisplayable using a snigle text string and
+            standard button images.
+
+            IN:
+                text_str - the text to use for the button
+                incl_disb_text - True if we may have a disabled state for this
+                    button, False if not
+                *args - positional args to pass into constructor.
+                    do NOT include:
+                        - idle_text
+                        - hover_text
+                        - disable_text
+                        - idle_back
+                        - hover_back
+                        - disable_back
+                **kwargs - keyword args to pass into constructor
+            """
+            if incl_disb_text:
+                disb_button = Text(
+                    text_str,
+                    font=gui.default_font,
+                    size=gui.text_size,
+                    color=mas_globals.button_text_insensitive_color,
+                    outlines=[]
+                )
+                disb_back = Frame(
+                    mas_getTimeFile(
+                        "mod_assets/buttons/generic/insensitive_bg.png"
+                    ),
+                    Borders(5, 5, 5, 5)
+                )
+            else:
+                disb_button = Null()
+                disb_back = Null()
+
+            return MASButtonDisplayable(
+                Text(
+                    text_str,
+                    font=gui.default_font,
+                    size=gui.text_size,
+                    color=mas_globals.button_text_idle_color,
+                    outlines=[]
+                ),
+                Text(
+                    text_str,
+                    font=gui.default_font,
+                    size=gui.text_size,
+                    color=mas_globals.button_text_hover_color,
+                    outlines=[],
+                ),
+                disb_button,
+                Frame(
+                    mas_getTimeFile("mod_assets/buttons/generic/idle_bg.png"),
+                    Borders(5, 5, 5, 5)
+                ),
+                Frame(
+                    mas_getTimeFile("mod_assets/buttons/generic/hover_bg.png"),
+                    Borders(5, 5, 5, 5)
+                ),
+                disb_back,
+                *args,
+                **kwargs
+            )
 
         def disable(self):
             """
@@ -1726,7 +1850,6 @@ python early:
             self.disabled = True
             self._state = self._STATE_DISABLED
 
-
         def enable(self):
             """
             Enables this button. This changes the internal state, so its
@@ -1735,7 +1858,6 @@ python early:
             """
             self.disabled = False
             self._state = self._STATE_IDLE
-
 
         def getSize(self):
             """
@@ -1747,7 +1869,6 @@ python early:
                     [1]: height
             """
             return (self.width, self.height)
-
 
         def ground(self):
             """
@@ -1766,7 +1887,6 @@ python early:
                 else:
                     self._state = self._STATE_IDLE
 
-
         def hover(self):
             """
             Hovers this button. This changes the internal state, so its
@@ -1778,7 +1898,6 @@ python early:
             if not self.disabled or self.enable_when_disabled:
                 self.hovered = True
                 self._state = self._STATE_HOVER
-
 
         def render(self, width, height, st, at):
 
@@ -1802,7 +1921,6 @@ python early:
 
             # return rendere
             return r
-
 
         def event(self, ev, x, y, st):
 

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -537,10 +537,13 @@ style choice_button_dark is generic_button_dark:
     xysize (420, None)
     padding (100, 5, 100, 5)
 
-style choice_button_text is generic_button_text_light
+style choice_button_text is generic_button_text_light:
+    text_align 0.5
+    layout "subtitle"
 
-style choice_button_text_dark is generic_button_text_dark
-
+style choice_button_text_dark is generic_button_text_dark:
+    text_align 0.5
+    layout "subtitle"
 
 init python:
     def RigMouse():
@@ -2389,9 +2392,11 @@ style twopane_scrollable_menu_button_dark is choice_button_dark:
 
 style twopane_scrollable_menu_button_text is choice_button_text:
     align (0.0, 0.0)
+    text_align 0.0
 
 style twopane_scrollable_menu_button_text_dark is choice_button_text_dark:
     align (0.0, 0.0)
+    text_align 0.0
 
 style twopane_scrollable_menu_new_button is twopane_scrollable_menu_button
 

--- a/Monika After Story/game/styles.rpy
+++ b/Monika After Story/game/styles.rpy
@@ -242,7 +242,7 @@ style generic_button_dark is generic_button_base:
 style generic_button_text_base:
     font gui.default_font
     size gui.text_size
-    align (0.5, 0.5)
+    align (0.5, 0.1)
     outlines []
 
 style generic_button_text_light is generic_button_text_base:

--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -127,75 +127,6 @@ init -1 python:
                 ysize=self.FRAME_HEIGHT
             )
 
-            # button backs
-            button_idle = Frame(mas_getTimeFile("mod_assets/buttons/generic/idle_bg.png"), Borders(5, 5, 5, 5))
-            button_hover = Frame(mas_getTimeFile("mod_assets/buttons/generic/hover_bg.png"), Borders(5, 5, 5, 5))
-            button_disabled = Frame(mas_getTimeFile("mod_assets/buttons/generic/insensitive_bg.png"), Borders(5, 5, 5, 5))
-
-            # ok button text
-            button_text_ok_idle = Text(
-                _("Ok"),
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_idle_color,
-                outlines=[]
-            )
-            button_text_ok_hover = Text(
-                _("Ok"),
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_hover_color,
-                outlines=[]
-            )
-
-            # cancel button text
-            button_text_cancel_idle = Text(
-                _("Cancel"),
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_idle_color,
-                outlines=[]
-            )
-            button_text_cancel_hover = Text(
-                _("Cancel"),
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_hover_color,
-                outlines=[]
-            )
-
-            # update button text
-            button_text_update_idle = Text(
-                _("Update"),
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_idle_color,
-                outlines=[]
-            )
-            button_text_update_hover = Text(
-                _("Update"),
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_hover_color,
-                outlines=[]
-            )
-
-            # retry button text
-            button_text_retry_idle = Text(
-                _("Retry"),
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_idle_color,
-                outlines=[]
-            )
-            button_text_retry_hover = Text(
-                _("Retry"),
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_hover_color,
-                outlines=[]
-            )
-
             # calculate positions
             # top left x, y
             self._confirm_x = int((self.VIEW_WIDTH - self.FRAME_WIDTH) / 2)
@@ -227,13 +158,9 @@ init -1 python:
             button_left_y = button_center_y
 
             # create the buttons
-            self._button_ok = MASButtonDisplayable(
-                button_text_ok_idle,
-                button_text_ok_hover,
-                button_text_ok_idle,
-                button_idle,
-                button_hover,
-                button_idle,
+            self._button_ok = MASButtonDisplayable.create_stb(
+                _("Ok"),
+                False,
                 button_center_x,
                 button_center_y,
                 self.BUTTON_WIDTH,
@@ -242,13 +169,9 @@ init -1 python:
                 activate_sound=gui.activate_sound
             )
 
-            self._button_cancel = MASButtonDisplayable(
-                button_text_cancel_idle,
-                button_text_cancel_hover,
-                button_text_cancel_idle,
-                button_idle,
-                button_hover,
-                button_idle,
+            self._button_cancel = MASButtonDisplayable.create_stb(
+                _("Cancel"),
+                False,
                 button_left_x + self.BUTTON_WIDTH + self.BUTTON_SPACING,
                 button_left_y,
                 self.BUTTON_WIDTH,
@@ -257,13 +180,9 @@ init -1 python:
                 activate_sound=gui.activate_sound
             )
 
-            self._button_update = MASButtonDisplayable(
-                button_text_update_idle,
-                button_text_update_hover,
-                button_text_update_idle,
-                button_idle,
-                button_hover,
-                button_disabled,
+            self._button_update = MASButtonDisplayable.create_stb(
+                _("Update"),
+                True,
                 button_left_x,
                 button_left_y,
                 self.BUTTON_WIDTH,
@@ -272,13 +191,9 @@ init -1 python:
                 activate_sound=gui.activate_sound
             )
 
-            self._button_retry = MASButtonDisplayable(
-                button_text_retry_idle,
-                button_text_retry_hover,
-                button_text_retry_idle,
-                button_idle,
-                button_hover,
-                button_disabled,
+            self._button_retry = MASButtonDisplayable.create_stb(
+                _("Retry"),
+                True,
                 button_left_x,
                 button_left_y,
                 self.BUTTON_WIDTH,

--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -128,9 +128,9 @@ init -1 python:
             )
 
             # button backs
-            button_idle = Image(mas_getTimeFile("mod_assets/hkb_idle_background.png"))
-            button_hover = Image(mas_getTimeFile("mod_assets/hkb_hover_background.png"))
-            button_disabled = Image(mas_getTimeFile("mod_assets/hkb_disabled_background.png"))
+            button_idle = Frame(mas_getTimeFile("mod_assets/buttons/generic/idle_bg.png"), Borders(5, 5, 5, 5))
+            button_hover = Frame(mas_getTimeFile("mod_assets/buttons/generic/hover_bg.png"), Borders(5, 5, 5, 5))
+            button_disabled = Frame(mas_getTimeFile("mod_assets/buttons/generic/insensitive_bg.png"), Borders(5, 5, 5, 5))
 
             # ok button text
             button_text_ok_idle = Text(

--- a/Monika After Story/game/zz_graphicsmenu.rpy
+++ b/Monika After Story/game/zz_graphicsmenu.rpy
@@ -68,15 +68,9 @@ init -1 python:
             )
 
             # button backs
-            button_idle = Image(
-                "gui/button/scrollable_menu_dark_idle_background.png" if store.mas_globals.dark_mode else "gui/button/scrollable_menu_idle_background.png"
-            )
-            button_hover = Image(
-                "gui/button/scrollable_menu_dark_hover_background.png" if store.mas_globals.dark_mode else "gui/button/scrollable_menu_hover_background.png"
-            )
-            button_disable = Image(
-                "gui/button/scrollable_menu_dark_disable_background.png" if store.mas_globals.dark_mode else "gui/button/scrollable_menu_disable_background.png"
-            )
+            button_idle = Frame(mas_getTimeFile("mod_assets/buttons/generic/idle_bg.png"), Borders(5, 5, 5, 5))
+            button_hover = Frame(mas_getTimeFile("mod_assets/buttons/generic/hover_bg.png"), Borders(5, 5, 5, 5))
+            button_disable = Frame(mas_getTimeFile("mod_assets/buttons/generic/insensitive_bg.png"), Borders(5, 5, 5, 5))
 
             # Auto button
             button_text_auto_idle = Text(

--- a/Monika After Story/game/zz_graphicsmenu.rpy
+++ b/Monika After Story/game/zz_graphicsmenu.rpy
@@ -67,91 +67,6 @@ init -1 python:
                 ysize=self.VIEW_HEIGHT
             )
 
-            # button backs
-            button_idle = Frame(mas_getTimeFile("mod_assets/buttons/generic/idle_bg.png"), Borders(5, 5, 5, 5))
-            button_hover = Frame(mas_getTimeFile("mod_assets/buttons/generic/hover_bg.png"), Borders(5, 5, 5, 5))
-            button_disable = Frame(mas_getTimeFile("mod_assets/buttons/generic/insensitive_bg.png"), Borders(5, 5, 5, 5))
-
-            # Auto button
-            button_text_auto_idle = Text(
-                "Automatically Choose",
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_idle_color,
-                outlines=[]
-            )
-            button_text_auto_hover = Text(
-                "Automatically Choose",
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_hover_color,
-                outlines=[]
-            )
-
-            # GL button
-            button_text_gl_idle = Text(
-                "OpenGL",
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_idle_color,
-                outlines=[]
-            )
-            button_text_gl_hover = Text(
-                "OpenGL",
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_hover_color,
-                outlines=[]
-            )
-
-            # DirectX button
-            button_text_dx_idle = Text(
-                "Angle/DirectX",
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_idle_color,
-                outlines=[]
-            )
-            button_text_dx_hover = Text(
-                "Angle/DirectX",
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_hover_color,
-                outlines=[]
-            )
-
-            # Software button
-            button_text_sw_idle = Text(
-                "Software",
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_idle_color,
-                outlines=[]
-            )
-            button_text_sw_hover = Text(
-                "Software",
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_hover_color,
-                outlines=[]
-            )
-
-            # Return button
-            button_text_ret_idle = Text(
-                "Return",
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_idle_color,
-                outlines=[]
-            )
-            button_text_ret_hover = Text(
-                "Return",
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_hover_color,
-                outlines=[]
-            )
-
             # calculate positions
             # top left x,y of button area
             button_x = int((self.VIEW_WIDTH - self.BUTTON_WIDTH) / 2)
@@ -159,7 +74,7 @@ init -1 python:
 
             # create teh buttons
             self.button_auto = MASButtonDisplayable.create_stb(
-                "Automatically Choose",
+                _("Automatically Choose"),
                 True,
                 button_x,
                 button_y,
@@ -169,31 +84,9 @@ init -1 python:
                 activate_sound=gui.activate_sound,
                 return_value="auto"
             )
-            self.button_gl = MASButtonDisplayable(
-                Text(
-                    "OpenGL",
-                    font=gui.default_font,
-                    size=gui.text_size,
-                    color=mas_globals.button_text_idle_color,
-                    outlines=[]
-                ),
-                Text(
-                    "OpenGL",
-                    font=gui.default_font,
-                    size=gui.text_size,
-                    color=mas_globals.button_text_hover_color,
-                    outlines=[]
-                ),
-                Text(
-                    "OpenGL",
-                    font=gui.default_font,
-                    size=gui.text_size,
-                    color=mas_globals.button_text_insensitive_color,
-                    outlines=[]
-                ),
-                button_idle,
-                button_hover,
-                button_disable,
+            self.button_gl = MASButtonDisplayable.create_stb(
+                _("OpenGL"),
+                True,
                 button_x,
                 button_y + self.BUTTON_SPACING + self.BUTTON_HEIGHT,
                 self.BUTTON_WIDTH,
@@ -202,31 +95,9 @@ init -1 python:
                 activate_sound=gui.activate_sound,
                 return_value="gl"
             )
-            self.button_dx = MASButtonDisplayable(
-                Text(
-                    "Angle/DirectX",
-                    font=gui.default_font,
-                    size=gui.text_size,
-                    color=mas_globals.button_text_idle_color,
-                    outlines=[]
-                ),
-                Text(
-                    "Angle/DirectX",
-                    font=gui.default_font,
-                    size=gui.text_size,
-                    color=mas_globals.button_text_hover_color,
-                    outlines=[]
-                ),
-                Text(
-                    "Angle/DirectX",
-                    font=gui.default_font,
-                    size=gui.text_size,
-                    color=mas_globals.button_text_insensitive_color,
-                    outlines=[]
-                ),
-                button_idle,
-                button_hover,
-                button_disable,
+            self.button_dx = MASButtonDisplayable.create_stb(
+                _("Angle/DirectX"),
+                True,
                 button_x,
                 button_y + (2 * (self.BUTTON_SPACING + self.BUTTON_HEIGHT)),
                 self.BUTTON_WIDTH,
@@ -235,31 +106,9 @@ init -1 python:
                 activate_sound=gui.activate_sound,
                 return_value="angle"
             )
-            self.button_sw = MASButtonDisplayable(
-                Text(
-                    "Software",
-                    font=gui.default_font,
-                    size=gui.text_size,
-                    color=mas_globals.button_text_idle_color,
-                    outlines=[]
-                ),
-                Text(
-                    "Software",
-                    font=gui.default_font,
-                    size=gui.text_size,
-                    color=mas_globals.button_text_hover_color,
-                    outlines=[]
-                ),
-                Text(
-                    "Software",
-                    font=gui.default_font,
-                    size=gui.text_size,
-                    color=mas_globals.button_text_insensitive_color,
-                    outlines=[]
-                ),
-                button_idle,
-                button_hover,
-                button_disable,
+            self.button_sw = MASButtonDisplayable.create_stb(
+                _("Software"),
+                True,
                 button_x,
                 button_y + (3 * (self.BUTTON_SPACING + self.BUTTON_HEIGHT)),
                 self.BUTTON_WIDTH,
@@ -269,7 +118,7 @@ init -1 python:
                 return_value="sw"
             )
             self.button_ret = MASButtonDisplayable.create_stb(
-                "Return",
+                _("Return"),
                 False,
                 button_x,
                 button_y + (4 * self.BUTTON_HEIGHT) + (5 * self.BUTTON_SPACING),
@@ -284,21 +133,21 @@ init -1 python:
             small_text_size = 18
             small_text_heading = 20
             self.text_instruct = Text(
-                "Select a renderer to use:",
+                _("Select a renderer to use:"),
                 font=gui.default_font,
                 size=gui.text_size,
                 color="#ffe6f4",
                 outlines=[]
             )
             self.text_restart = Text(
-                "*Changing the renderer requires a restart to take effect",
+                _("*Changing the renderer requires a restart to take effect"),
                 font=gui.default_font,
                 size=small_text_size,
                 color="#ffe6f4",
                 outlines=[]
             )
             self.text_current = Text(
-                "Current Renderer:",
+                _("Current Renderer:"),
                 font=gui.default_font,
                 size=small_text_heading,
                 color="#ffe6f4",

--- a/Monika After Story/game/zz_graphicsmenu.rpy
+++ b/Monika After Story/game/zz_graphicsmenu.rpy
@@ -164,13 +164,9 @@ init -1 python:
             button_y = self.BUTTON_Y_START
 
             # create teh buttons
-            self.button_auto = MASButtonDisplayable(
-                button_text_auto_idle,
-                button_text_auto_hover,
-                button_text_auto_idle,
-                button_idle,
-                button_hover,
-                button_disable,
+            self.button_auto = MASButtonDisplayable.create_stb(
+                "Automatically Choose",
+                True,
                 button_x,
                 button_y,
                 self.BUTTON_WIDTH,
@@ -180,9 +176,27 @@ init -1 python:
                 return_value="auto"
             )
             self.button_gl = MASButtonDisplayable(
-                button_text_gl_idle,
-                button_text_gl_hover,
-                button_text_gl_idle,
+                Text(
+                    "OpenGL",
+                    font=gui.default_font,
+                    size=gui.text_size,
+                    color=mas_globals.button_text_idle_color,
+                    outlines=[]
+                ),
+                Text(
+                    "OpenGL",
+                    font=gui.default_font,
+                    size=gui.text_size,
+                    color=mas_globals.button_text_hover_color,
+                    outlines=[]
+                ),
+                Text(
+                    "OpenGL",
+                    font=gui.default_font,
+                    size=gui.text_size,
+                    color=mas_globals.button_text_insensitive_color,
+                    outlines=[]
+                ),
                 button_idle,
                 button_hover,
                 button_disable,
@@ -195,9 +209,27 @@ init -1 python:
                 return_value="gl"
             )
             self.button_dx = MASButtonDisplayable(
-                button_text_dx_idle,
-                button_text_dx_hover,
-                button_text_dx_idle,
+                Text(
+                    "Angle/DirectX",
+                    font=gui.default_font,
+                    size=gui.text_size,
+                    color=mas_globals.button_text_idle_color,
+                    outlines=[]
+                ),
+                Text(
+                    "Angle/DirectX",
+                    font=gui.default_font,
+                    size=gui.text_size,
+                    color=mas_globals.button_text_hover_color,
+                    outlines=[]
+                ),
+                Text(
+                    "Angle/DirectX",
+                    font=gui.default_font,
+                    size=gui.text_size,
+                    color=mas_globals.button_text_insensitive_color,
+                    outlines=[]
+                ),
                 button_idle,
                 button_hover,
                 button_disable,
@@ -210,9 +242,27 @@ init -1 python:
                 return_value="angle"
             )
             self.button_sw = MASButtonDisplayable(
-                button_text_sw_idle,
-                button_text_sw_hover,
-                button_text_sw_idle,
+                Text(
+                    "Software",
+                    font=gui.default_font,
+                    size=gui.text_size,
+                    color=mas_globals.button_text_idle_color,
+                    outlines=[]
+                ),
+                Text(
+                    "Software",
+                    font=gui.default_font,
+                    size=gui.text_size,
+                    color=mas_globals.button_text_hover_color,
+                    outlines=[]
+                ),
+                Text(
+                    "Software",
+                    font=gui.default_font,
+                    size=gui.text_size,
+                    color=mas_globals.button_text_insensitive_color,
+                    outlines=[]
+                ),
                 button_idle,
                 button_hover,
                 button_disable,
@@ -224,13 +274,9 @@ init -1 python:
                 activate_sound=gui.activate_sound,
                 return_value="sw"
             )
-            self.button_ret = MASButtonDisplayable(
-                button_text_ret_idle,
-                button_text_ret_hover,
-                button_text_ret_idle,
-                button_idle,
-                button_hover,
-                button_disable,
+            self.button_ret = MASButtonDisplayable.create_stb(
+                "Return",
+                False,
                 button_x,
                 button_y + (4 * self.BUTTON_HEIGHT) + (5 * self.BUTTON_SPACING),
                 self.BUTTON_WIDTH,

--- a/Monika After Story/game/zz_pianokeys.rpy
+++ b/Monika After Story/game/zz_pianokeys.rpy
@@ -2418,7 +2418,7 @@ init 810 python:
             )
             self._button_quit = MASButtonDisplayable.create_stb(
                 _("Quit"),
-                True,
+                False,
                 pbutton_x_start + self.BUTTON_WIDTH + self.BUTTON_SPACING,
                 pbutton_y_start,
                 self.BUTTON_WIDTH,

--- a/Monika After Story/game/zz_pianokeys.rpy
+++ b/Monika After Story/game/zz_pianokeys.rpy
@@ -2345,9 +2345,9 @@ init 810 python:
             self.lyrical_bar = Image(self.ZZPK_LYR_BAR)
 
             # button shit
-            button_idle = Image(mas_getTimeFile("mod_assets/hkb_idle_background.png"))
-            button_hover = Image(mas_getTimeFile("mod_assets/hkb_hover_background.png"))
-            button_disabled = Image(mas_getTimeFile("mod_assets/hkb_disabled_background.png"))
+            button_idle = Frame(mas_getTimeFile("mod_assets/buttons/generic/idle_bg.png"), Borders(5, 5, 5, 5))
+            button_hover = Frame(mas_getTimeFile("mod_assets/buttons/generic/hover_bg.png"), Borders(5, 5, 5, 5))
+            button_disabled = Frame(mas_getTimeFile("mod_assets/buttons/generic/insensitive_bg.png"), Borders(5, 5, 5, 5))
 
             # button text
             button_done_text_idle = Text(

--- a/Monika After Story/game/zz_pianokeys.rpy
+++ b/Monika After Story/game/zz_pianokeys.rpy
@@ -2344,97 +2344,6 @@ init 810 python:
             # lyric bar
             self.lyrical_bar = Image(self.ZZPK_LYR_BAR)
 
-            # button shit
-            button_idle = Frame(mas_getTimeFile("mod_assets/buttons/generic/idle_bg.png"), Borders(5, 5, 5, 5))
-            button_hover = Frame(mas_getTimeFile("mod_assets/buttons/generic/hover_bg.png"), Borders(5, 5, 5, 5))
-            button_disabled = Frame(mas_getTimeFile("mod_assets/buttons/generic/insensitive_bg.png"), Borders(5, 5, 5, 5))
-
-            # button text
-            button_done_text_idle = Text(
-                "Done",
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_idle_color,
-                outlines=[]
-            )
-            button_done_text_hover = Text(
-                "Done",
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_hover_color,
-                outlines=[]
-            )
-            button_cancel_text_idle = Text(
-                "Cancel",
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_idle_color,
-                outlines=[]
-            )
-            button_cancel_text_hover = Text(
-                "Cancel",
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_hover_color,
-                outlines=[]
-            )
-            button_reset_text_idle = Text(
-                "Reset",
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_idle_color,
-                outlines=[]
-            )
-            button_reset_text_hover = Text(
-                "Reset",
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_hover_color,
-                outlines=[]
-            )
-            button_resetall_text_idle = Text(
-                "Reset All",
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_idle_color,
-                outlines=[]
-            )
-            button_resetall_text_hover = Text(
-                "Reset All",
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_hover_color,
-                outlines=[]
-            )
-            button_config_text_idle = Text(
-                "Config",
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_idle_color,
-                outlines=[]
-            )
-            button_config_text_hover = Text(
-                "Config",
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_hover_color,
-                outlines=[]
-            )
-            button_quit_text_idle = Text(
-                "Quit",
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_idle_color,
-                outlines=[]
-            )
-            button_quit_text_hover = Text(
-                "Quit",
-                font=gui.default_font,
-                size=gui.text_size,
-                color=mas_globals.button_text_hover_color,
-                outlines=[]
-            )
-
             # calculate button locations
             # buttons should be spaced by BUTTONS_SPACING
             cbutton_x_start = (
@@ -2455,13 +2364,9 @@ init 810 python:
             pbutton_y_start = cbutton_y_start
 
             # the 4 config buttons we have
-            self._button_done = MASButtonDisplayable(
-                button_done_text_idle,
-                button_done_text_hover,
-                button_done_text_idle,
-                button_idle,
-                button_hover,
-                button_disabled,
+            self._button_done = MASButtonDisplayable.create_stb(
+                _("Done"),
+                True,
                 cbutton_x_start,
                 cbutton_y_start,
                 self.BUTTON_WIDTH,
@@ -2469,13 +2374,9 @@ init 810 python:
                 hover_sound=gui.hover_sound,
                 activate_sound=gui.activate_sound
             )
-            self._button_cancel = MASButtonDisplayable(
-                button_cancel_text_idle,
-                button_cancel_text_hover,
-                button_cancel_text_idle,
-                button_idle,
-                button_hover,
-                button_disabled,
+            self._button_cancel = MASButtonDisplayable.create_stb(
+                _("Cancel"),
+                True,
                 cbutton_x_start + self.BUTTON_WIDTH + self.BUTTON_SPACING,
                 cbutton_y_start,
                 self.BUTTON_WIDTH,
@@ -2483,13 +2384,9 @@ init 810 python:
                 hover_sound=gui.hover_sound,
                 activate_sound=gui.activate_sound
             )
-            self._button_reset = MASButtonDisplayable(
-                button_reset_text_idle,
-                button_reset_text_hover,
-                button_reset_text_idle,
-                button_idle,
-                button_hover,
-                button_disabled,
+            self._button_reset = MASButtonDisplayable.create_stb(
+                _("Reset"),
+                True,
                 cbutton_x_start + ((self.BUTTON_WIDTH + self.BUTTON_SPACING) * 2),
                 cbutton_y_start,
                 self.BUTTON_WIDTH,
@@ -2497,13 +2394,9 @@ init 810 python:
                 hover_sound=gui.hover_sound,
                 activate_sound=gui.activate_sound
             )
-            self._button_resetall = MASButtonDisplayable(
-                button_resetall_text_idle,
-                button_resetall_text_hover,
-                button_resetall_text_idle,
-                button_idle,
-                button_hover,
-                button_disabled,
+            self._button_resetall = MASButtonDisplayable.create_stb(
+                _("Reset All"),
+                True,
                 cbutton_x_start + ((self.BUTTON_WIDTH + self.BUTTON_SPACING) * 2),
                 cbutton_y_start,
                 self.BUTTON_WIDTH,
@@ -2513,13 +2406,9 @@ init 810 python:
             )
 
             # the config button
-            self._button_config = MASButtonDisplayable(
-                button_config_text_idle,
-                button_config_text_hover,
-                button_config_text_idle,
-                button_idle,
-                button_hover,
-                button_disabled,
+            self._button_config = MASButtonDisplayable.create_stb(
+                _("Config"),
+                True,
                 pbutton_x_start,
                 pbutton_y_start,
                 self.BUTTON_WIDTH,
@@ -2527,13 +2416,9 @@ init 810 python:
                 hover_sound=gui.hover_sound,
                 activate_sound=gui.activate_sound
             )
-            self._button_quit = MASButtonDisplayable(
-                button_quit_text_idle,
-                button_quit_text_hover,
-                button_quit_text_idle,
-                button_idle,
-                button_hover,
-                button_disabled,
+            self._button_quit = MASButtonDisplayable.create_stb(
+                _("Quit"),
+                True,
                 pbutton_x_start + self.BUTTON_WIDTH + self.BUTTON_SPACING,
                 pbutton_y_start,
                 self.BUTTON_WIDTH,
@@ -2554,14 +2439,14 @@ init 810 python:
 
             # config help text
             self._config_wait_help = Text(
-                "Click on a pink area to change the keymap for that piano key",
+                _("Click on a pink area to change the keymap for that piano key"),
                 font=gui.default_font,
                 size=gui.text_size,
                 color="#fff",
                 outlines=[]
             )
             self._config_change_help = Text(
-                "Press the key you'd like to set this piano key to",
+                _("Press the key you'd like to set this piano key to"),
                 font=gui.default_font,
                 size=gui.text_size,
                 color="#fff",

--- a/Monika After Story/game/zz_transforms.rpy
+++ b/Monika After Story/game/zz_transforms.rpy
@@ -21,6 +21,82 @@ init -10 python:
         return renpy.display.image.images.get((char, expression), None)
 
 
+    def mas_getPropFromStyle(style_name, prop_name):
+        """
+        Retrieves a property from a style
+        Recursively checks parent styles until the property is found.
+
+        IN:
+            style_name - name of style as string
+            prop_name - property to find as string
+
+        RETURNS: value of the propery if we can find it, None if not found
+        """
+        style_name = (style_name,)
+        prop_not_found = True
+        while prop_not_found:
+            # pull from styles dict
+            # NOTE: directly accessing to avoid exceptions 
+            style_obj = renpy.style.styles.get(style_name, None)
+            if style_obj is None:
+                return None
+
+            # sanity check to ensure properties exists
+            if len(style_obj.properties) > 0:
+
+                # check for the prop we want
+                if prop_name in style_obj.properties[0]:
+                    return style_obj.properties[0][prop_name]
+
+            # otherwise check parent
+            if style_obj.parent is None:
+                return None
+
+            # recurse
+            style_name = style_obj.parent
+
+        # should never be reached
+        return None
+
+
+    def mas_prefixFrame(frm, prefix):
+        """
+        Generates a frame object with the given prefix substitued into the 
+        image. This effectively makes a copy of the given Frame object.
+
+        NOTE: cannot use _duplicate as it does shallow copy for some reason.
+
+        IN:
+            frm - Frame object
+            prefix - prefix to replace `prefix_`. "_" will be added if not
+                found
+
+        RETURNS: Frame object, or None if failed to make it
+        """
+        if not prefix.endswith("_"):
+            prefix += "_"
+
+        try:
+            # sve borders
+            frm_borders = {
+                "left": frm.left,
+                "top": frm.top,
+                "right": frm.right,
+                "bottom": frm.bottom,
+            }
+
+            # set image path
+            img_path = renpy.substitute(
+                frm.image.name,
+                scope={"prefix_": prefix}
+            )
+
+            # build frame
+            return Frame(img_path, **frm_borders)
+        except:
+            return None
+
+
 # user defined trasnforms
 transform leftin_slow(x=640, z=0.80, t=1.00):
     xcenter -300 yoffset 0 yanchor 1.0 ypos 1.03 zoom z*1.00 alpha 1.00 subpixel True


### PR DESCRIPTION
Includes fix from #5579 but obsoletes all other changes from that PR, so only merging that change here. The other PR will be closed.

# Key Changes
* From #5579 - fix button backs rendering to entire canvas in MASButtonDisplayable.render
* adds two new functions for button creation
    * `MASButtonDisplayable.create_st` - creates a button where the idle/hover/disable text is all the same 
    * `MASButtonDisplayable.create_stb` - creates a button where the idle/hover/disable text is all the same and the backgrounds use `choice_button`'s `background` frames if possible 
* all instances of MASButtonDisplayable now use grey text when disabled.

### API additions
* `mas_getPropFromStyle` - retrieves value of a property from a style. Use full names for a style (not style prefix). This obtains the actual value used by the style, so making any changes to this will affect anything using the style. Duplicate the object if you need something specific (duplicating is non-trivial so its up to the caller)
* `mas_prefixFrame` - extracts an image path from a frame and applies prefix to it using substitute, then builds a new frame with that image path. Only copies over image and left/top/right/bottom props (borders).

# Testing
* verify correct button behavior and appearance (grey text when disabled) in the following places:
    * chess
        * save - idle/hover/disabled (becomes not disabled after reaches the user's 5/6th turn)
        * give up - idle/hover/disabled (disabled during Monika's turn)
        * done - idle/hover
    * updater menu
        * update - idle/hover/disabled (disabled while checking for update, enabled when update found. could trick this by changing your version to a previous one)
        * cancel - idle/hover
        * retry - idle/hover/disabled (only appears if the first update check fails because of internet problems. becomes disabled while retrying. might be possible to trigger by killing internet connection while first update check runs)
        * Ok - idle/hover - appears if game is up-to-date
    * graphics menu
        * return - idle/hover
        * all the other buttons - idle/hover/disabled (disabled if they are the current renderer)
    * piano (normal mode)
        * config - idle/hover/disabled (disabled when a song has been completed)
        * quit - idle/hover
    * piano (config mode)
        * done - idle/hover/disabled (disabled while configuring a key)
        * cancel - idle/hover/disabled (disabled while **not** configuring a key)
        * reset all - idle/hover/disabled (appears while **not** configuring a key, disabled if no keyboard configuration exists)
        * reset - idle/hover/disabled (appears while configuring a key, disabled if the key has not been configured)