### PR TITLE
Song Analysis Framework

### DIFF
--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -494,6 +494,9 @@ init 15 python in mas_affection:
         # always rebuild randos
         store.mas_idle_mailbox.send_rebuild_msg()
 
+        #Check the song analysis delegate
+        store.mas_songs.checkSongAnalysisDelegate()
+
 
     def _normalToUpset():
         """
@@ -530,6 +533,9 @@ init 15 python in mas_affection:
         # remove change to def outfit event in case it's been pushed
         store.mas_rmallEVL("mas_change_to_def")
 
+        #Check the song analysis delegate
+        store.mas_songs.checkSongAnalysisDelegate(HAPPY)
+
 
     def _happyToNormal():
         """
@@ -548,6 +554,9 @@ init 15 python in mas_affection:
         if store.monika_chr.clothes != store.mas_clothes_def and not store.mas_hasSpecialOutfit():
             store.pushEvent("mas_change_to_def",skipeval=True)
 
+        #Check the song analysis delegate
+        store.mas_songs.checkSongAnalysisDelegate(NORMAL)
+
 
     def _happyToAff():
         """
@@ -564,6 +573,8 @@ init 15 python in mas_affection:
         # always rebuild randos
         store.mas_idle_mailbox.send_rebuild_msg()
 
+        #Check the song analysis delegate
+        store.mas_songs.checkSongAnalysisDelegate(AFFECTIONATE)
 
     def _affToHappy():
         """
@@ -587,6 +598,8 @@ init 15 python in mas_affection:
         # always rebuild randos
         store.mas_idle_mailbox.send_rebuild_msg()
 
+        #Check the song analysis delegate
+        store.mas_songs.checkSongAnalysisDelegate(HAPPY)
 
     def _affToEnamored():
         """
@@ -608,6 +621,8 @@ init 15 python in mas_affection:
         # always rebuild randos
         store.mas_idle_mailbox.send_rebuild_msg()
 
+        #Check the song analysis delegate
+        store.mas_songs.checkSongAnalysisDelegate(ENAMORED)
 
     def _enamoredToAff():
         """
@@ -620,6 +635,8 @@ init 15 python in mas_affection:
         # always rebuild randos
         store.mas_idle_mailbox.send_rebuild_msg()
 
+        #Check the song analysis delegate
+        store.mas_songs.checkSongAnalysisDelegate(AFFECTIONATE)
 
     def _enamoredToLove():
         """
@@ -634,6 +651,8 @@ init 15 python in mas_affection:
         # always rebuild randos
         store.mas_idle_mailbox.send_rebuild_msg()
 
+        #Check the song analysis delegate
+        store.mas_songs.checkSongAnalysisDelegate(LOVE)
 
     def _loveToEnamored():
         """
@@ -646,6 +665,8 @@ init 15 python in mas_affection:
         # always rebuild randos
         store.mas_idle_mailbox.send_rebuild_msg()
 
