### PR TITLE
Default selectors to seen

### DIFF
--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -1292,7 +1292,7 @@ init python:
         eventdb=None,
         skipCalendar=False,
         restartBlacklist=False,
-        defaultSeenever=False,
+        markSeen=False,
         code="EVE"
     ):
         """
@@ -1314,7 +1314,7 @@ init python:
             restartBlacklist - True if this topic should be added to the restart blacklist
                 (Default: False)
 
-            defaultSeenever - True if this topic should be `True` in persistent._seen_ever.
+            markSeen - True if this topic should be `True` in persistent._seen_ever.
                 (Default: False)
 
             code - code of the event database to add to.
@@ -1350,7 +1350,7 @@ init python:
         if restartBlacklist:
             evhand.RESTART_BLKLST.append(event.eventlabel)
 
-        if defaultSeenever:
+        if markSeen:
             persistent._seen_ever[event.eventlabel] = True
 
         # now this event has passsed checks, we can add it to the db

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -199,7 +199,7 @@ init -950 python in mas_ev_data_ver:
             # go through verification map and verify
             verify = _verify_map.get(index, None)
             if verify is not None and not verify(ev_line[index]):
-                # verification failed! 
+                # verification failed!
                 return False
 
         return True
@@ -207,7 +207,7 @@ init -950 python in mas_ev_data_ver:
 
     def verify_event_data(per_db):
         """
-        Verifies event data of the given persistent data. Entries that are 
+        Verifies event data of the given persistent data. Entries that are
         invalid are removed. We only check the bits of data that we have, so
         data lines with smaller sizes are only validated for what they have.
 
@@ -317,10 +317,10 @@ init 4 python:
 #        persistent._mas_ev_reset_date = datetime.date.today()
 
 #    else:
-        # 
+        #
 
 
-    # the mapping is built here so events can use to build 
+    # the mapping is built here so events can use to build
     # map databses to a code
     mas_all_ev_db_map = {
         "EVE": store.evhand.event_database,
@@ -340,7 +340,7 @@ init 4 python:
 
 init 6 python:
     # here we combine the data from teh databases so we can have easy lookups.
-    
+
     # mainly to create centralized database for calendar lookup
     # (and possible general db lookups)
     mas_all_ev_db = {}
@@ -386,8 +386,8 @@ init 6 python:
 
     def mas_hideEVL(
             ev_label,
-            code, 
-            lock=False, 
+            code,
+            lock=False,
             derandom=False,
             depool=False,
             decond=False
@@ -418,8 +418,8 @@ init 6 python:
 
     def mas_showEVL(
             ev_label,
-            code, 
-            unlock=False, 
+            code,
+            unlock=False,
             _random=False,
             _pool=False,
         ):
@@ -588,7 +588,7 @@ init -880 python:
         A Delayed action consists of the following:
 
         All exceptions are logged
-      
+
         id - the unique ID of this DelayedAction
         ev - the event this action is associated with
         conditional - the logical conditional we want to check before performing
@@ -601,7 +601,7 @@ init -880 python:
             NOTE: this is not checked for existence
             NOTE: this can also be a callable
                 the event would be passd in as ev
-                if callable, make this return True upon success and false 
+                if callable, make this return True upon success and false
                     othrewise
         flowcheck - FC constant saying when this delayed action should be
             checked
@@ -610,7 +610,7 @@ init -880 python:
         executed - True if this delayed action has been executed
             - Delayed actions that have been executed CANNOT be executed again
         cond_is_callable - True if the conditional is a callable instead of
-            a eval check. 
+            a eval check.
             NOTE: we do not check callable for correctness
         """
         import store.mas_utils as m_util
@@ -618,7 +618,7 @@ init -880 python:
         ERR_COND = "[ERROR] delayed action has bad conditional '{0}' | {1}\n"
 
 
-        def __init__(self, 
+        def __init__(self,
                 _id,
                 ev,
                 conditional,
@@ -709,17 +709,17 @@ init -880 python:
                     else:
                         # action must be a callable
                         self.executed = self.action(ev=self.ev)
-                            
+
             except Exception as e:
                 self.m_util.writelog(self.ERR_COND.format(
                     self.conditional,
                     str(e)
-                ))                   
+                ))
 #                raise e
 
             return self.executed
 
-        
+
         @staticmethod
         def makeWithLabel(
                 _id,
@@ -814,7 +814,7 @@ init -880 python:
             action = mas_delayed_action_map[action_id]
 
             # bitcheck the flow
-            if (action.flowcheck & flow) > 0:                        
+            if (action.flowcheck & flow) > 0:
                 if action():
                     # then pop the item if it was successful
                     mas_removeDelayedAction(action_id)
@@ -866,7 +866,7 @@ init -880 python:
         """
         Creates delayed actions given ids as args
 
-        assumes each arg is a valid id 
+        assumes each arg is a valid id
         """
         mas_addDelayedActions_list(args)
 
@@ -884,7 +884,7 @@ init -880 python in mas_delact:
         Adds MASDelayedAction ids to the persistent mas delayed action list.
 
         NOTE: this is only meant for code that runs super early yet needs to
-        add MASDelayedActions. 
+        add MASDelayedActions.
 
         NOTE: This will NOT add duplicates.
 
@@ -948,7 +948,7 @@ init 994 python in mas_delact:
     # this is also where we initialize the delayed action map
     def loadDelayedActionMap():
         """
-        Checks the persistent delayed action list and generates the 
+        Checks the persistent delayed action list and generates the
         runtime map of delayed actions
         """
         store.mas_addDelayedActions_list(
@@ -959,7 +959,7 @@ init 994 python in mas_delact:
     def saveDelayedActionMap():
         """
         Checks the runtime map of delayed actions and saves them into the
-        persistent value. 
+        persistent value.
 
         NOTE: this does not ADD to the persistent's list. This recreates it
             entirely.
@@ -1238,7 +1238,7 @@ init -1 python in evhand:
         """
         _unlockEvent(eventdb.get(evlabel, None))
 
-    
+
     def addYearsetBlacklist(evl, expire_dt):
         """
         Adds the given evl to the yearset blacklist, with the given expiration
@@ -1288,29 +1288,38 @@ init python:
     import datetime
 
     def addEvent(
-            event,
-            eventdb=None,
-            skipCalendar=False,
-            restartBlacklist=False,
-            code="EVE"
-        ):
-        #
-        # Adds an event object to the given eventdb dict
-        # Properly checksfor label and conditional statements
-        # This function ensures that a bad item is not added to the database
-        #
-        # NOTE: this MUST be ran after init level 4.
-        #
-        # IN:
-        #   event - the Event object to add to database
-        #   eventdb - The Event databse (dict) we want to add to
-        #       NOTE: DEPRECATED. Use code instead.
-        #       NOTE: this can still be used for custom adds.
-        #       (Default: None)
-        #   skipCalendar - flag that marks wheter or not calendar check should
-        #       be skipped
-        #   code - code of the event database to add to.
-        #       (Default: EVE) - event database
+        event,
+        eventdb=None,
+        skipCalendar=False,
+        restartBlacklist=False,
+        defaultSeenever=False,
+        code="EVE"
+    ):
+        """
+        Adds an event object to the given eventdb dict
+        Properly checksfor label and conditional statements
+        This function ensures that a bad item is not added to the database
+
+        NOTE: this MUST be ran after init level 4.
+
+        IN:
+            event - the Event object to add to database
+            eventdb - The Event databse (dict) we want to add to
+                NOTE: DEPRECATED. Use code instead.
+                NOTE: this can still be used for custom adds.
+                (Default: None)
+            skipCalendar - flag that marks wheter or not calendar check should
+                be skipped
+
+            restartBlacklist - True if this topic should be added to the restart blacklist
+                (Default: False)
+
+            defaultSeenever - True if this topic should be `True` in persistent._seen_ever.
+                (Default: False)
+
+            code - code of the event database to add to.
+                (Default: EVE) - event database
+        """
         if eventdb is None:
             eventdb = mas_all_ev_db_map.get(code, None)
 
@@ -1340,6 +1349,9 @@ init python:
         # check whether we should add the event in the restart blacklist
         if restartBlacklist:
             evhand.RESTART_BLKLST.append(event.eventlabel)
+
+        if defaultSeenever:
+            persistent._seen_ever[event.eventlabel] = True
 
         # now this event has passsed checks, we can add it to the db
         eventdb.setdefault(event.eventlabel, event)
@@ -1484,7 +1496,7 @@ init python:
                 (Default: False)
         """
         if ev:
-            
+
             if unlock:
                 ev.unlocked = True
 
@@ -1592,7 +1604,7 @@ init python:
         """
         This adds low priority or order-sensitive events onto the bottom of
         the event list. This is slow, but rarely called and list should be small.
-        
+
         IN:
             @event_label - a renpy label for the event to be called
             notify - True will trigger a notification if appropriate, False
@@ -1967,7 +1979,7 @@ init python:
 init 1 python in evhand:
     # mainly to contain action-based functions and fill an appropriate action
     # map
-    # all action-based functions are designed for speed, so they don't 
+    # all action-based functions are designed for speed, so they don't
     # do any sort of sanity checks
     # NOTE: do NOT use these in dialogue code. These are designed for
     #   internal use only
@@ -2053,7 +2065,7 @@ label call_next_event:
         # TODO: we should have a way to keep track of how many topics/hr
         #   users tend to end up with. without this data we cant really do
         #   too many things based on topic freqeuency.
-        #if not seen_event(event_label): 
+        #if not seen_event(event_label):
         #    # give whatver the hourly rate is for unseens
         #    $ store.mas_xp._grant_xp(store.mas_xp.xp_rate)
 
@@ -2162,7 +2174,7 @@ label prompt_menu:
     $ mas_RaiseShield_dlg()
 
     if store.mas_globals.in_idle_mode:
-        # if talk is hit here, then we retrieve label from mailbox and 
+        # if talk is hit here, then we retrieve label from mailbox and
         # call it.
         # after the event is over, we drop shields return to idle flow
         $ cb_label = mas_idle_mailbox.get_idle_cb()
@@ -2228,7 +2240,7 @@ label prompt_menu:
         )
 
     #Top level menu
