### PR TITLE
Substitute img for MASFilterSwitch if appropriate

### DIFF
--- a/Monika After Story/game/sprite-chart-matrix.rpy
+++ b/Monika After Story/game/sprite-chart-matrix.rpy
@@ -187,6 +187,9 @@ python early:
 
         RETURNS: ConditionSwitch for filters
         """
+        if isinstance(img, basestring):
+            img = renpy.substitute(img)
+
         args = []
         for flt in store.mas_sprites.FILTERS.iterkeys():
 


### PR DESCRIPTION
`ConditionSwitch` substitutes filepaths by default, `MASFilterSwitch` doesn't. Not big deal, but why make things harder?
```renpy
$ path = store.my_store.path_to_assets

# from this
image my_cool_asset = MASFilterSwitch(
    renpy.substitute("[path]asset-1.png")
)
# to this
image another_cool_asset = MASFilterSwitch(
    "[path]asset-2.png"
)
```
