### PR TITLE
Added sanity checks for consumable events

### DIFF
--- a/Monika After Story/game/zz_consumables.rpy
+++ b/Monika After Story/game/zz_consumables.rpy
@@ -1432,8 +1432,7 @@ init 5 python:
 
 label mas_consumables_generic_queued_running_out:
     $ low_cons = MASConsumable._getLowCons()
-    if low_cons:
-        call mas_consumables_generic_queued_running_out_dlg(low_cons)
+    call mas_consumables_generic_queued_running_out_dlg(low_cons)
     return "no_unlock"
 
 init 5 python:
@@ -1446,12 +1445,15 @@ init 5 python:
 
 label mas_consumables_generic_running_out_absentuse:
     $ low_cons = MASConsumable._getLowConsNotWarned()
-    if low_cons:
-        call mas_consumables_generic_queued_running_out_dlg(low_cons)
+    call mas_consumables_generic_queued_running_out_dlg(low_cons)
     return "no_unlock"
 
 
 label mas_consumables_generic_queued_running_out_dlg(low_cons):
+    # sanity check for non-empty list
+    if not low_cons:
+        return
+
     m 1esc "By the way, [player]..."
     if len(low_cons) > 2:
         $ mas_generateShoppingList(low_cons)

--- a/Monika After Story/game/zz_consumables.rpy
+++ b/Monika After Story/game/zz_consumables.rpy
@@ -1432,7 +1432,8 @@ init 5 python:
 
 label mas_consumables_generic_queued_running_out:
     $ low_cons = MASConsumable._getLowCons()
-    call mas_consumables_generic_queued_running_out_dlg(low_cons)
+    if low_cons:
+        call mas_consumables_generic_queued_running_out_dlg(low_cons)
     return "no_unlock"
 
 init 5 python:
@@ -1445,7 +1446,8 @@ init 5 python:
 
 label mas_consumables_generic_running_out_absentuse:
     $ low_cons = MASConsumable._getLowConsNotWarned()
-    call mas_consumables_generic_queued_running_out_dlg(low_cons)
+    if low_cons:
+        call mas_consumables_generic_queued_running_out_dlg(low_cons)
     return "no_unlock"
 
 


### PR DESCRIPTION
Potentially closes #5721
It's possible to have 2 queued events. One is about running out of something, another is for gifting a consumable. If we get the gifting event first, we'll refill the consumables. Which will lead to a crash since the former event will get an empty list from `_getLowConsNotWarned`/`_getLowCons` (we just refilled).
I don't want to pop it from the event list, since we still can have another consumable that we want Monika to mention to the player. But we can add a check if we have at least 1 consumable which Monika is low on during the time we see the event.
For testing I set a consumable to low amount and said goodbye. Then I gifted the consumable and opened the game. Monika reacted on the gift and skipped the running out event.