-    # NOTE: should we force this to a particualr exp considering that 
+    # NOTE: should we force this to a particualr exp considering that
     # monika now rotates
     # NOTE: actually we could use boredom setup in here.
     show monika at t21
@@ -2487,7 +2499,7 @@ label mas_bookmarks:
             ]
 
         # generate list of propmt/label tuples of bookmarks
-        bookmarks_pl = [ 
+        bookmarks_pl = [
             (renpy.substitute(ev.prompt), ev.eventlabel)
             for ev in mas_get_player_bookmarks()
         ]
@@ -2505,7 +2517,7 @@ label mas_bookmarks:
 
 
 label mas_bookmarks_loop:
-    
+
     # sanity check for bookmark data
     if len(bookmarks_pl) < 1 or len(bookmarks_pl) != len(bookmarks_disp):
         # ensure that we have at least 1 bookmark to deal with and the evs and
@@ -2595,7 +2607,7 @@ label mas_bookmarks_unbookmark_loop:
 
             # re-generate bookmarks disp
             bookmarks_disp = regen(bookmarks_pl)
-        
+
         show monika at t11
         m 1eua "Okay, [player]..."
 
@@ -2615,4 +2627,3 @@ label mas_bookmarks_unbookmark_loop:
             return bookmarks_disp
 
     jump mas_bookmarks_unbookmark_loop
-

--- a/Monika After Story/game/script-brbs.rpy
+++ b/Monika After Story/game/script-brbs.rpy
@@ -1,6 +1,6 @@
 ## This script file holds all of the brb topics
 # Some conventions:
-#   - All brbs should have their defaultSeenever set to True so they don't show up in unseen
+#   - All brbs should have their markSeen set to True so they don't show up in unseen
 #   - Brbs should return "idle" to move into idle mode
 #   - Brbs should be short and sweet. Nothing long which makes it feel like an actual topic or is keeping you away
 #       A good practice for these should be no more than 10 lines will be said before you go into idle mode.
@@ -15,7 +15,7 @@ init 5 python:
             pool=True,
             unlocked=True
         ),
