### PR TITLE
Always show the base submod info on the submods screen

### DIFF
--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -2740,26 +2740,26 @@ screen submods():
 
             vbox:
                 style_prefix "check"
-                box_wrap False
-                xmaximum 1000
                 xfill True
+                xmaximum 1000
 
                 for submod in sorted(store.mas_submod_utils.submod_map.values(), key=lambda x: x.name):
-                    if submod.settings_pane:
+                    vbox:
+                        xfill True
+                        xmaximum 1000
+
                         label submod.name yanchor 0 xalign 0
+
                         hbox:
-                            box_wrap False
                             spacing 20
                             xmaximum 1000
 
                             text "v{}".format(submod.version) yanchor 0 xalign 0 style "main_menu_version"
                             text "by {}".format(submod.author) yanchor 0 xalign 0 style "main_menu_version"
 
-                        vbox:
-                            box_wrap False
-                            xfill True
-                            xmaximum 1000
-                            text submod.description
+                        text submod.description
+
+                    if submod.settings_pane:
                         $ renpy.display.screen.use_screen(submod.settings_pane, _name="{0}_{1}".format(submod.author, submod.name))
 
         vbar value YScrollValue("scrollme")

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -2757,7 +2757,8 @@ screen submods():
                             text "v{}".format(submod.version) yanchor 0 xalign 0 style "main_menu_version"
                             text "by {}".format(submod.author) yanchor 0 xalign 0 style "main_menu_version"
 
-                        text submod.description
+                        if submod.description:
+                            text submod.description
 
                     if submod.settings_pane:
                         $ renpy.display.screen.use_screen(submod.settings_pane, _name="{0}_{1}".format(submod.author, submod.name))


### PR DESCRIPTION
I suggest to show the base info (name, author, version) even for the submods that don't have setting pane specified. This way we make it clear for users which submods they have installed, and what version they're using (so they know if they need to update).

For testing make sure that the submods screen shows **all** installed submods. Also check that everything still looks good after the new changes.
```renpy
# Copy/paste for testing.
init -990 python in mas_submod_utils:
    Submod(
        author="Monika",
        name="Boops",
        description="A submod which allows me to boop you.",
        version="9.2.2"
    )
```