### PR TITLE
Fix the alignment of the return button in the game menu

### DIFF
--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -722,7 +722,8 @@ screen navigation():
             ## The quit button is banned on iOS and unnecessary on Android.
             textbutton _("Quit") action Quit(confirm=_confirm_quit)
 
-
+        if not main_menu:
+            textbutton _("Return") action Return()
 
 style navigation_button is gui_button:
     size_group "navigation"
@@ -928,11 +929,6 @@ screen game_menu(title, scroll=None):
 
     # if not main_menu and not persistent.menu_bg_m and renpy.random.randint(0, 49) == 0:
     #     on "show" action Show("game_menu_m")
-
-    textbutton _("Return"):
-        style "return_button"
-
-        action Return()
 
     label title style "game_menu_label"
 


### PR DESCRIPTION
Before:
![current](https://user-images.githubusercontent.com/53382877/80815850-0b2dc580-8bd7-11ea-9377-bad905d1ae60.PNG)
After:
![fixed](https://user-images.githubusercontent.com/53382877/80816685-9cea0280-8bd8-11ea-8bae-45e7d2c791e1.PNG)
For testing I made sure it always has the same alignment regardless of the other buttons, also checked that the main menu looks good (and doesn't have the button).