-        defaultSeenever=True
+        markSeen=True
     )
 
 label monika_brb_idle:
@@ -73,7 +73,7 @@ init 5 python:
             pool=True,
             unlocked=True
         ),
-        defaultSeenever=True
+        markSeen=True
     )
 
 label monika_writing_idle:
@@ -120,7 +120,7 @@ init 5 python:
             pool=True,
             unlocked=True
         ),
-        defaultSeenever=True
+        markSeen=True
     )
 
 label monika_idle_shower:
@@ -202,7 +202,7 @@ init 5 python:
             pool=True,
             unlocked=True
         ),
-        defaultSeenever=True
+        markSeen=True
     )
 
 label monika_idle_game:

--- a/Monika After Story/game/script-brbs.rpy
+++ b/Monika After Story/game/script-brbs.rpy
@@ -1,6 +1,6 @@
 ## This script file holds all of the brb topics
 # Some conventions:
-#   - All brbs should have their persistent._seen_ever as True so they don't show up in unseen
+#   - All brbs should have their defaultSeenever set to True so they don't show up in unseen
 #   - Brbs should return "idle" to move into idle mode
 #   - Brbs should be short and sweet. Nothing long which makes it feel like an actual topic or is keeping you away
 #       A good practice for these should be no more than 10 lines will be said before you go into idle mode.
@@ -14,11 +14,9 @@ init 5 python:
             category=['be right back'],
             pool=True,
             unlocked=True
-        )
+        ),
+        defaultSeenever=True
     )
-
-    #BRBs should be seen
-    persistent._seen_ever["monika_brb_idle"] = True
 
 label monika_brb_idle:
     if mas_isMoniAff(higher=True):
@@ -74,11 +72,9 @@ init 5 python:
             category=['be right back'],
             pool=True,
             unlocked=True
-        )
+        ),
+        defaultSeenever=True
     )
-
-    #BRBs should be seen
-    persistent._seen_ever["monika_writing_idle"] = True
 
 label monika_writing_idle:
     if random.randint(1,5) == 1:
@@ -123,11 +119,9 @@ init 5 python:
             category=['be right back'],
             pool=True,
             unlocked=True
-        )
+        ),
+        defaultSeenever=True
     )
-
-    #BRBs should be seen
-    persistent._seen_ever["monika_idle_shower"] = True
 
 label monika_idle_shower:
     if mas_isMoniLove():
@@ -207,11 +201,9 @@ init 5 python:
             prompt="I'm going to game for a bit",
             pool=True,
             unlocked=True
-        )
+        ),
+        defaultSeenever=True
     )
-
-    #BRBs should be seen
-    persistent._seen_ever["monika_idle_game"] = True
 
 label monika_idle_game:
     m 1eud "Oh, you're going to play another game?"
@@ -224,7 +216,7 @@ label monika_idle_game:
             _("Enjoy your game!"),
             _("I'll be cheering you on!"),
             _("Do your best!")
-            ]
+        ]
         gaming_quip=renpy.random.choice(gaming_quips)
 
     m 3hub "[gaming_quip]"

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -6347,7 +6347,7 @@ init 5 python:
         ),
         code="CMP",
         skipCalendar=True,
-        defaultSeenever=True
+        markSeen=True
     )
 
     #Create the undo action rule
@@ -6402,7 +6402,7 @@ init 5 python:
         ),
         code="CMP",
         skipCalendar=True,
-        defaultSeenever=True
+        markSeen=True
     )
 
 label mas_bday_pool_happy_belated_bday:

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -192,7 +192,7 @@ init -810 python:
         start_dt=datetime.datetime(2019, 10, 31),
 
         # end is 1 day out in case of an overnight trick or treat
-        end_dt=datetime.datetime(2019, 11, 2) 
+        end_dt=datetime.datetime(2019, 11, 2)
     ))
 
 # Images
@@ -293,7 +293,7 @@ init -10 python:
             manually later.
 
         IN:
-            selection_pool - pool to select clothes from. If NOne, we get a 
+            selection_pool - pool to select clothes from. If NOne, we get a
                 default list of clothes with costume exprop
 
         RETURNS: a single MASClothes object of what to wear. None if cannot
@@ -325,7 +325,7 @@ init -10 python:
                     filt_sel_pool.append(cloth)
                 else:
                     wearing_costume = True
-                
+
 
         selection_pool = filt_sel_pool
 
@@ -1597,7 +1597,7 @@ init -10 python in mas_d25_utils:
             "mas_reaction_end",
             mas_frs._pick_starter_label()
         )
-    
+
 
 ####START: d25 arts
 
@@ -1873,7 +1873,7 @@ label mas_d25_gift_end:
             extend 3dku "Just having you here with me was more than enough."
         else:
             extend 3dku "Just being with you was all I wanted."
-        m 1eka "But the fact you took the time to get me something...{w=0.5}{nw}" 
+        m 1eka "But the fact you took the time to get me something...{w=0.5}{nw}"
         extend 3ekbsa "well I can't thank you enough."
         m 3ekbfa "It really makes me feel loved."
 
@@ -5116,7 +5116,7 @@ init 20 python:
  One where I{i}'{/i}m free,
  One where all my troubles are gone,
  One where all of my dreams come true.
- 
+
  But today is not any day,
  Today is special; today is your day.
  A day I can appreciate you even more for what you do.
@@ -5250,7 +5250,7 @@ label mas_pf14_monika_lovey_dovey:
 
     if mas_HistVerifyAll_k(True, "f14.actions.spent_f14"):
         m 3ekbsa "Valentine's Day is coming soon, and it just makes me so overwhelmingly happy knowing you're still by my side."
-        
+
     else:
         m 3ekbsa "Valentine's Day is coming soon, and it just gets me in a good mood because I know I have you by my side."
 
@@ -6117,7 +6117,7 @@ init -1 python:
             _date = datetime.date.today()
 
         return (
-            _date.month == mas_monika_birthday.month 
+            _date.month == mas_monika_birthday.month
             and _date.day == mas_monika_birthday.day
         )
 
