### PR TITLE
Open door greet fix

### DIFF
--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1076,7 +1076,7 @@ default persistent.opendoor_knockyes = False
 init 5 python:
 
     # this greeting is disabled on certain days
-    if not (mas_isO31() or mas_isD25Season() or mas_isplayer_bday() or mas_isF14()):
+    if persistent.closed_self and not (mas_isO31() or mas_isD25Season() or mas_isplayer_bday() or mas_isF14()):
 
         ev_rules = dict()
         # why are we limiting this to certain day range?


### PR DESCRIPTION
It's possible for the open door greet to override the forced close greet. This checks for `persistent.closed_self` before making this greet available.

## Testing
set `opendoor.chance` to 1 and then force close the game. verify you get a forced closed greet and not an open door greet.