### PR TITLE
fix an issue in getting sprite object info

### DIFF
--- a/Monika After Story/game/zz_reactions.rpy
+++ b/Monika After Story/game/zz_reactions.rpy
@@ -996,14 +996,14 @@ init python:
                 None
             )
             if giftname is None:
-                return (None, None, None, None)
+                return (None, None, None, None, None)
 
         elif len(persistent._mas_filereacts_sprite_reacted) > 0:
             sp_data = persistent._mas_filereacts_sprite_reacted.keys()[0]
             giftname = persistent._mas_filereacts_sprite_reacted[sp_data]
 
         else:
-            return (None, None, None, None)
+            return (None, None, None, None, None)
 
         # check if this gift has already been gifted
         gifted_before = sp_data in persistent._mas_sprites_json_gifted_sprites


### PR DESCRIPTION
So it turns out it was possible to return a tuple of *four* `None`s meaning that anywhere that unpacks the sprite data tuple would crash. This fixes said problem.

## Testing:
- Verify that `getSpriteObjInfo` always returns a tuple of 5 items.
- Verify that no reactions crash