@@ -6346,7 +6346,8 @@ init 5 python:
             years=[]
         ),
         code="CMP",
-        skipCalendar=True
+        skipCalendar=True,
+        defaultSeenever=True
     )
 
     #Create the undo action rule
@@ -6400,7 +6401,8 @@ init 5 python:
             years=[]
         ),
         code="CMP",
-        skipCalendar=True
+        skipCalendar=True,
+        defaultSeenever=True
     )
 
 label mas_bday_pool_happy_belated_bday:
@@ -7045,7 +7047,7 @@ label greeting_returned_home_bday:
         mas_isMonikaBirthday()
         and mas_isplayer_bday()
         and mas_isMoniNormal(higher=True)
-        and not persistent._mas_player_bday_in_player_bday_mode 
+        and not persistent._mas_player_bday_in_player_bday_mode
         and not persistent._mas_bday_sbp_reacted
         and checkout_time.date() < mas_monika_birthday
 

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -59,7 +59,7 @@ init 5 python:
             pool=True,
             rules={"no unlock": None}
         ),
-        defaultSeenever=True
+        markSeen=True
     )
 
 label monika_gender_redo:
@@ -544,7 +544,7 @@ init 5 python:
             pool=True,
             rules={"no unlock": None}
         ),
-        defaultSeenever=True
+        markSeen=True
     )
     #NOTE: This needs to be unlocked by the random name change event
 

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -45,7 +45,6 @@ label mas_gender:
 
     #Unlock the gender redo event
     $ mas_unlockEVL("monika_gender_redo","EVE")
-    $ persistent._seen_ever["monika_gender_redo"] = True # dont want this in unseen
 
     return "love"
 
@@ -59,7 +58,8 @@ init 5 python:
             unlocked=False,
             pool=True,
             rules={"no unlock": None}
-        )
+        ),
+        defaultSeenever=True
     )
 
 label monika_gender_redo:
@@ -530,7 +530,6 @@ label mas_preferredname:
 
     #Unlock the name change event
     $ mas_unlockEVL("monika_changename","EVE")
-    $ persistent._seen_ever["monika_changename"] = True
     return
 
 
@@ -544,7 +543,8 @@ init 5 python:
             unlocked=False,
             pool=True,
             rules={"no unlock": None}
-        )
+        ),
+        defaultSeenever=True
     )
     #NOTE: This needs to be unlocked by the random name change event
 
@@ -1370,7 +1370,7 @@ label mas_crashed_quip_takecare:
     m 2ekc "Another crash, [player]?"
 
     if persistent._mas_idle_data.get("monika_idle_game", False):
-    
+
         m 3ekc "Do you think it had something to do with your game?{nw}"
         $ _history_list.pop()
         menu:
@@ -1666,7 +1666,7 @@ label monika_rpy_files:
         m 2etc "Unless..."
         m 4eua "Maybe you installed a version with the source code on purpose because you are trying to help me come closer to your reality!"
         m 2eka "But in case you didn't, I figured I'd ask..."
-    
+
         m "Are you sure you installed the right version, [player]?{nw}"
         $ _history_list.pop()
         menu:
@@ -1805,7 +1805,7 @@ label mas_bday_player_bday_select_select:
         m 2eksdlc "[player]..."
         m 2rksdlc "You know I'm asking for your exact date of birth, right?"
         m 2hksdlb "It's just I'm having a hard time believing you're {i}that{/i} young."
- 
+
     else:
         m 1eua "Alright, [player]."
 
@@ -1848,7 +1848,7 @@ label mas_bday_player_bday_select_select:
                 selected_date,
                 range(selected_date.year,MASCalendar.MAX_VIEWABLE_YEAR)
             )