+        #Check the song analysis delegate
+        store.mas_songs.checkSongAnalysisDelegate(ENAMORED)
 
     def _gSadToNormal():
         """

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1947,6 +1947,9 @@ label ch30_reset:
     #Check if we need to unlock the songs rand delegate
     $ mas_songs.checkRandSongDelegate()
 
+    #Now check the analysis ev
+    $ store.mas_songs.checkSongAnalysisDelegate()
+
     #Run a confirmed party check within a week of Moni's bday
     $ mas_confirmedParty()
 

--- a/Monika After Story/game/script-songs.rpy
+++ b/Monika After Story/game/script-songs.rpy
@@ -198,12 +198,15 @@ label monika_sing_song_pool_menu:
             if song_length == "short":
                 $ song_length = "long"
                 $ switch_str = "short"
+
             else:
                 $ song_length = "short"
                 $ switch_str = "full"
+
             $ end = "{fast}"
             $ _history_list.pop()
             jump monika_sing_song_pool_menu
+
         else:
             $ pushEvent(sel_song, skipeval=True)
             show monika at t11
@@ -249,10 +252,16 @@ label monika_sing_song_analysis:
     call screen mas_gen_scrollable_menu(unlocked_analyses, mas_ui.SCROLLABLE_MENU_TXT_AREA, mas_ui.SCROLLABLE_MENU_XALIGN, ret_back)
 
     $ sel_analysis = _return
-    $ pushEvent(sel_analysis, skipeval=True)
-    show monika at t11
-    m 3hub "Alright!"
+
+    if sel_analysis:
+        $ pushEvent(sel_analysis, skipeval=True)
+        show monika at t11
+        m 3hub "Alright!"
+
+    else:
+        return "prompt"
     return
+
 #START: Random song delegate
 init 5 python:
     addEvent(

--- a/Monika After Story/game/script-songs.rpy
+++ b/Monika After Story/game/script-songs.rpy
@@ -245,7 +245,7 @@ label monika_sing_song_analysis:
             which = "Which"
 
     show monika 1eua at t21
-    $ renpy.say(m, "[which] song would you like me to sing?", interact=False)
+    $ renpy.say(m, "[which] song would you like to talk about?", interact=False)
 
     call screen mas_gen_scrollable_menu(unlocked_analyses, mas_ui.SCROLLABLE_MENU_TXT_AREA, mas_ui.SCROLLABLE_MENU_XALIGN, ret_back)
 
@@ -291,7 +291,7 @@ label monika_sing_song_random:
             mas_unlockEVL(rand_song + "_analysis", "SNG")
 
             #If we have unlocked analyses for our current aff level, let's unlock the label
-            if hasUnlockedSongAnalyses():
+            if store.mas_songs.hasUnlockedSongAnalyses():
                 mas_unlockEVL("monika_sing_song_analysis", "EVE")
 
     #We have no songs! let's pull back the shown count for this and derandom

--- a/Monika After Story/game/script-songs.rpy
+++ b/Monika After Story/game/script-songs.rpy
@@ -225,8 +225,6 @@ init 5 python:
             eventlabel="monika_sing_song_analysis",
             prompt="Can you explain a song for me?",
             category=["music"],
-            conditional="store.mas_songs.hasUnlockedSongAnalyses()",
-            action=EV_ACT_UNLOCK,
             pool=True,
             unlocked=False,
             aff_range=(mas_aff.NORMAL, None),
@@ -291,6 +289,10 @@ label monika_sing_song_random:
 
             #And unlock the analysis of the song
             mas_unlockEVL(rand_song + "_analysis", "SNG")
+
+            #If we have unlocked analyses for our current aff level, let's unlock the label
+            if hasUnlockedSongAnalyses():
+                mas_unlockEVL("monika_sing_song_analysis", "EVE")
 
     #We have no songs! let's pull back the shown count for this and derandom
     else:

--- a/Monika After Story/game/script-songs.rpy
+++ b/Monika After Story/game/script-songs.rpy
@@ -5,13 +5,20 @@ init -10 python in mas_songs:
     song_db = {}
 
     #Song type constants
-    #NOTE: TYPE_SHORT will never be picked in the random delegate, these are filters for that
+    #NOTE: TYPE_LONG will never be picked in the random delegate, these are filters for that
+
     #TYPE_LONG songs should either be unlocked via a 'preview' song of TYPE_SHORT or (for ex.) some story event
     #TYPE_LONG songs would essentially be songs longer than 10-15 lines
     #NOTE: TYPE_LONG songs must have the same label name as their short song counterpart with '_long' added to the end so they unlock correctly
-    #Example: the long song for short song mas_song_example would be mas_song_example_long
+    #Example: the long song for short song mas_song_example would be: mas_song_example_long
+
+    #TYPE_ANALYSIS songs are events which provide an analysis for a song
+    #NOTE: Like TYPE_LONG songs, these must have the same label as the short counterpart, but with '_analysis' appended onto the end
+    #Using the example song above, the analysis label would be: mas_song_example_analysis
+
     TYPE_LONG = "long"
     TYPE_SHORT = "short"
+    TYPE_ANALYSIS = "analysis"
 
 init python in mas_songs:
     import store
@@ -31,7 +38,9 @@ init python in mas_songs:
         IN:
             length - a filter for the type of song we want. "long" for songs of TYPE_LONG
                 "short" for TYPE_SHORT or None for all songs. (Default None)
-        OUT: list of unlocked all songs of the desired length in tuple format for a scrollable menu
+
+        OUT:
+            list of unlocked all songs of the desired length in tuple format for a scrollable menu
         """
         if length is None:
             return [
@@ -59,6 +68,53 @@ init python in mas_songs:
             if ev.random and TYPE_SHORT in ev.category and ev.checkAffection(store.mas_curr_affection)
         ]
 
