### PR TITLE
Consumables Dialogue Props

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -5202,7 +5202,7 @@ init python:
             #We want to modify only text
             if _tuple[0] == renpy.TEXT_TEXT:
                 contents[_id] = (_tuple[0], mas_a_an_str(_tuple[1]))
-                break
+                return contents
 
         return contents
 

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -5176,6 +5176,27 @@ init 2 python:
         if ref_str[0] in "aeiou":
             return "an"
         return "a"
+
+#EXTRA TEXT TAGS
+init python:
+    def a_an_tag(tag, argument, contents):
+        """
+        Handles a/an mid-string
+
+        NOTE: This should ONLY surround the exact word needing to be prefixed with a/an
+        All text tags should be kept OUTSIDE of the opening and closing tags for this function
+
+        Usage: I bought [player] {a_an}[tempvar]{/a_an}.
+
+        If tempvar was 'item,' the output is: I bought [player] an item.
+        If tempvar was 'coffee,' the output is: I bought [player] a coffee.
+        """
+        for kind, _text in contents:
+            if kind == renpy.TEXT_TEXT:
+                return [(kind, mas_a_an_str(_text))]
+
+    config.custom_text_tags["a_an"] = a_an_tag
+
 # Music
 define audio.t1 = "<loop 22.073>bgm/1.ogg"  #Main theme (title)
 define audio.t2 = "<loop 4.499>bgm/2.ogg"   #Sayori theme

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -5161,9 +5161,15 @@ init 2 python:
         OUT:
             string prefixed with a/an
         """
-        return "{0} {1}".format(mas_a_an(ref_str), ref_str)
+        return ("{0} {1}".format(
+            mas_a_an(
+                ref_str,
+                should_capitalize=ref_str[0].isupper()
+            ),
+            ref_str.lower() if ref_str[0].isupper() and not ref_str.isupper() else ref_str
+        ))
 
-    def mas_a_an(ref_str):
+    def mas_a_an(ref_str, should_capitalize):
         """
         Takes in a reference string and returns either a/an based on the first letter of the word
 
@@ -5173,9 +5179,9 @@ init 2 python:
         OUT:
             string prefixed with a/an
         """
-        if ref_str[0] in "aeiou":
-            return "an"
-        return "a"
+        if ref_str[0] in "aeiouAEIOU":
+            return "An" if should_capitalize else "an"
+        return "A" if should_capitalize else "a"
 
 #EXTRA TEXT TAGS
 init python:
@@ -5191,9 +5197,15 @@ init python:
         If tempvar was 'item,' the output is: I bought [player] an item.
         If tempvar was 'coffee,' the output is: I bought [player] a coffee.
         """
+        list_to_return = list()
         for kind, _text in contents:
+            #We want to modify only text
             if kind == renpy.TEXT_TEXT:
-                return [(kind, mas_a_an_str(_text))]
+                list_to_return.append((kind, mas_a_an_str(_text)))
+            else:
+                list_to_return.append((kind, _text))
+
+        return list_to_return
 
     config.custom_text_tags["a_an"] = a_an_tag
 

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -5161,10 +5161,21 @@ init 2 python:
         OUT:
             string prefixed with a/an
         """
-        if ref_str[0] in "aeiou":
-            return "an " + ref_str
-        return "a " + ref_str
+        return "{0} {1}".format(mas_a_an(ref_str), ref_str)
 
+    def mas_a_an(ref_str):
+        """
+        Takes in a reference string and returns either a/an based on the first letter of the word
+
+        IN:
+            ref_str - string in question to prefix
+
+        OUT:
+            string prefixed with a/an
+        """
+        if ref_str[0] in "aeiou":
+            return "an"
+        return "a"
 # Music
 define audio.t1 = "<loop 22.073>bgm/1.ogg"  #Main theme (title)
 define audio.t2 = "<loop 4.499>bgm/2.ogg"   #Sayori theme

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -5151,32 +5151,34 @@ init 2 python:
         #If we're here, that means we need to do some returns based on the values we put in
         return seen_all
 
-    def mas_a_an_str(ref_str):
+    def mas_a_an_str(ref_str, ignore_case=False):
         """
         Takes in a reference string and returns it back with an 'a' prefix or 'an' prefix depending on starting letter
 
         IN:
             ref_str - string in question to prefix
+            ignore_case - whether or not we should ignore capitalization of a/an and not adjust the capitalization of ref_str
 
         OUT:
             string prefixed with a/an
         """
         return ("{0} {1}".format(
-            mas_a_an(ref_str),
-            ref_str.lower() if ref_str[0].isupper() and not ref_str.isupper() else ref_str
+            mas_a_an(ref_str, ignore_case),
+            ref_str.lower() if not ignore_case and (ref_str[0].isupper() and not ref_str.isupper()) else ref_str
         ))
 
-    def mas_a_an(ref_str):
+    def mas_a_an(ref_str, ignore_case=False):
         """
         Takes in a reference string and returns either a/an based on the first letter of the word
 
         IN:
             ref_str - string in question to prefix