- 
+
     else:
         python:
             store.mas_calendar.addRepeatable_d(
@@ -2104,7 +2104,7 @@ label mas_change_to_def:
     elif mas_isMoniNormal(lower=True) and monika_chr.clothes != mas_clothes_def:
         m 1eka "Hey [player], I miss my old school uniform..."
         m 3eka "I'm just going to go change, be right back..."
-        
+
         call mas_clothes_change()
 
         m "Okay, what else should we do today?"

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -1302,7 +1302,7 @@ label monika_outfit:
 
         if mas_isMoniLove():
             m 3eka "I'll wear whatever outfit you like, just ask~"
-        
+
         m 2eua "Do you know any artists?"
         m 3sua "Maybe they could make some more outfits for me to wear!"
 
@@ -1544,12 +1544,12 @@ label monika_kiss_tease:
     m 2efu "I had you going for a second there, didn't I?"
     m 2eka "Of course you can kiss me, [player]!"
     return
-    
+
 init 5 python:
     addEvent(
         Event(
             persistent.event_database,
-            eventlabel="monika_think_first_kiss", 
+            eventlabel="monika_think_first_kiss",
             conditional=(
                 "persistent._mas_first_kiss is not None "
                 "and mas_timePastSince(persistent._mas_first_kiss, datetime.timedelta(days=30))"
@@ -1894,7 +1894,7 @@ label monika_holdme_start:
 label monika_holdme_reactions:
     $ elapsed_time = datetime.datetime.now() - start_time
     $ store.mas_history._pm_holdme_adj_times(elapsed_time)
-    
+
     # stop the timer if the holding time is less than 30 minutes
     if elapsed_time <= datetime.timedelta(minutes=30):
         $ play_song(None, fadeout=1.0)
@@ -4123,7 +4123,7 @@ label monika_mountain:
     m 1eua "How one would hike up through the forests and trees..."
     m 1eub "Climbing up cliff faces and trudge through streams..."
     m "Hearing nothing but the birds and the sounds of the mountain as you made your way up its heights."
-    show monika 5rub at t11 zorder MAS_MONIKA_Z with dissolve 
+    show monika 5rub at t11 zorder MAS_MONIKA_Z with dissolve
     m 5rub "And finally...after all the effort and struggles..."
     m 5eub "Finding yourself standing at the top, knowing that you made it, seeing the testament to your success around you."
     m 5eka "I...I truly want to share that with you."
@@ -4144,7 +4144,7 @@ label monika_mountain:
 
             show monika 1eud at t11 zorder MAS_MONIKA_Z with dissolve
             m 1eud "Oh."
-            m 1ruc "Well... I suppose it doesn't matter." 
+            m 1ruc "Well... I suppose it doesn't matter."
             m 1eka "As long as I have you, I'll be happy wherever we are."
 
     return "derandom"
@@ -5234,11 +5234,9 @@ init 5 python:
             prompt="Good [mas_globals.time_of_day_3state]",
             unlocked=True,
             pool=True
-        )
+        ),
+        defaultSeenever=True
     )
-
-    #Ideally, we don't really want this in unseen as it's pretty general
-    persistent._seen_ever["monika_good_tod"] = True
 
 label monika_good_tod:
     $ curr_hour = datetime.datetime.now().time().hour
@@ -5426,7 +5424,7 @@ label monika_penname:
                         while not penbool:
                             $ penname = renpy.input("What is your penname?",length=20).strip(' \t\n\r')
                             $ lowerpen = penname.lower()
-            
+
                             if lowerpen == player.lower():
                                 m 1eud "Oh, so you're using your pen name?"
                                 m 4euc "I'd like to think we are on a first name basis with each other. We are dating, after all."
@@ -6541,7 +6539,7 @@ label monika_rock:
             m 1ekc "Oh... That's okay, everyone has their own taste in music."
             m 1hua "Though, if you ever do decide to listen to some rock 'n' roll, I'll happily listen right alongside you."
     return "derandom"
-    
+
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_standup",category=['literature','media'],prompt="Stand-up comedy",random=True))
 
@@ -6557,7 +6555,7 @@ label monika_standup:
     m 4esa "It differs from making simple one-liner jokes, because it really needs to tell a story."
     m 4eud "But at the same time, you have to make sure you don't lose your audience."
     m 2euc "So it's important to develop your ideas as much as you can, maybe even segueing into something that relates to your topic..."
-    m 2eub "All the while keeping your audience captivated until you reach the punch line;{w=0.5} hopefully resulting in lots of laughs."    
+    m 2eub "All the while keeping your audience captivated until you reach the punch line;{w=0.5} hopefully resulting in lots of laughs."
     m 3esa "In some ways, it's kind of like writing a short story, except you cut out the falling action."
     m 3esc "And yet between the jokes, you can find the soul of the writer...{w=0.5}what their thoughts and feelings are towards any given subject..."
     m 3esd "...What their life experiences were, and who they are today."
@@ -6570,7 +6568,7 @@ label monika_standup:
     m 3esa "It's kind of like poetry in that way, don't you think?"
     m 2rksdlc "A lot of people won't even try stand-up for themselves because they have to face a crowd..."
     m 2eksdlc "Did you know that the number one fear most people have is public speaking?"
-    m 4wud "Number two is death.{w=0.5} Death is number two!{w=0.5} What's the deal with that?!" 
+    m 4wud "Number two is death.{w=0.5} Death is number two!{w=0.5} What's the deal with that?!"
     m 4eud "This means to the average person, if you go to a funeral, you're better off in the casket..."
     m 4tub "...than doing the eulogy!"
     m 1hub "...Ahaha! Sorry, I wanted to tell you a joke Jerry Seinfeld once wrote--"
@@ -6773,7 +6771,7 @@ label monika_sports:
             m 4hub "Ahaha! I'm only joking..."
             m 4eka "Just playing with you as my partner is more than enough for me, [player]~"
 
-        "No, but if it were with you...": 
+        "No, but if it were with you...":
             $ persistent._mas_pm_like_playing_sports = True
             # NOTE: we cant really determine from this answer if you do like
             #   playing tennis or not.
@@ -8909,7 +8907,7 @@ label monika_timeconcern_night_1:
                     m 1eua "If you're doing it this one time then it must be {i}really{/i} important."
                     m 1hub "Good luck with your work and thanks for keeping me company when you're so busy!"
                     m 1eka "It means a lot to me, [player], that even when you're preoccupied...you're here with me~"
- 
+
         "No, I'm not.":
             $ persistent._mas_timeconcern = 3
             m 1esc "I see."
@@ -9712,7 +9710,7 @@ default persistent._mas_pm_driving_can_drive = None
 # Is the player learning to drive
 default persistent._mas_pm_driving_learning = None
 
-# Has the player been in an accident 
+# Has the player been in an accident
 default persistent._mas_pm_driving_been_in_accident = None
 
 # Has the player driven much after the accident
@@ -9750,7 +9748,7 @@ label monika_driving:
                 "I've been in an accident before.":
                     $ persistent._mas_pm_driving_been_in_accident = True
                     m 2ekc "Oh..."
-                    m 2lksdlc "Sorry to bring that up, [player]..." 
+                    m 2lksdlc "Sorry to bring that up, [player]..."
                     m 2lksdld "I just..."
                     m 2ekc "I hope it wasn't too bad."
                     m 2lksdlb "I mean, here you are with me so it must have been alright."
@@ -9773,7 +9771,7 @@ label monika_driving:
                 "I haven't.":
                     $ persistent._mas_pm_driving_been_in_accident = False
                     m 1eua "I'm glad you haven't had to go through anything like that."
-                    m 1eka "Even just seeing one can be pretty scary." 
+                    m 1eka "Even just seeing one can be pretty scary."
                     m "If you do witness anything scary like that, I'll be here to comfort you."
         "I'm learning.":
             $ persistent._mas_pm_driving_can_drive = True
@@ -9946,7 +9944,7 @@ label monika_bullying:
             m 1dkc "It may seem like no one cares, but there has to be someone you trust that you can turn to."
             m 3ekc "And if there isn't, do what you have to do to protect yourself, and just remember..."
             m 1eka "I'll always love you no matter what."
-            m 1rksdlc "I don't know what I'd do if something were to happen to you." 
+            m 1rksdlc "I don't know what I'd do if something were to happen to you."
             m 1ektpa "You're all I have...{w=0.5}please stay safe."
 
         "I've been bullied.":
@@ -10056,7 +10054,7 @@ label monika_procrastination:
     m 3eua "So if you have something you've been putting off, why don't you go do it right now?"
     m 1hua "If it's something you can do right here, I'll stay with you and provide all the support you need."
     m 1hub "Then, when you're done, we can celebrate your accomplishment!"
-    m 1eka "All I want is for you to be happy and to be the best you can be, [player]~"    
+    m 1eka "All I want is for you to be happy and to be the best you can be, [player]~"
     return
 
 init 5 python:
@@ -10396,7 +10394,7 @@ label monika_grad_speech_call:
             m "So, [player], now that you actually {i}heard{/i} my speech, what do you think?{nw}"
             $ _history_list.pop()
             #another timed menu checking if you were listening
-            show screen mas_background_timed_jump(10, "monika_grad_speech_ignored_lock") 
+            show screen mas_background_timed_jump(10, "monika_grad_speech_ignored_lock")
             menu:
                 m "So, [player], now that you actually {i}heard{/i} my speech, what do you think?{fast}"
                 #If menu is used, set player on a good path
@@ -10421,7 +10419,7 @@ label monika_grad_speech_call:
                     $ persistent._mas_pm_liked_grad_speech = True
 
                     m 2eka "Thanks for listening this time, [player]~"
-                    m "I'm so glad you enjoyed it!"                   
+                    m "I'm so glad you enjoyed it!"
 
                 "That {i}was{/i} long":
                     hide screen mas_background_timed_jump
@@ -10520,7 +10518,7 @@ label monika_grad_speech:
     m 4eud "{w=0.2}Today isn't about me.{w=0.7}{nw}"
     m 2esa "{w=0.2}Today is about celebrating what we all did.{w=0.6}{nw}"
     m 4eud "{w=0.2}We took on the challenge of our own dreams,{w=0.3} and from here,{w=0.3} the sky's the limit.{w=0.6}{nw}"
-    m 2eud "{w=0.2}Before moving on though,{w=0.3} I think we could all look back on our time here in high school and effectively end this chapter in our lives.{w=0.7}{nw}" 
+    m 2eud "{w=0.2}Before moving on though,{w=0.3} I think we could all look back on our time here in high school and effectively end this chapter in our lives.{w=0.7}{nw}"
     m 2hub "{w=0.2}We'll laugh at our past{w=0.7} and see just how far we've come in these four short years.{w=0.6}{nw}"
     m 2duu "{w=0.2}.{w=0.3}.{w=0.3}.{w=0.6}{nw}"
     m 2eud "{w=0.2}It honestly feels like just a couple weeks ago...{w=0.6}{nw}"
@@ -10545,7 +10543,7 @@ label monika_grad_speech:
     m 4eua "{w=0.2}Debate club taught me a lot about dealing with people and how to properly handle heated situations.{w=0.6}{nw}"
     m 4eub "Starting the literature club,{w=0.7} however,{w=0.7} was one of the best things I ever did.{w=0.6}{nw}"
     m 4hub "{w=0.2}I met the best friends I could have possibly imagined,{w=0.3} and I learned a lot about leadership.{w=0.6}{nw}"
-    m 2eka "{w=0.2}Sure,{w=0.3} not all of you may have decided to start your own clubs,{w=0.3} but I'm sure plenty of you had the opportunities to learn these values nonetheless.{w=0.6}{nw}" 
+    m 2eka "{w=0.2}Sure,{w=0.3} not all of you may have decided to start your own clubs,{w=0.3} but I'm sure plenty of you had the opportunities to learn these values nonetheless.{w=0.6}{nw}"
     m 4eub "{w=0.2}Maybe you yourself got into a position in band where you had to lead your instrument section,{w=0.3} or maybe you were the captain of a sports team!{w=0.6}{nw}"
     m 2eka "{w=0.2}All these small roles teach you so much about the future and how to manage both{w=0.3} projects and people,{w=0.3} in an environment you enjoy, nonetheless.{w=0.6}{nw}"
     m "{w=0.2}If you didn't join a club,{w=0.3} I encourage you to at least try something in your future paths.{w=0.6}{nw}"
@@ -10786,7 +10784,7 @@ label monika_savingwater:
         if mas_isMoniAff():
             m 3tsbsa "Maybe I'll even be willing to share if I'm feeling generous, ehehe~"
     return
-    
+
 init 5 python:
     addEvent(
         Event(
@@ -10863,7 +10861,7 @@ label monika_gotomonika:
         m "[player]...{w=1}don't tell me you would really give up your reality--the {i}real{/i} world--just to come {i}here{/i}, whatever this place is?{fast}"
         "I would.":
             $ persistent._mas_pm_would_come_to_spaceroom = True
-            
+
             m 4wkd "But [player]!"
             m "There's nothing to do here!"
             m 2dsc "Do you really hate your reality {i}that{/i} much?"
@@ -10942,7 +10940,7 @@ label monika_vehicle:
     m 1eua "When I think of cars, the first things that come to mind are probably the commonly known types."
     m 3eud "SUVs or pickup trucks, sports cars, sedans and hatchbacks..."
     m 3rksdlb "And while they're not really cars, I guess motorcycles are common vehicles too."
-    
+
     if persistent._mas_pm_driving_can_drive:
         m 1eua "What about you?"
 
@@ -11003,7 +11001,7 @@ label monika_vehicle:
         m 3rksdla "You sure asked an interesting question, ehehe..."
         m 1hua "Maybe that'll change one day and you'll get something then."
         m 1hubfb "That way, you can take me all sorts of places, ahaha!"
-    return 
+    return
 
 label monika_vehicle_sedan:
     $ persistent._mas_pm_owns_car_type = "sedan"
@@ -12190,9 +12188,9 @@ label monika_add_custom_music_instruct:
     m 3hub "See, [player], I told you it was easy, ahaha!"
 
     # unlock the topic as a pool topic, also mark it as seen
-    $ unlockEventLabel("monika_add_custom_music")
+    $ mas_unlockEVL("monika_add_custom_music", "EVE")
     $ persistent._seen_ever["monika_add_custom_music"] = True
-    $ unlockEventLabel("monika_load_custom_music")
+    $ mas_unlockEVL("monika_load_custom_music", "EVE")
     $ persistent._seen_ever["monika_load_custom_music"] = True
     return
 
@@ -12276,7 +12274,7 @@ label monika_mystery:
     m 2eua "Even cheesy action films use mystery elements to keep them interesting."
     m 4hksdlb "Though I guess a story with absolutely no form of mystery would be pretty boring!"
     return
-    
+
 init 5 python:
     addEvent(
         Event(
@@ -13373,7 +13371,7 @@ init 5 python:
             action=EV_ACT_RANDOM,
         )
     )
-            
+
 label monika_catch22:
     m 1euc "I've been doing some reading while you've been away, [player]."
     m 3eua "Have you ever heard of {i}Catch-22{/i}?"
@@ -13389,7 +13387,7 @@ label monika_catch22:
     m 1ekc "Sane or insane, all pilots were being sent out anyway...{w=0.5} {nw}"
     extend 3eua "That's when the reader is introduced to Catch-22."
     m 3eub "The captain even admires its genius once he learns how it works!"
-    m 1eua "Anyway, Yossarian continued flying and was close to completing the requirement needed to receive his discharge...{w=0.5}but his higher-up had other plans." 
+    m 1eua "Anyway, Yossarian continued flying and was close to completing the requirement needed to receive his discharge...{w=0.5}but his higher-up had other plans."
     m 3ekd "He kept increasing the amount of assignments the pilots needed to complete before they reached the required amount."
     m 3ekc "Once again, the reasoning was that it was specified in the clause of Catch-22."
     m 3esa "I'm sure you realize by now, it's a problem caused by conflicting or dependent conditions."
@@ -13946,7 +13944,7 @@ label monika_ship_of_theseus:
     m 1eua "Have you heard of the 'Ship of Theseus'?"
     m 3eua "It's a well known philosophical problem about the nature of identity that's been around for millennia."
     m 1rkb "Well, I say 'well known' but I suppose that's only true among scholars, ahaha..."
-    m 1eua "Let's consider the legendary Greek hero, Theseus and the ship he sailed during his adventures." 
+    m 1eua "Let's consider the legendary Greek hero, Theseus and the ship he sailed during his adventures."
     m 3eud "He's from a long time ago, so let's say his ship is now stored in a famous museum."
     m 3etc "If, due to repairs, his ship's parts were replaced bit by bit over a century, at what point has the ship lost its status as Theseus' ship?"
     m 3eud "Once a single part was replaced? {w=0.2}Half? {w=0.2}Or perhaps even all of them? {w=0.2}Maybe even never?{w=0.3} There's not really a consensus on the solution."

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -5235,7 +5235,7 @@ init 5 python:
             unlocked=True,
             pool=True
         ),
-        defaultSeenever=True
+        markSeen=True
     )
 
 label monika_good_tod:

--- a/Monika After Story/game/zz_selector.rpy
+++ b/Monika After Story/game/zz_selector.rpy
@@ -3449,7 +3449,7 @@ init 5 python:
             aff_range=(mas_aff.HAPPY, None)
         ),
         restartBlacklist=True,
