### PR TITLE
More pool unlocks

### DIFF
--- a/Monika After Story/game/progression.rpy
+++ b/Monika After Story/game/progression.rpy
@@ -224,12 +224,7 @@ init python in mas_xp:
 
         # unlock prompts
         for x in range(lvl_gained):
-            # do 5 per level
-            store.queueEvent("unlock_prompt")
-            store.queueEvent("unlock_prompt")
-            store.queueEvent("unlock_prompt")
-            store.queueEvent("unlock_prompt")
-            store.queueEvent("unlock_prompt")
+            store.mas_unlockPrompt(5)
 
         # set xp and lvls
         store.persistent._mas_xp_lvl += lvl_gained

--- a/Monika After Story/game/progression.rpy
+++ b/Monika After Story/game/progression.rpy
@@ -224,6 +224,11 @@ init python in mas_xp:
 
         # unlock prompts
         for x in range(lvl_gained):
+            # do 5 per level
+            store.queueEvent("unlock_prompt")
+            store.queueEvent("unlock_prompt")
+            store.queueEvent("unlock_prompt")
+            store.queueEvent("unlock_prompt")
             store.queueEvent("unlock_prompt")
 
         # set xp and lvls

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -372,6 +372,20 @@ label v0_3_1(version=version): # 0.3.1
     return
 
 # non generic updates go here
+
+label v0_11_3(version="v0_11_3"):
+    python:
+        # give extra pool unlocks for recent players
+        if mas_isFirstSeshPast(datetime.date(2020, 4, 4)):
+            # only 0.11.0 + week ago 
+
+            # NOTE: multiply by 4 becaue everyone should already have level
+            #   number of pool unlocks given (whether or not they were
+            #   used is not really a concern, as this is a very large freebie)
+            persistent._mas_pool_unlocks = store.mas_xp.level() * 4
+
+    return
+
 #0.11.1
 label v0_11_1(version="v0_11_1"):
     python:

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -380,9 +380,8 @@ label v0_11_3(version="v0_11_3"):
             # only 0.11.0 + week ago 
 
             # NOTE: multiply by 4 becaue everyone should already have level
-            #   number of pool unlocks given (whether or not they were
-            #   used is not really a concern, as this is a very large freebie)
-            persistent._mas_pool_unlocks = store.mas_xp.level() * 4
+            #   number of pool unlocks given 
+            persistent._mas_pool_unlocks += store.mas_xp.level() * 4
 
     return
 


### PR DESCRIPTION
# Key Changes
* increase pool unlocks per level to 5
* removes the `unlock_prompt` label and instead uses the function to unlock pool topics (`mas_unlockPrompt`). This function also now can be given a number of topics to unlock.
* update script to give people who started with the new xp system a boost 

# Testing
* verify that when you gain a level, you potentially unlock up to 5 pool topics, and any unused unlocks are added to `persistent._mas_pool_unlocks`. You can use `mas_xp._grant_xp` to directly grant xp.
* verify update script increases `persistent._mas_pool_unlocks` by the users's current level * 4 if they started after april 4. (**NOTE:** it is **increases** by level * 4. This is because pool unlocks should have already incremented normally for when levels are reached)