+            ignore_case - whether or not we should ignore capitalization of a/an and just use lowercase
 
         OUT:
             a/an based on the ref string
         """
-        should_capitalize = ref_str[0].isupper()
+        should_capitalize = not ignore_case and ref_str[0].isupper()
 
         if ref_str[0] in "aeiouAEIOU":
             return "An" if should_capitalize else "an"

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -5174,7 +5174,7 @@ init 2 python:
             ref_str - string in question to prefix
 
         OUT:
-            string prefixed with a/an
+            a/an based on the ref string
         """
         should_capitalize = ref_str[0].isupper()
 

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -5162,14 +5162,11 @@ init 2 python:
             string prefixed with a/an
         """
         return ("{0} {1}".format(
-            mas_a_an(
-                ref_str,
-                should_capitalize=ref_str[0].isupper()
-            ),
+            mas_a_an(ref_str),
             ref_str.lower() if ref_str[0].isupper() and not ref_str.isupper() else ref_str
         ))
 
-    def mas_a_an(ref_str, should_capitalize):
+    def mas_a_an(ref_str):
         """
         Takes in a reference string and returns either a/an based on the first letter of the word
 
@@ -5179,6 +5176,8 @@ init 2 python:
         OUT:
             string prefixed with a/an
         """
+        should_capitalize = ref_str[0].isupper()
+
         if ref_str[0] in "aeiouAEIOU":
             return "An" if should_capitalize else "an"
         return "A" if should_capitalize else "a"

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -5197,15 +5197,13 @@ init python:
         If tempvar was 'item,' the output is: I bought [player] an item.
         If tempvar was 'coffee,' the output is: I bought [player] a coffee.
         """
-        list_to_return = list()
-        for kind, _text in contents:
+        for _id, _tuple in enumerate(contents):
             #We want to modify only text
-            if kind == renpy.TEXT_TEXT:
-                list_to_return.append((kind, mas_a_an_str(_text)))
-            else:
-                list_to_return.append((kind, _text))
+            if _tuple[0] == renpy.TEXT_TEXT:
+                contents[_id] = (_tuple[0], mas_a_an_str(_tuple[1]))
+                break
 
-        return list_to_return
+        return contents
 
     config.custom_text_tags["a_an"] = a_an_tag
 

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -377,12 +377,18 @@ label v0_11_3(version="v0_11_3"):
     python:
         # give extra pool unlocks for recent players
         if mas_isFirstSeshPast(datetime.date(2020, 4, 4)):
-            # only 0.11.0 + week ago 
+            # only 0.11.0 + week ago
 
             # NOTE: multiply by 4 becaue everyone should already have level
-            #   number of pool unlocks given 
+            #   number of pool unlocks given
             persistent._mas_pool_unlocks += store.mas_xp.level() * 4
 
+        #Adjust consumables to be at their max stock amount
+        for consumable_id in persistent._mas_consumable_map.iterkeys():
+            cons = mas_getConsumable(consumable_id)
+
+            if cons and cons.getStock() > cons.max_stock_amount:
+                persistent._mas_consumable_map[cons.consumable_id]["servings_left"] = cons.max_stock_amount
     return
 
 #0.11.1

--- a/Monika After Story/game/zz_consumables.rpy
+++ b/Monika After Story/game/zz_consumables.rpy
@@ -1334,7 +1334,7 @@ label mas_consumables_generic_get(consumable):
 
         #No valid dlg props
         else:
-            a_an = "some" if plur else mas_a_an(consumable.disp_name)
+            a_an = "some" if plur else mas_a_an(consumable.disp_name, ignore_case=True)
             line_starter = renpy.substitute("I'm going to get [a_an] [consumable.disp_name][plur].")
 
     if store.mas_globals.in_idle_mode or (mas_canCheckActiveWindow() and not mas_isFocused()):

--- a/Monika After Story/game/zz_consumables.rpy
+++ b/Monika After Story/game/zz_consumables.rpy
@@ -1330,7 +1330,6 @@ label mas_consumables_generic_get(consumable):
 
         #Otherwise we use the object reference for this
         elif obj_ref:
-            a_an = mas_a_an(obj_ref)
             line_starter = renpy.substitute("I'm going to get {a_an}[obj_ref]{/a_an} of [consumable.disp_name][plur].")
 
         #No valid dlg props

--- a/Monika After Story/game/zz_consumables.rpy
+++ b/Monika After Story/game/zz_consumables.rpy
@@ -1326,15 +1326,17 @@ label mas_consumables_generic_get(consumable):
 
         #We need to parse the dialogue depending on the given dlg_props
         if container:
-            line_starter = renpy.substitute("I'm going to get a [container] of [consumable.disp_name][plur].")
+            a_an = mas_a_an(container)
+            line_starter = renpy.substitute("I'm going to get [a_an] [container] of [consumable.disp_name][plur].")
 
         #Otherwise we use the object reference for this
         elif obj_ref:
-            line_starter = renpy.substitute("I'm going to get a [obj_ref] of [consumable.disp_name][plur].")
+            a_an = mas_a_an(obj_ref)
+            line_starter = renpy.substitute("I'm going to get [a_an] [obj_ref] of [consumable.disp_name][plur].")
 
         #No valid dlg props
         else:
-            a_an = "some" if plur else "a"
+            a_an = "some" if plur else mas_a_an(consumable.disp_name)
             line_starter = renpy.substitute("I'm going to get [a_an] [consumable.disp_name][plur].")
 
     if store.mas_globals.in_idle_mode or (mas_canCheckActiveWindow() and not mas_isFocused()):

--- a/Monika After Story/game/zz_consumables.rpy
+++ b/Monika After Story/game/zz_consumables.rpy
@@ -1533,7 +1533,7 @@ label mas_consumables_generic_running_out(consumable):
             plur = "s" if dlg_props.get(mas_consumables.PROP_PLUR, False) else ""
 
             #We need to parse the dialogue depending on the given dlg_props
-            if mcontainer:
+            if container:
                 line_ender = renpy.substitute("[container]s of [consumable.disp_name][plur] left.")
 
             #Otherwise we use the object reference for this

--- a/Monika After Story/game/zz_consumables.rpy
+++ b/Monika After Story/game/zz_consumables.rpy
@@ -1326,13 +1326,12 @@ label mas_consumables_generic_get(consumable):
 
         #We need to parse the dialogue depending on the given dlg_props
         if container:
-            a_an = mas_a_an(container)
-            line_starter = renpy.substitute("I'm going to get [a_an] [container] of [consumable.disp_name][plur].")
+            line_starter = renpy.substitute("I'm going to get {a_an}[container]{/a_an} of [consumable.disp_name][plur].")
 
         #Otherwise we use the object reference for this
         elif obj_ref:
             a_an = mas_a_an(obj_ref)
-            line_starter = renpy.substitute("I'm going to get [a_an] [obj_ref] of [consumable.disp_name][plur].")
+            line_starter = renpy.substitute("I'm going to get {a_an}[obj_ref]{/a_an} of [consumable.disp_name][plur].")
 
         #No valid dlg props
         else:

--- a/Monika After Story/game/zz_consumables.rpy
+++ b/Monika After Story/game/zz_consumables.rpy
@@ -27,6 +27,40 @@ init python in mas_consumables:
     TYPE_DRINK = 0
     TYPE_FOOD = 1
 
+    #Consumable dialogue prop constants
+    #We'll store some shorthand constants for ways to route/say dialogue for consumables here
+    CONTAINER_NONE = None
+    CONTAINER_PLATE = "plate"
+    CONTAINER_CUP = "cup"
+
+    #Dlg property names
+    # key: marks the string to use when referencing the object's container
+    # value: string - container name
+    PROP_CONTAINER = "container"
+    # key: marks the reference for the object
+    # value: string - reference name to use (slice, batch, etc.) (Used if no container found)
+    PROP_OBJ_REF = "obj_ref"
+    # key: marks whether the consumable should be referred to in plural or not
+    # value: boolean, True if plural, False if not.
+    PROP_PLUR = "plural"
+
+    #Some templates for consumable dialogue
+    DLG_PREP_HOT_DRINK = {
+        PROP_CONTAINER: CONTAINER_CUP,
+        PROP_PLUR: False
+    }
+
+    DLG_NON_PREP_PASTRY = {
+        PROP_CONTAINER: CONTAINER_NONE,
+        PROP_PLUR: False
+    }
+
+    DLG_NON_PREP_CAKE = {
+        PROP_CONTAINER: CONTAINER_PLATE,
+        PROP_OBJ_REF: "slice",
+        PROP_PLUR: False
+    }
+
     #Dict of dicts:
     #consumable_map = {
     #   0: {"consumable_id": MASConsumable},
@@ -48,7 +82,7 @@ init 5 python:
             consumable_id - id of the consumable
             consumable_type - Type of consumable this is
             disp_name - friendly name for this consumable
-            container - the container of this consumable (cup, mug, glass, bottle, etc)
+            dlg_props - dialogue properties for flows for this consumable
             start_end_tuple_list - list of (start_hour, end_hour) tuples
             acs - MASAccessory to display for the consumable
             split_list - list of split hours
@@ -88,10 +122,10 @@ init 5 python:
             consumable_id,
             consumable_type,
             disp_name,
-            container,
             start_end_tuple_list,
             acs,
             split_list,
+            dlg_props=None,
             portable=False,
             should_restock_warn=True,
             late_entry_list=None,
@@ -118,8 +152,6 @@ init 5 python:
 
                 disp_name - Friendly diaply name (for use in dialogue)
 