-        defaultSeenever=True
+        markSeen=True
     )
 
     #Selectors shouldn't be in unseen
@@ -3532,7 +3532,7 @@ init 5 python:
             aff_range=(mas_aff.UPSET, mas_aff.NORMAL)
         ),
         restartBlacklist=True,
-        defaultSeenever=True
+        markSeen=True
     )
 
 label monika_event_clothes_select:
@@ -3599,7 +3599,7 @@ init 5 python:
             rules={"no unlock": None}
         ),
         restartBlacklist=True,
-        defaultSeenever=True
+        markSeen=True
     )
 
 label monika_hair_select:
@@ -3711,7 +3711,7 @@ init 5 python:
             aff_range=(mas_aff.HAPPY, None)
         ),
         restartBlacklist=True,
-        defaultSeenever=True
+        markSeen=True
     )
 
 label monika_hairclip_select:
@@ -3735,7 +3735,7 @@ init 5 python:
             aff_range=(mas_aff.HAPPY, None)
         ),
         restartBlacklist=True,
-        defaultSeenever=True
+        markSeen=True
     )
 
 label monika_hairflower_select:
@@ -3785,7 +3785,7 @@ init 5 python:
             aff_range=(mas_aff.HAPPY, None)
         ),
         restartBlacklist=True,