+    def checkSongAnalysisDelegate(curr_aff=None):
+        """
+        Checks to see if the song analysis topic should be unlocked or locked and does the appropriate action
+
+        IN:
+            curr_aff - Affection level to ev.checkAffection with. If none, mas_curr_affection is assumed
+                (Default: None)
+        """
+        if hasUnlockedSongAnalyses(curr_aff):
+            store.mas_unlockEVL("monika_sing_song_analysis", "EVE")
+        else:
+            store.mas_lockEVL("monika_sing_song_analysis", "EVE")
+
+    def getUnlockedSongAnalyses(curr_aff=None):
+        """
+        Gets a list of all song analysis evs in scrollable menu format
+
+        IN:
+            curr_aff - Affection level to ev.checkAffection with. If none, mas_curr_affection is assumed
+                (Default: None)
+
+        OUT:
+            List of unlocked song analysis topics in mas_gen_scrollable_menu format
+        """
+        if curr_aff is None:
+            curr_aff = store.mas_curr_affection
+
+        return [
+            (ev.prompt, ev_label, False, False)
+            for ev_label, ev in song_db.iteritems()
+            if ev.unlocked and TYPE_ANALYSIS in ev.category and ev.checkAffection(curr_aff)
+        ]
+
+    def hasUnlockedSongAnalyses(curr_aff=None):
+        """
+        Checks if there's any unlocked song analysis topics available
+
+        IN:
+            curr_aff - Affection level to ev.checkAffection with. If none, mas_curr_affection is assumed
+                (Default: None)
+        OUT:
+            boolean:
+                True if we have unlocked song analyses
+                False otherwise
+        """
+        return len(getUnlockedSongAnalyses(curr_aff)) > 0
+
     def hasUnlockedSongs(length=None):
         """
         Checks if the player has unlocked a song at any point via the random selection
@@ -81,7 +137,7 @@ init python in mas_songs:
         """
         return len(getRandomSongs()) > 0
 
-#START: Pool delegate for songs
+#START: Pool delegates for songs
 init 5 python:
     addEvent(
         Event(
@@ -158,6 +214,45 @@ label monika_sing_song_pool_menu:
 
     return
 
+#START: Song analysis delegate
+init 5 python:
+    addEvent(
+        Event(
+            persistent.event_database,
+            eventlabel="monika_sing_song_analysis",
+            prompt="Can you explain a song for me?",
+            category=["music"],
+            conditional="store.mas_songs.hasUnlockedSongAnalyses()",
+            action=EV_ACT_UNLOCK,
+            pool=True,
+            unlocked=False,
+            aff_range=(mas_aff.NORMAL, None),
+            rules={"no unlock": None}
+        )
+    )
+
+
+label monika_sing_song_analysis:
+    python:
+        ret_back = ("Nevermind.", False, False, False, 20)
+
+        unlocked_analyses = mas_songs.getUnlockedSongAnalyses()
+
+        if mas_isO31():
+            which = "Witch"
+        else:
+            which = "Which"
+
+    show monika 1eua at t21
+    $ renpy.say(m, "[which] song would you like me to sing?", interact=False)
+
+    call screen mas_gen_scrollable_menu(unlocked_analyses, mas_ui.SCROLLABLE_MENU_TXT_AREA, mas_ui.SCROLLABLE_MENU_XALIGN, ret_back)
+
+    $ sel_analysis = _return
+    $ pushEvent(sel_analysis, skipeval=True)
+    show monika at t11
+    m 3hub "Alright!"
+    return
 #START: Random song delegate
 init 5 python:
     addEvent(
@@ -183,7 +278,10 @@ label monika_sing_song_random:
             mas_unlockEVL(rand_song, "SNG")
 
             #Unlock the long version of the song
-            mas_unlockEVL(rand_song+"_long","SNG")
+            mas_unlockEVL(rand_song + "_long", "SNG")
+
+            #And unlock the analysis of the song
+            mas_unlockEVL(rand_song + "_analysis", "SNG")
 
     #We have no songs! let's pull back the shown count for this and derandom
     else:


### PR DESCRIPTION
Will be used for #5728 

Adds a new song analysis topic for the songs framework. This allows in-depth analysis for specific songs as a more optional approach.

These analysis topics in this subset will follow aff_range rules, so there have been functions added to all aff prog points which are at/above normal aff to verify if the topic should be unlocked or not.

Additionally, like long songs, these will automatically unlock when seeing their short variant if the analysis topic has the same eventlabel as the short song, but with `_analysis` added onto it.

## Testing:
- Verify that analysis topics unlock automatically if they're correctly labeled
- Verify that the topic to ask Monika to explain a song locks if there's no analyses available, or none available at the aff level you're at, and unlocks when there is something at your aff level.