-                container - containment for this consumable (cup/mug/bottle/etc)
-
                 start_end_tuple_list - list of tuples storing (start_hour, end_hour)
                     NOTE: Does NOT support midnight crossover times. If needed, requires a separate entry
                     NOTE: end_hour is exclusive
@@ -127,6 +159,14 @@ init 5 python:
                 acs - MASAccessory object for this consumable
 
                 split_list - list of split hours for prepping
+
+                dlg_props - dialogue properties for use in generic labels. If None, an empty dict is used, and fallback text will be shown
+                    AVAILABLE PROPERTIES:
+                        - mas_consumables.PROP_CONTAINER - Container for this consumable
+                        - mas_consumables.PROP_OBJ_REF - Object reference for this consumable (use if container is not applicable)
+                        - mas_consumables.PROP_PLUR - Whether or not this should be referenced as plural in text
+
+                    (Default: None)
 
                 portable - NOTE: for drinks only. True if Monika can take this with her when going out
                     (Default: False)
@@ -199,7 +239,7 @@ init 5 python:
             self.max_re_serve=max_re_serve
             self.re_serves_had=0
 
-            self.container=container
+            self.dlg_props = dlg_props if dlg_props else dict()
             self.split_list=split_list
             self.should_restock_warn=should_restock_warn
             self.prep_low=prep_low
@@ -1117,7 +1157,7 @@ init 6 python:
         consumable_id="coffee",
         consumable_type=store.mas_consumables.TYPE_DRINK,
         disp_name="coffee",
-        container="cup",
+        dlg_props=mas_consumables.DLG_PREP_HOT_DRINK,
         start_end_tuple_list=[(5, 12)],
         acs=mas_acs_mug,
         portable=True,
@@ -1129,7 +1169,7 @@ init 6 python:
         consumable_id="hotchoc",
         consumable_type=store.mas_consumables.TYPE_DRINK,
         disp_name="hot chocolate",
-        container="cup",
+        dlg_props=mas_consumables.DLG_PREP_HOT_DRINK,
         start_end_tuple_list=[(16,23)],
         acs=mas_acs_hotchoc_mug,
         portable=True,
@@ -1254,11 +1294,32 @@ label mas_get_food:
 
 #START: Generic consumable labels
 label mas_consumables_generic_get(consumable):
+    #Get our dlg_props
+    python:
+        dlg_props = consumable.dlg_props
+
+        container = dlg_props.get(mas_consumables.PROP_CONTAINER)
+        obj_ref = dlg_props.get(mas_consumables.PROP_OBJ_REF)
+        plur = "s" if dlg_props.get(mas_consumables.PROP_PLUR, False) else ""
+
+        #We need to parse the dialogue depending on the given dlg_props
+        if container:
+            line_starter = renpy.substitute("I'm going to get a [container] of [consumable.disp_name][plur].")
+
+        #Otherwise we use the object reference for this
+        elif obj_ref:
+            line_starter = renpy.substitute("I'm going to get a [obj_ref] of [consumable.disp_name][plur].")
+
+        #No valid dlg props
+        else:
+            a_an = "some" if plur else "a"
+            line_starter = renpy.substitute("I'm going to get [a_an] [consumable.disp_name][plur].")
+
     if store.mas_globals.in_idle_mode or (mas_canCheckActiveWindow() and not mas_isFocused()):
-        m 1eua "I'm going to get a [consumable.container] of [consumable.disp_name]. I'll be right back.{w=1}{nw}"
+        m 1eua "[line_starter] I'll be right back.{w=1}{nw}"
 
     else:
-        m 1eua "I'm going to get a [consumable.container] of [consumable.disp_name]."
+        m 1eua "[line_starter]"
         m 1eua "Hold on a moment."
 
     #We want to take plush with
@@ -1289,28 +1350,55 @@ label mas_consumables_generic_get(consumable):
         m 1eua "Okay, what else should we do today?"
     return
 
+
 label mas_consumables_generic_finish_having(consumable):