-        defaultSeenever=True
+        markSeen=True
     )
 
 label monika_choker_select:
@@ -3809,7 +3809,7 @@ init 5 python:
             aff_range=(mas_aff.HAPPY, None)
         ),
         restartBlacklist=True,
-        defaultSeenever=True
+        markSeen=True
     )
 
 label monika_hat_select:

--- a/Monika After Story/game/zz_selector.rpy
+++ b/Monika After Story/game/zz_selector.rpy
@@ -19,7 +19,7 @@ init -150 python in mas_selspr:
     import store.mas_utils as mas_utils
 
     ## selector rules
-    # selector rules are functions that should be checked prior to unlocking 
+    # selector rules are functions that should be checked prior to unlocking
     # a selector.
     # NOTE: all selector rules are assumed to be ran at runtime
 
@@ -676,7 +676,7 @@ init -10 python in mas_selspr:
             else:
                 lock_prompt(group)
 
-    
+
     def _switch_to_wear_prompts():
         """
         Switches all prompts for grp_topic_list topics to use their wear prompt.
@@ -1705,7 +1705,7 @@ init -10 python in mas_selspr:
             Returns the value of the outfit checkbox visible message
 
             RETURNS:
-                True if the outfit checkbox should be visible, False otherwise    
+                True if the outfit checkbox should be visible, False otherwise
             """
             return self._read(MB_OCB_VISIBLE)
 
