### PR TITLE
Infinite Loop override

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -19,7 +19,7 @@ python early:
     import traceback
     _dev_tb_list = []
 
-    def dummy():
+    def dummy(*args, **kwargs):
         """
         Dummy function that does nothing
         """

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -19,6 +19,15 @@ python early:
     import traceback
     _dev_tb_list = []
 
+    def dummy():
+        """
+        Dummy function that does nothing
+        """
+        return
+
+    # clear this so no more traceback. We expect node loops anyway
+    renpy.execution.check_infinite_loop = dummy
+
 
 # uncomment this if you want syntax highlighting support on vim
 # init -1 python:
@@ -3204,9 +3213,6 @@ init -1 python in _mas_root:
 
 init -999 python:
     import os
-
-    # this is initially set to 60 seconds
-    renpy.not_infinite_loop(120)
 
     # create the log folder if not exist
     if not os.access(os.path.normcase(renpy.config.basedir + "/log"), os.F_OK):

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -1321,10 +1321,6 @@ label monika_outfit:
         m 5hub "We're not that far into our relationship yet. Ahaha!"
     return
 
-# random infinite loop check
-python:
-    renpy.not_infinite_loop(60)
-
 default persistent._mas_pm_likes_horror = None
 default persistent._mas_pm_likes_spoops = False
 
@@ -1442,9 +1438,6 @@ label monika_rap:
             m 1ekc "Oh... Well I can understand that, rap music isn't everyone's taste."
             m 3hua "But if you ever do decide to give it a try, I'm sure we can find an artist or two that we both like!"
     return "derandom"
-
-python:
-    renpy.not_infinite_loop(60)
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_wine",category=['club members'],prompt="Yuri's wine",random=True))

--- a/Monika After Story/game/zz_extrasmenu.rpy
+++ b/Monika After Story/game/zz_extrasmenu.rpy
@@ -115,7 +115,6 @@ label mas_extra_menu_close:
 
 label mas_idle_loop:
     pause 10.0
-    $ renpy.not_infinite_loop(60)
     jump mas_idle_loop
 
 default persistent._mas_opened_extra_menu = False


### PR DESCRIPTION
# Key Changes
* `renpy.execution.check_infinite_loop` replaced with dummy function (that can be used for other overrides as well).
* removed instances of `not_infinite_loop`

# Testing
* verify no crashes/loop-related tracebacks