-    $ get_more = (
-        consumable.shouldHave()
-        and (consumable.prepable() or (not consumable.prepable() and consumable.hasServing()))
-    )
+    #Some prep
+    python:
+        get_more = (
+            consumable.shouldHave()
+            and (consumable.prepable() or (not consumable.prepable() and consumable.hasServing()))
+        )
+
+        dlg_props = consumable.dlg_props
+
+        container = dlg_props.get(mas_consumables.PROP_CONTAINER)
+        obj_ref = dlg_props.get(mas_consumables.PROP_OBJ_REF)
+
+        plur = "s" if dlg_props.get(mas_consumables.PROP_PLUR, False) else ""
+        dlg_map = {
+            mas_consumables.PROP_CONTAINER: {
+                0: "I'm going to put this [container] away.",
+                1: "I'm going to get another [container] of [consumable.disp_name][plur]."
+            },
+            mas_consumables.PROP_OBJ_REF: {
+                0: "I'm going to put this away.",
+                1: "I'm going to get another [obj_ref] of [consumable.disp_name][plur]."
+            },
+            "else": {
+                0: "I'm going to put this away.",
+                1: "I'm going to get another one."
+            }
+        }
+
+        #We need to parse the dialogue depending on the given dlg_props
+        if container:
+            line_starter = renpy.substitute(dlg_map[mas_consumables.PROP_CONTAINER][get_more])
+
+        #Otherwise we use the object reference for this
+        elif obj_ref:
+            line_starter = renpy.substitute(dlg_map[mas_consumables.PROP_OBJ_REF][get_more])
+
+        #No valid dlg props
+        else:
+            line_starter = renpy.substitute(dlg_map["else"][get_more])
 
     if (not mas_canCheckActiveWindow() or mas_isFocused()) and not store.mas_globals.in_idle_mode:
-        m 1esd "Oh, I've finished my [consumable.disp_name]."
+        m 1eua "[line_starter]"
+        m "Hold on a moment."
 
-    if store.mas_globals.in_idle_mode or (mas_canCheckActiveWindow() and not mas_isFocused()):
-        if get_more:
-            #It's drinking time
-            m 1eua "I'm going to get some more [consumable.disp_name]. I'll be right back.{w=1}{nw}"
-
-        else:
-            m 1eua "I'm going to put this [consumable.container] away. I'll be right back.{w=1}{nw}"
-
-    else:
-        if get_more:
-            m 1eua "I'm going to get another [consumable.container]."
-
-        m 1eua "Hold on a moment."
+    elif store.mas_globals.in_idle_mode or (mas_canCheckActiveWindow() and not mas_isFocused()):
+        m 1esd "Oh, I've finished my [consumable.disp_name][plur].{w=1}{nw}"
+        m 1eua "[line_starter] I'll be right back.{w=1}{nw}"
 
     #Monika is off screen
     $ consumable.acs.keep_on_desk = False
@@ -1362,16 +1450,22 @@ label mas_consumables_generic_finish_having(consumable):
         m 1eua "Okay, what else should we do today?"
     return
 
-label mas_consumables_generic_finished_prepping(consumable):
-    if (not mas_canCheckActiveWindow() or mas_isFocused()) and not store.mas_globals.in_idle_mode:
-        m 1esd "Oh, my [consumable.disp_name] is ready."
 
-    if store.mas_globals.in_idle_mode or (mas_canCheckActiveWindow() and not mas_isFocused()):
-        #Idle pauses and then progresses on its own
-        m 1eua "I'm going to grab some [consumable.disp_name]. I'll be right back.{w=1}{nw}"
+label mas_consumables_generic_finished_prepping(consumable):
+    python:
+        dlg_props = consumable.dlg_props
+
+        plur = "s" if dlg_props.get(mas_consumables.PROP_PLUR, False) else ""
+
+    if (not mas_canCheckActiveWindow() or mas_isFocused()) and not store.mas_globals.in_idle_mode:
+        $ is_are = "are" if plur else "is"
+        m 1esd "Oh, my [consumable.disp_name][plur] [is_are] ready."
+        m 1eua "Hold on a moment."
 
     else:
-        m 1eua "Hold on a moment."
+        #Idle pauses and then progresses on its own
+        m 1eua "I'm going to get my [consumable.disp_name][plur]. I'll be right back.{w=1}{nw}"
+
 
     #Monika goes offscreen
     call mas_transition_to_emptydesk
@@ -1405,19 +1499,60 @@ label mas_consumables_generic_finished_prepping(consumable):
 
 label mas_consumables_generic_running_out(consumable):
     $ amt_left = consumable.getStock()
+
     m 1euc "By the way, [player]..."
 
     if amt_left > 0:
-        m 3eud "I just wanted to let you know I only have [amt_left] [consumable.container]s of [consumable.disp_name] left."
+        python:
+            dlg_props = consumable.dlg_props
+
+            container = dlg_props[mas_consumables.PROP_CONTAINER]
+            obj_ref = dlg_props[mas_consumables.PROP_OBJ_REF]
+            plur = "s" if dlg_props.get(mas_consumables.PROP_PLUR, False) else ""
+
+            #We need to parse the dialogue depending on the given dlg_props
+            if mcontainer:
+                line_ender = renpy.substitute("[container]s of [consumable.disp_name][plur] left.")
+
+            #Otherwise we use the object reference for this
+            elif obj_ref:
+                line_ender = renpy.substitute("[obj_ref]s of [consumable.disp_name][plur] left.")
+
+            #No valid dlg props
+            else:
+                line_ender = renpy.substitute("[consumable.disp_name][plur] left.")
+
+        m 3eud "I just wanted to let you know I only have [amt_left] [line_ender]"
+
     else:
-        m 3eud "I just wanted to let you know that I'm out of [consumable.disp_name]."
+        m 3eud "I just wanted to let you know that I'm out of [consumable.disp_name][plur]."
 
     m 1eka "You wouldn't mind getting some more for me, would you?"
     return
 
 label mas_consumables_generic_critical_low(consumable):
+    python:
+        dlg_props = consumable.dlg_props
+
+
+        container = dlg_props.get(mas_consumables.PROP_CONTAINER)
+        obj_ref = dlg_props.get(mas_consumables.PROP_OBJ_REF)
+        plur = "s" if dlg_props.get(mas_consumables.PROP_PLUR, False) else ""
+
+        #We need to parse the dialogue depending on the given dlg_props
+        if container:
+            line_ender = renpy.substitute("[container] of [consumable.disp_name] left.")
+
+        #Otherwise we use the object reference for this
+        elif obj_ref:
+            line_ender = renpy.substitute("[obj_ref] of [consumable.disp_name] left.")
+
+        #No valid dlg props
+        else:
+            line_ender = renpy.substitute("serving of [consumable.disp_name] left.")
+
     m 1euc "Hey, [player]..."
-    m 3eua "I only have one [consumable.container] of [consumable.disp_name] left."
+    m 3eua "I only have one [line_ender]"
     m 3eka "Would you mind getting me some more sometime?"
     m 1hua "Thanks~"
     return
@@ -1456,6 +1591,7 @@ label mas_consumables_generic_queued_running_out_dlg(low_cons):
         m 3rksdla "I've been running out of a few things in here..."
         m 3eua "So I hope you don't mind, but I left you a list of things in the characters folder."
         $ them = "them"
+
     else:
         python:
             items_running_out_of = ""

--- a/Monika After Story/game/zz_dump.rpy
+++ b/Monika After Story/game/zz_dump.rpy
@@ -321,15 +321,28 @@ init 999 python:
 
                 #Need to account for consumables which were removed
                 if consumable:
-                    _var_data_file.write(
-                        "{0}S OF {1} {2}: {3}\n".format(
-                        consumable.container.upper(),
-                        consumable.disp_name.upper(),
-                        "EATEN" if consumable.consumable_type == store.mas_consumables.TYPE_FOOD else "DRANK",
-                        consumable.getAmountHad()
-                        )
-                    )
+                    #Some prep
+                    dlg_props = consumable.dlg_props
 