@@ -1721,7 +1721,7 @@ init -10 python in mas_selspr:
             """
             Returns the value of the restore enable message
 
-            RETURNS: True if the restore button should be enabled, False 
+            RETURNS: True if the restore button should be enabled, False
                 otherwise
             """
             return self._read(MB_RSTR_ENABLE)
@@ -2215,7 +2215,7 @@ init -1 python:
             """
             if selected:
                 color = mas_ui.light_button_text_hover_color
-                
+
             else:
                 color = mas_globals.button_text_idle_color
 
@@ -2758,7 +2758,7 @@ init -1 python:
                         if self._is_over_me(x, y):
                             if self.disabled:
                                 self._select_disabled()
-                            
+
                             elif not self.locked:
                                 self._select()
                                 renpy.redraw(self, 0)
@@ -3032,7 +3032,7 @@ label mas_selector_sidebar_select(items, select_type, preview_selections=True, o
         # setup the mailbox
         if mailbox is None:
             mailbox = store.mas_selspr.MASSelectableSpriteMailbox()
-        
+
         # save state
         prev_moni_state = monika_chr.save_state(True, True, True)
         mailbox.send_prev_state(prev_moni_state)
@@ -3215,7 +3215,7 @@ label mas_selector_sidebar_select_restore:
             monika_chr,
             force=True
         )
-    
+
         # restore monika back to previous
         monika_chr.restore(prev_moni_state)
 
@@ -3385,11 +3385,11 @@ label mas_selector_sidebar_select_clothes(items, preview_selections=True, only_u
 #   idle_exp - the expression to use while the selector is runing.
 #       if None is passed in, we use the launch exp.
 #       (Default: None)
-#   sel_group - the selector group to use. 
+#   sel_group - the selector group to use.
 #       if None, we use the acs_type
 #       (Default: None)
 #   idle_dlg - dialogue shown while selector is running and nothing has been
-#       hovered/selected. 
+#       hovered/selected.
 #       if None, we use acs_type, which might be yuck:
 #       "Which <acs_type> would you like me to wear?"
 #       (Default: None)
@@ -3448,18 +3448,18 @@ init 5 python:
             unlocked=True,
             aff_range=(mas_aff.HAPPY, None)
         ),
-        restartBlacklist=True
+        restartBlacklist=True,
+        defaultSeenever=True
     )
 
+    #Selectors shouldn't be in unseen
+    persistent._seen_ever
 default persistent._mas_setting_ocb = False
 # Outfit CheckBox setting
 
 label monika_clothes_select:
-    # setup
+    #Setup
     python:
-        # set the other clothes selector to seen
-        persistent._seen_ever['monika_event_clothes_select'] = True
-
         mailbox = store.mas_selspr.MASSelectableSpriteMailbox(
             "Which clothes would you like me to wear?"
         )
@@ -3531,15 +3531,13 @@ init 5 python:
             rules={"no unlock": None},
             aff_range=(mas_aff.UPSET, mas_aff.NORMAL)
         ),
-        restartBlacklist=True
+        restartBlacklist=True,
+        defaultSeenever=True
     )
 
 label monika_event_clothes_select:
     # setup
     python:
-        # set the other clothes selector to seen
-        persistent._seen_ever['monika_clothes_select'] = True
-
         mailbox = store.mas_selspr.MASSelectableSpriteMailbox(
             "Do you want me to change?"
         )
@@ -3600,7 +3598,8 @@ init 5 python:
             unlocked=False,
             rules={"no unlock": None}
         ),
-        restartBlacklist=True
+        restartBlacklist=True,
+        defaultSeenever=True
     )
 
 label monika_hair_select:
@@ -3643,10 +3642,14 @@ init 5 python:
             prompt=store.mas_selspr.get_prompt("ribbon", "change"),
             pool=True,
             unlocked=False,
-            rules={"no unlock": None}
+            rules={"no unlock": None},
+            aff_range=(mas_aff.NORMAL, None)
         ),
         restartBlacklist=True
     )
+
+    #NOTE: This does not default persistent._seen_ever as True to give the users an idea
+    #That these are things which show up under the appearance tab
 
 label monika_ribbon_select:
     python:
@@ -3664,7 +3667,7 @@ label monika_ribbon_select:
                 )
             ):
                 use_acs.pop(index)
-        
+
         # make sure ot use ribbon for remover type
         use_acs.append(store.mas_selspr.create_selectable_remover(
             "ribbon",
@@ -3707,7 +3710,8 @@ init 5 python:
             rules={"no unlock": None},
             aff_range=(mas_aff.HAPPY, None)
         ),
-        restartBlacklist=True
+        restartBlacklist=True,
+        defaultSeenever=True
     )
 
 label monika_hairclip_select:
@@ -3730,7 +3734,8 @@ init 5 python:
             rules={"no unlock": None},
             aff_range=(mas_aff.HAPPY, None)
         ),
-        restartBlacklist=True
+        restartBlacklist=True,
+        defaultSeenever=True
     )
 
 label monika_hairflower_select:
@@ -3779,7 +3784,8 @@ init 5 python:
             rules={"no unlock": None},
             aff_range=(mas_aff.HAPPY, None)
         ),
-        restartBlacklist=True
+        restartBlacklist=True,
+        defaultSeenever=True
     )
 
 label monika_choker_select:
@@ -3802,7 +3808,8 @@ init 5 python:
             rules={"no unlock": None},
             aff_range=(mas_aff.HAPPY, None)
         ),
-        restartBlacklist=True
+        restartBlacklist=True,
+        defaultSeenever=True
     )
 
 label monika_hat_select:


### PR DESCRIPTION
This PR adds a new param to addEvent, `defaultSeenever`. It's the equivalent of adding a `persistent._seen_ever["topic_evl"] = True` after its addEvent.

I have also updated the documentation on the addEvent function.

Additionally, selectors now all default to seen with the exception of the ribbon selector, which is now `aff_range`d (Normal+), to indicate to the user that the Appearance tab is something where they can go to change Moni's appearance.

# Testing:
- Verify BRBs don't show up in unseen still,
- Verify that the happy birthday topics in the compliments menu are not italicized if you haven't used them before
- Verify that all selectors aside from the ribbon selector will default to a True _seen_ever