+                    ref = dlg_props.get(mas_consumables.PROP_CONTAINER, dlg_props.get(mas_consumables.PROP_OBJ_REF))
+                    if ref:
+                        _var_data_file.write(
+                            "{0}S OF {1} {2}: {3}\n".format(
+                                ref.upper(),
+                                consumable.disp_name.upper(),
+                                "EATEN" if consumable.consumable_type == store.mas_consumables.TYPE_FOOD else "DRANK",
+                                consumable.getAmountHad()
+                            )
+                        )
+
+                    else:
+                        _var_data_file.write(
+                            "{0}S {1}: {2}\n".format(
+                                consumable.disp_name.upper(),
+                                "EATEN" if consumable.consumable_type == store.mas_consumables.TYPE_FOOD else "DRANK",
+                                consumable.getAmountHad()
+                            )
+                        )
 
     def mas_dataDumpFlag():
         """

--- a/Monika After Story/game/zz_reactions.rpy
+++ b/Monika After Story/game/zz_reactions.rpy
@@ -1437,56 +1437,65 @@ init 5 python:
     addReaction("mas_reaction_gift_coffee", "coffee", is_good=True, exclude_on=["d25g"])
 
 label mas_reaction_gift_coffee:
-    m 1wub "Oh!{w=0.2} {nw}"
-    extend 3hub "Coffee!"
+    #Even if we don't "accept" it, we still register it was given
     $ mas_receivedGift("mas_reaction_gift_coffee")
-
     $ coffee = mas_getConsumable("coffee")
 
-    if coffee.enabled() and coffee.hasServing():
-        $ mas_giftCapGainAff(0.5)
-        m 1wuo "It's a flavor I haven't had before."
-        m 1hua "I can't wait to try it!"
-        m "Thank you so much, [player]!"
-
-    elif coffee.enabled() and not coffee.hasServing():
-        $ mas_giftCapGainAff(0.5)
-        m 3eub "I actually ran out of coffee, so getting more from you now is amazing!"
-        m 1hua "Thanks again, [player]~"
+    #Check if we accept this
+    if coffee.isMaxedStock():
+        m 1euc "More coffee, [player]?"
+        m 3rksdla "Don't get me wrong, I appreciate it, but I think I've got enough coffee to last me a while already..."
+        m 1eka "I'll let you know when I'm running low, alright?"
 
     else:
-        $ mas_giftCapGainAff(5)
+        m 1wub "Oh!{w=0.2} {nw}"
+        extend 3hub "Coffee!"
 
-        m 1hua "Now I can finally make some!"
-        m 1hub "Thank you so much, [player]!"
+        if coffee.enabled() and coffee.hasServing():
+            $ mas_giftCapGainAff(0.5)
+            m 1wuo "It's a flavor I haven't had before."
+            m 1hua "I can't wait to try it!"
+            m "Thank you so much, [player]!"
 
-        #If we're currently brewing/drinking anything, or it's not time for this consumable, we'll just not have it now
-        if (
-            not coffee.isConsTime()
-            or bool(MASConsumable._getCurrentDrink())
-        ):
-            m 3eua "I'll be sure to have some later!"
+        elif coffee.enabled() and not coffee.hasServing():
+            $ mas_giftCapGainAff(0.5)
+            m 3eub "I actually ran out of coffee, so getting more from you now is amazing!"
+            m 1hua "Thanks again, [player]~"
 
         else:
-            m 3eua "Why don't I go ahead and make a cup right now?"
-            m 1eua "I'd like to share the first with you, after all."
+            $ mas_giftCapGainAff(5)
 
-            #Monika is off screen
-            call mas_transition_to_emptydesk
-            pause 2.0
-            m "I know there's a coffee machine somewhere around here...{w=2}{nw}"
-            m "Ah, there it is!{w=2}{nw}"
-            pause 5.0
-            m "And there we go!{w=2}{nw}"
-            call mas_transition_from_emptydesk()
+            m 1hua "Now I can finally make some!"
+            m 1hub "Thank you so much, [player]!"
 
-            #Monika back on screen
-            m 1eua "I'll let that brew for a few minutes."
+            #If we're currently brewing/drinking anything, or it's not time for this consumable, we'll just not have it now
+            if (
+                not coffee.isConsTime()
+                or bool(MASConsumable._getCurrentDrink())
+            ):
+                m 3eua "I'll be sure to have some later!"
 
-            $ coffee.prepare()
-        $ coffee.enable()
+            else:
+                m 3eua "Why don't I go ahead and make a cup right now?"
+                m 1eua "I'd like to share the first with you, after all."
+
+                #Monika is off screen
+                call mas_transition_to_emptydesk
+                pause 2.0
+                m "I know there's a coffee machine somewhere around here...{w=2}{nw}"
+                m "Ah, there it is!{w=2}{nw}"
+                pause 5.0
+                m "And there we go!{w=2}{nw}"
+                call mas_transition_from_emptydesk()
+
+                #Monika back on screen
+                m 1eua "I'll let that brew for a few minutes."
+
+                $ coffee.prepare()
+            $ coffee.enable()
 
     #Stock some coffee
+    #NOTE: This function already checks if we're maxed. So restocking while maxed is okay as it adds nothing
     $ coffee.restock()
 
     $ gift_ev = mas_getEV("mas_reaction_gift_coffee")
@@ -1497,62 +1506,71 @@ init 5 python:
     addReaction("mas_reaction_hotchocolate", "hotchocolate", is_good=True, exclude_on=["d25g"])
 
 label mas_reaction_hotchocolate:
-    m 3hub "Hot chocolate!"
-    m 3hua "Thank you, [player]!"
+    #Even though we may not "accept" this, we'll still mark it was given
     $ mas_receivedGift("mas_reaction_hotchocolate")
 
     $ hotchoc = mas_getConsumable("hotchoc")
 
-    if hotchoc.enabled() and hotchoc.hasServing():
-        $ mas_giftCapGainAff(0.5)
-        m 1wuo "It's a flavor I haven't had before."
-        m 1hua "I can't wait to try it!"
-        m "Thank you so much, [player]!"
-
-    elif hotchoc.enabled() and not hotchoc.hasServing():
-        $ mas_giftCapGainAff(0.5)
-        m 3rksdla "I'm actually out of hot chocolate, ahaha...{w=0.5} {nw}"
-        extend 3eub "So getting more from you now is amazing!"
-        m 1hua "Thanks again, [player]~"
+    #Check if we should accept this or not
+    if hotchoc.isMaxedStock():
+        m 1euc "More hot chocolate, [player]?"
+        m 3rksdla "Don't get me wrong, I appreciate it, but I think I've got enough to last me a while already..."
+        m 1eka "I'll let you know when I'm running out, alright?"
 
     else:
-        python:
-            mas_giftCapGainAff(3)
-            those = "these" if mas_current_background.isFltNight() and mas_isWinter() else "those"
+        m 3hub "Hot chocolate!"
+        m 3hua "Thank you, [player]!"
 
-        m 1hua "You know I love my coffee, but hot chocolate is always really nice, too!"
+        if hotchoc.enabled() and hotchoc.hasServing():
+            $ mas_giftCapGainAff(0.5)
+            m 1wuo "It's a flavor I haven't had before."
+            m 1hua "I can't wait to try it!"
+            m "Thank you so much, [player]!"
 
-
-        m 2rksdla "...Especially on [those] cold, winter nights."
-        m 2ekbfa "Someday I hope to be able to drink hot chocolate with you, sharing a blanket by the fireplace..."
-        m 3ekbfa "...Doesn't that sound so romantic?"
-        m 1dkbfa "..."
-        m 1hua "But for now, at least I can enjoy it here."
-        m 1hub "Thanks again, [player]!"
-
-        #If we're currently brewing/drinking anything, we don't do this now
-        if (
-            hotchoc.isConsTime()
-            and not mas_isWinter()
-            or bool(MASConsumable._getCurrentDrink())
-        ):
-            m 3eua "I'll be sure to have some later!"
+        elif hotchoc.enabled() and not hotchoc.hasServing():
+            $ mas_giftCapGainAff(0.5)
+            m 3rksdla "I'm actually out of hot chocolate, ahaha...{w=0.5} {nw}"
+            extend 3eub "So getting more from you now is amazing!"
+            m 1hua "Thanks again, [player]~"
 
         else:
-            m 3eua "In fact, I think I'll make some right now!"
+            python:
+                mas_giftCapGainAff(3)
+                those = "these" if mas_current_background.isFltNight() and mas_isWinter() else "those"
 
-            call mas_transition_to_emptydesk
-            pause 5.0
-            call mas_transition_from_emptydesk("monika 1eua")
+            m 1hua "You know I love my coffee, but hot chocolate is always really nice, too!"
 
-            m 1hua "There, it'll be ready in a few minutes."
 
-            $ hotchoc.prepare()
+            m 2rksdla "...Especially on [those] cold, winter nights."
+            m 2ekbfa "Someday I hope to be able to drink hot chocolate with you, sharing a blanket by the fireplace..."
+            m 3ekbfa "...Doesn't that sound so romantic?"
+            m 1dkbfa "..."
+            m 1hua "But for now, at least I can enjoy it here."
+            m 1hub "Thanks again, [player]!"
 
-        if mas_isWinter():
-            $ hotchoc.enable()
+            #If we're currently brewing/drinking anything or if it's not winter, we won't have this
+            if (
+                not mas_isWinter()
+                or bool(MASConsumable._getCurrentDrink())
+            ):
+                m 3eua "I'll be sure to have some later!"
+
+            else:
+                m 3eua "In fact, I think I'll make some right now!"
+
+                call mas_transition_to_emptydesk
+                pause 5.0
+                call mas_transition_from_emptydesk("monika 1eua")
+
+                m 1hua "There, it'll be ready in a few minutes."
+
+                $ hotchoc.prepare()
+
+            if mas_isWinter():
+                $ hotchoc.enable()
 
     #Stock up some hotchocolate
+    #NOTE: Like coffee, this runs checks to see if we should actually stock
     $ hotchoc.restock()
 
     $ gift_ev = mas_getEV("mas_reaction_hotchocolate")

--- a/Monika After Story/game/zz_reactions.rpy
+++ b/Monika After Story/game/zz_reactions.rpy
@@ -2440,10 +2440,8 @@ label mas_reaction_new_ribbon:
     return
 
 label mas_reaction_old_ribbon:
-    m 1rksdlb "[player]..."
-    #Need to handle vowels lol
-    show monika 1rusdlb
-    $ renpy.say(m, "You already gave me {0} ribbon!".format(mas_a_an_str(_mas_new_ribbon_color)))
+    m 1rksdla "[player]..."
+    m 1hksdlb "You already gave me {a_an}[_mas_new_ribbon_color]{/a_an} ribbon!"
     return
 
 init 5 python:


### PR DESCRIPTION
Adds dialogue props dict as a property of `MASConsumable`s

These properties will be used to adjust the dialogue for generic labels to be more flexible for more consumables (prep for when we add more)

Current added props which are used:
- `mas_consumables.PROP_CONTAINER`
  - This is used in place of the old `container` property
- `mas_consumables.PROP_OBJ_REF`
  - This is used for consumables which don't necessarily have a container. For example cake, which would be referenced to as a *slice*
  - At the moment, this is only used if we don't have a container
- `mas_consumables.PROP_PLUR`
  - This is used to mark whether or not this consumable should be referenced to in plural or not

Also added some prefab `dlg_props` dicts to be used for consumables

Additionally, this also implements a maximum stock amount for consumables. This defaults to 150, but can be changed per consumable as it is a property which can be set on init.

- **NOTE:** If none of the props are present, there are fallback bits of dialogue to account for this. They may not always line up, but realistically, there shouldn't be a reason to not include at least one of the above reference properties (container/obj_ref).

# Testing
- Experiment with combinations of the dialogue properties and make sure that dialogue fits and is actually proper English
- Verify that there's no crashes
- Verify that you can only give up to a maximum of 150 servings of coffee/hotchoc (or if you adjust the value, that maximum)
- Verify that if you were over 150 servings of a consumable, the update script will adjust this and set you to the max stock amount