### PR TITLE
Persistent MASBackgrounds and MASWeather

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1363,8 +1363,10 @@ label ch30_preloop:
     $ mas_idle_mailbox.send_scene_change()
 
     # rain check
-    # TODO: the weather progression alg needs to run here
     $ mas_startupWeather()
+
+    #We've skipped the initial weather set, we can now clear this flag
+    $ skip_setting_weather = False
 
     # otherwise, we are NOT skipping visuals
     $ mas_startup_song()

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1973,4 +1973,7 @@ label ch30_reset:
 
         if seen_event('mas_preferredname'):
             mas_unlockEVL("monika_changename","EVE")
+
+    #Check BGSel topic unlocked state
+    $ mas_checkBackgroundChangeDelegate()
     return

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1034,20 +1034,24 @@ label ch30_nope:
 label ch30_autoload:
     # This is where we check a bunch of things to see what events to push to the
     # event list
-    $ m.display_args["callback"] = slow_nodismiss
-    $ m.what_args["slow_abortable"] = config.developer
-    $ import store.evhand as evhand
-    if not config.developer:
-        $ config.allow_skipping = False
-    $ mas_resetTextSpeed()
-    $ quick_menu = True
-    $ startup_check = True #Flag for checking events at game startup
-    $ mas_skip_visuals = False
+    python:
+        import store.evhand as evhand
 
-    # set flag to True to prevent ch30 from running weather alg
-    $ skip_setting_weather = False
+        m.display_args["callback"] = slow_nodismiss
+        m.what_args["slow_abortable"] = config.developer
 
-    $ mas_cleanEventList()
+        if not config.developer:
+            config.allow_skipping = False
+
+        mas_resetTextSpeed()
+        quick_menu = True
+        startup_check = True #Flag for checking events at game startup
+        mas_skip_visuals = False
+
+        #Set flag to True to prevent ch30 from running weather alg
+        skip_setting_weather = False
+
+        mas_cleanEventList()
 
     # set the gender
     call mas_set_gender
@@ -1057,16 +1061,17 @@ label ch30_autoload:
 
     #Affection will trigger a final farewell mode
     #If we got a fresh start, then -50 is the cutoff vs -115.
-    if (
-        persistent._mas_pm_got_a_fresh_start
-        and _mas_getAffection() <= -50
-    ):
-        $ persistent._mas_load_in_finalfarewell_mode = True
-        $ persistent._mas_finalfarewell_poem_id = "ff_failed_promise"
+    python:
+        if (
+            persistent._mas_pm_got_a_fresh_start
+            and _mas_getAffection() <= -50
+        ):
+            persistent._mas_load_in_finalfarewell_mode = True
+            persistent._mas_finalfarewell_poem_id = "ff_failed_promise"
 
-    elif _mas_getAffection() <= -115:
-        $ persistent._mas_load_in_finalfarewell_mode = True
-        $ persistent._mas_finalfarewell_poem_id = "ff_affection"
+        elif _mas_getAffection() <= -115:
+            persistent._mas_load_in_finalfarewell_mode = True
+            persistent._mas_finalfarewell_poem_id = "ff_affection"
 
 
     #If we should go into FF mode, we do.
@@ -1075,6 +1080,9 @@ label ch30_autoload:
 
     # set this to None for now
     $ selected_greeting = None
+
+    #We'll set up the background here, so other flows don't need to adjust it unless its for a specific reason
+    $ mas_startupBackground()
 
     # check if we took monika out
     # NOTE:
@@ -1314,35 +1322,36 @@ label ch30_preloop:
 
     window auto
 
-    # NOTE: keymaps will be set, but all actions will be shielded unless
-    #   desired by the appropriate flow.
-    $ mas_HKRaiseShield()
-    $ mas_HKBRaiseShield()
-    $ set_keymaps()
+    python:
+        # NOTE: keymaps will be set, but all actions will be shielded unless
+        #   desired by the appropriate flow.
+        mas_HKRaiseShield()
+        mas_HKBRaiseShield()
+        set_keymaps()
 
-    $ persistent.closed_self = False
-    $ persistent._mas_game_crashed = True
-    $ startup_check = False
-    $ mas_checked_update = False
-    $ mas_globals.last_minute_dt = datetime.datetime.now()
-    $ mas_globals.last_hour = mas_globals.last_minute_dt.hour
-    $ mas_globals.last_day = mas_globals.last_minute_dt.day
+        persistent.closed_self = False
+        persistent._mas_game_crashed = True
+        startup_check = False
+        mas_checked_update = False
+        mas_globals.last_minute_dt = datetime.datetime.now()
+        mas_globals.last_hour = mas_globals.last_minute_dt.hour
+        mas_globals.last_day = mas_globals.last_minute_dt.day
 
-    # delayed actions in here please
-    $ mas_runDelayedActions(MAS_FC_IDLE_ONCE)
+        # delayed actions in here please
+        mas_runDelayedActions(MAS_FC_IDLE_ONCE)
 
-    #Unlock windowreact topics
-    $ mas_resetWindowReacts()
+        #Unlock windowreact topics
+        mas_resetWindowReacts()
 
-    #Then prepare the notifs
-    $ mas_updateFilterDict()
+        #Then prepare the notifs
+        mas_updateFilterDict()
 
-    # save here before we enter the loop
-    $ renpy.save_persistent()
+        # save here before we enter the loop
+        renpy.save_persistent()
 
-    # check if we need to rebulid ev
-    if mas_idle_mailbox.get_rebuild_msg():
-        $ mas_rebuildEventLists()
+        # check if we need to rebulid ev
+        if mas_idle_mailbox.get_rebuild_msg():
+            mas_rebuildEventLists()
 
     if mas_skip_visuals:
         $ mas_OVLHide()
@@ -1355,10 +1364,7 @@ label ch30_preloop:
 
     # rain check
     # TODO: the weather progression alg needs to run here
-    if not mas_weather.force_weather and not skip_setting_weather:
-        $ set_to_weather = mas_shouldRain()
-        if set_to_weather is not None:
-            $ mas_changeWeather(set_to_weather)
+    $ mas_startupWeather()
 
     # otherwise, we are NOT skipping visuals
     $ mas_startup_song()

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1076,7 +1076,17 @@ default persistent.opendoor_knockyes = False
 init 5 python:
 
     # this greeting is disabled on certain days
-    if persistent.closed_self and not (mas_isO31() or mas_isD25Season() or mas_isplayer_bday() or mas_isF14()):
+    # and if we're not in the spaceroom
+    if (
+        persistent.closed_self
+        and not (
+            mas_isO31()
+            or mas_isD25Season()
+            or mas_isplayer_bday()
+            or mas_isF14()
+        )
+        and persistent._mas_current_background == "spaceroom"
+    ):
 
         ev_rules = dict()
         # why are we limiting this to certain day range?

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1298,6 +1298,7 @@ label monikaroom_greeting_ear_narration:
         # clear out var
         $ willchange_ev = None
 
+    $ mas_startupWeather()
     call spaceroom(dissolve_all=True, scene_change=True)
 
     if mas_isMoniNormal(higher=True):
@@ -1551,6 +1552,7 @@ label monikaroom_greeting_opendoor_locked:
 
     hide paper_glitch2
     $ mas_globals.change_textbox = False
+    $ mas_startupWeather()
     call spaceroom(scene_change=True)
 
     if renpy.seen_label("monikaroom_greeting_opendoor_locked_tbox"):
@@ -1673,6 +1675,7 @@ label monikaroom_greeting_opendoor_post2:
 #    else:
 #        m 3eua "Let me fix this scene up."
     m 1dsc ".{w=0.5}.{w=0.5}.{nw}"
+    $ mas_startupWeather()
     call spaceroom(hide_monika=True, scene_change=True, show_emptydesk=False)
     show monika 4eua_static zorder MAS_MONIKA_Z at i11
     m "Tada!"
@@ -1689,6 +1692,7 @@ label monikaroom_greeting_opendoor:
     # reset outfit since standing is stock
     $ monika_chr.reset_outfit(False)
     $ monika_chr.wear_acs(mas_acs_ribbon_def)
+    $ mas_startupWeather()
 
     call spaceroom(start_bg="bedroom",hide_monika=True, dissolve_all=True, show_emptydesk=False)
 
@@ -1730,6 +1734,7 @@ label monikaroom_greeting_opendoor:
             m 2hua_static "All fixed!"
             show monika 1eua_static at lhide
             hide monika
+
     $ persistent.seen_monika_in_room = True
     jump monikaroom_greeting_post
     # NOTE: return is expected in monikaroom_greeting_post
@@ -1762,6 +1767,7 @@ label monikaroom_greeting_knock:
                 if persistent.seen_monika_in_room:
                     m "Thanks for knocking."
 
+            $ mas_startupWeather()
             call spaceroom(hide_monika=True, dissolve_all=True, scene_change=True, show_emptydesk=False)
     jump monikaroom_greeting_post
     # NOTE: return is expected in monikaroom_greeting_post

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -1105,9 +1105,7 @@ default persistent._mas_crashed_trynot = False
 
 # start of crash flow
 label mas_crashed_start:
-
     if persistent._mas_crashed_before:
-
         # preshort setup
         call mas_crashed_preshort
 
@@ -1118,7 +1116,6 @@ label mas_crashed_start:
         call mas_crashed_post
 
     else:
-
         # long setup (includes scene black)
         call mas_crashed_prelong
 
@@ -1146,8 +1143,11 @@ label mas_crashed_start:
     return
 
 label mas_crashed_prelong:
+    #Setup weather
+    #Since we're in the room but the lights are off, if it's raining we want it to be audible here
+    $ mas_startupWeather()
 
-    # otherwise continue to long flow
+    #Setup the rest of the scene
     $ persistent._mas_crashed_before = True
     scene black
     $ HKBHideButtons()
@@ -1358,12 +1358,14 @@ label mas_crashed_long_fluster:
 
 
 label mas_crashed_preshort:
+    #Setup weather
+    $ mas_startupWeather()
+
     # we can call spaceroom appropriately here
     call spaceroom(scene_change=True)
     return
 
 label mas_crashed_short:
-
     python:
         # generate a quiplist
         q_list = MASQuipList()

--- a/Monika After Story/game/splash.rpy
+++ b/Monika After Story/game/splash.rpy
@@ -350,6 +350,9 @@ label quit:
         # save weather options
         store.mas_weather.saveMWData()
 
+        # save bgs
+        store.mas_background.saveMBGData()
+
         # remove special images
         store.mas_island_event.removeImages()
 

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -1,6 +1,10 @@
 #Here's where we store our background data
 default persistent._mas_background_MBGdata = {}
 
+#Store the persistent background
+#Defaults to def (spaceroom)
+default persistent._mas_current_background = "def"
+
 #START: Class definition
 init -10 python:
 
@@ -312,7 +316,6 @@ init -20 python in mas_background:
 
 #START: BG change functions
 init 800 python:
-
     def mas_setBackground(_background):
         """
         Sets the initial bg
@@ -328,7 +331,7 @@ init 800 python:
         mas_current_background = _background
         mas_current_background.entry(old_background)
 
-    def mas_changeBackground(new_background, by_user=None):
+    def mas_changeBackground(new_background, by_user=None, set_persistent=False):
         """
         changes the background w/o any scene changes
 
@@ -337,13 +340,30 @@ init 800 python:
                 The background we're changing to
 
             by_user:
-                If the user switched the background themselves
+                True if the user switched the background themselves
+
+            set_persistent:
+                True if we want this to be persistent
         """
         if by_user is not None:
             mas_background.force_background = bool(by_user)
 
         mas_current_background.exit(new_background)
         mas_setBackground(new_background)
+
+    def mas_startupBackground():
+        """
+        Sets up the spaceroom to start up in the background you left in if it is unlocked and still exists
+        """
+        if (
+            persistent._mas_current_background in store.mas_background.BACKGROUND_MAP
+            and store.mas_background.BACKGROUND_MAP[persistent._mas_current_background].unlocked
+        ):
+            background_to_set = store.mas_background.BACKGROUND_MAP[persistent._mas_current_background]
+            mas_changeBackground(background_to_set)
+
+            if background_to_set.disable_progressive:
+                store.skip_setting_weather = True
 
     #Just set us to the normal room here
     mas_current_background = None
@@ -352,6 +372,8 @@ init 800 python:
     #Make sure the bg selector is only available with at least 2 bgs unlocked
     if mas_background.getUnlockedBGCount() < 2:
         mas_lockEVL("monika_change_background","EVE")
+    else:
+        mas_unlockEVL("monika_change_background", "EVE")
 
 #START: Programming points
 init -2 python in mas_background:
@@ -412,24 +434,25 @@ image monika_snow_room_night = "mod_assets/location/spaceroom/spaceroom_snow-n.p
 
 #TODO: locking/unlocking of this based on other backgrounds
 #START: Location Selector
-#init 5 python:
-#    # available only if moni affection is affectionate+
-#    addEvent(
-#        Event(
-#            persistent.event_database,
-#            eventlabel="monika_change_background",
-#            category=["location"],
-#            prompt="Can we go somewhere else?",
-#            pool=True,
-#            unlocked=False,
-#            rules={"no unlock": None},
-#            aff_range=(mas_aff.AFFECTIONATE, None)
-#        )
-#    )
+init 5 python:
+    # available only if moni affection is affectionate+
+    addEvent(
+        Event(
+            persistent.event_database,
+            eventlabel="monika_change_background",
+            category=["location"],
+            prompt="Can we go somewhere else?",
+            pool=True,
+            unlocked=False,
+            rules={"no unlock": None},
+            aff_range=(mas_aff.AFFECTIONATE, None)
+        )
+    )
 
 label monika_change_background:
-
     m 1hua "Sure!"
+
+    #FALL THROUGH
 
 label monika_change_background_loop:
 
@@ -471,20 +494,18 @@ label monika_change_background_loop:
 
     # return value False? then return
     if sel_background is False:
-        m 1eka "Oh, alright."
-        m "If you want to go somewhere, just ask, okay?"
-        return
+        return "prompt"
 
     if sel_background == mas_current_background:
         m 1hua "We're here right now, silly."
         m "Try again~"
         jump monika_change_background_loop
 
-    call mas_background_change(sel_background)
+    call mas_background_change(sel_background, set_persistent=True)
     return
 
 #Generic background changing label, can be used if we wanted a sort of story related change
-label mas_background_change(new_bg, skip_leadin=False, skip_outro=False):
+label mas_background_change(new_bg, skip_leadin=False, skip_outro=False, set_persistent=False):
     # otherwise, we can change the background now
     if not skip_leadin:
         m 1eua "Alright!"
@@ -496,29 +517,35 @@ label mas_background_change(new_bg, skip_leadin=False, skip_outro=False):
     with dissolve
     pause 2.0
 
-    # finally change the background
-    $ mas_changeBackground(new_bg)
+    python:
+        #Set persistent
+        if set_persistent:
+            persistent._mas_current_background = new_bg.background_id
 
-    #If we've disabled progressive and hidden masks, then we shouldn't allow weather change
-    if new_bg.disable_progressive and new_bg.hide_masks:
-        $ mas_weather.temp_weather_storage = mas_current_weather
-        $ mas_changeWeather(mas_weather_def)
-        $ mas_lockEVL("monika_change_weather", "EVE")
+        #Store the old bg for use later
+        old_bg = mas_current_background
 
-    else:
-        if mas_weather.temp_weather_storage is not None:
-            $ mas_changeWeather(mas_weather.temp_weather_storage)
+        #Finally, change the background
+        mas_changeBackground(new_bg)
+
+        #If we've disabled progressive and hidden masks, then we shouldn't allow weather change
+        if new_bg.disable_progressive and new_bg.hide_masks:
+            mas_weather.temp_weather_storage = mas_current_weather
+            mas_changeWeather(mas_weather_def)
+            mas_lockEVL("monika_change_weather", "EVE")
 
         else:
-            #If we don't have tempstor, run the startup weather
-            $ set_to_weather = mas_shouldRain()
-            if set_to_weather is not None:
-                $ mas_changeWeather(set_to_weather)
-            else:
-                $ mas_changeWeather(mas_weather_def)
+            if mas_weather.temp_weather_storage is not None:
+                mas_changeWeather(mas_weather.temp_weather_storage)
+                #Now reset the temp storage for weather
+                mas_weather.temp_weather_storage = None
 
-        #Then we unlock the weather sel here
-        $ mas_unlockEVL("monika_change_weather", "EVE")
+            else:
+                #If we don't have tempstor, run the startup weather
+                mas_startupWeather()
+
+            #Then we unlock the weather sel here
+            mas_unlockEVL("monika_change_weather", "EVE")
 
     call spaceroom(scene_change=True, dissolve_all=True)
 

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -402,6 +402,13 @@ init -2 python in mas_background:
         if store.seen_event("mas_monika_islands"):
             store.mas_unlockEVL("mas_monika_islands", "EVE")
 
+        #Since these holidays demand a specific weather, we'll set them here
+        if store.mas_isO31():
+            store.mas_changeWeather(store.mas_weather_thunder, by_user=True)
+
+        elif store.mas_isD25():
+            store.mas_changeWeather(store.mas_weather_snow, by_user=True)
+
     def _def_background_exit(_new):
         """
         Exit programming point for befault background

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -411,6 +411,10 @@ init -2 python in mas_background:
             elif store.mas_isD25():
                 store.mas_changeWeather(store.mas_weather_snow, by_user=True)
 
+        #Weather should always be unlocked for spaceroom
+        #This catches the potential of a deleted background which does not support weather
+        store.mas_unlockEVL("monika_change_weather", "EVE")
+
     def _def_background_exit(_new):
         """
         Exit programming point for befault background

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -359,7 +359,8 @@ init 800 python:
         Sets up the spaceroom to start up in the background you left in if it is unlocked and still exists
         """
         if (
-            persistent._mas_current_background in store.mas_background.BACKGROUND_MAP
+            mas_isMoniEnamored(higher=True)
+            and persistent._mas_current_background in store.mas_background.BACKGROUND_MAP
             and store.mas_background.BACKGROUND_MAP[persistent._mas_current_background].unlocked
         ):
             background_to_set = store.mas_background.BACKGROUND_MAP[persistent._mas_current_background]
@@ -436,6 +437,8 @@ init -1 python:
         exit_pp=store.mas_background._def_background_exit
     )
 
+    #Now load data
+    store.mas_background.loadMBGData()
 
 #START: Image definitions
 #Spaceroom
@@ -460,7 +463,7 @@ init 5 python:
             pool=True,
             unlocked=False,
             rules={"no unlock": None},
-            aff_range=(mas_aff.AFFECTIONATE, None)
+            aff_range=(mas_aff.ENAMORED, None)
         )
     )
 

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -402,12 +402,14 @@ init -2 python in mas_background:
         if store.seen_event("mas_monika_islands"):
             store.mas_unlockEVL("mas_monika_islands", "EVE")
 
-        #Since these holidays demand a specific weather, we'll set them here
-        if store.mas_isO31():
-            store.mas_changeWeather(store.mas_weather_thunder, by_user=True)
+        #NOTE: We check if _old here because it acts as a check for whether or not we're in the init phase
+        if _old:
+            #Since these holidays demand a specific weather, we'll set them here
+            if store.mas_isO31():
+                store.mas_changeWeather(store.mas_weather_thunder, by_user=True)
 
-        elif store.mas_isD25():
-            store.mas_changeWeather(store.mas_weather_snow, by_user=True)
+            elif store.mas_isD25():
+                store.mas_changeWeather(store.mas_weather_snow, by_user=True)
 
     def _def_background_exit(_new):
         """

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -348,6 +348,9 @@ init 800 python:
         if by_user is not None:
             mas_background.force_background = bool(by_user)
 
+        if set_persistent:
+            persistent._mas_current_background = new_background.background_id
+
         mas_current_background.exit(new_background)
         mas_setBackground(new_background)
 
@@ -365,15 +368,27 @@ init 800 python:
             if background_to_set.disable_progressive:
                 store.skip_setting_weather = True
 
+        #If for whatever reason, we are no longer able to use the persistent background now, we reset to spaceroom
+        else:
+            persistent._mas_current_background = "spaceroom"
+
+    def mas_checkBackgroundChangeDelegate():
+        """
+        Checks to see if the background change delegate should be locked or unlocked and changes its state accordingly
+
+        Key rule: at least 2 available backgrounds
+        """
+        if mas_background.getUnlockedBGCount() < 2:
+            mas_lockEVL("monika_change_background","EVE")
+        else:
+            mas_unlockEVL("monika_change_background", "EVE")
+
+
     #Just set us to the normal room here
     mas_current_background = None
     mas_setBackground(mas_background_def)
 
-    #Make sure the bg selector is only available with at least 2 bgs unlocked
-    if mas_background.getUnlockedBGCount() < 2:
-        mas_lockEVL("monika_change_background","EVE")
-    else:
-        mas_unlockEVL("monika_change_background", "EVE")
+
 
 #START: Programming points
 init -2 python in mas_background:

--- a/Monika After Story/game/zz_calendar.rpy
+++ b/Monika After Story/game/zz_calendar.rpy
@@ -2261,5 +2261,5 @@ init python:
         """RUNTIME ONLY
         Shows the calendar overlay
         """
-        if not mas_calIsVisible_ovl():
+        if not mas_current_background.hide_calendar and not mas_calIsVisible_ovl():
             renpy.show_screen("calendar_overlay", _layer="master")

--- a/Monika After Story/game/zz_dockingstation.rpy
+++ b/Monika After Story/game/zz_dockingstation.rpy
@@ -2234,95 +2234,98 @@ label mas_dockstat_abort_gen:
 
 #Call this label to reset the date vars
 label mas_dockstat_decrement_date_counts:
-    # we are not leaving
-    $ persistent._mas_dockstat_going_to_leave = False
+    python:
+        #We are not leaving
+        persistent._mas_dockstat_going_to_leave = False
 
-    # we are not leaving and need to reset these
-    if persistent._mas_player_bday_left_on_bday:
-        $ persistent._mas_player_bday_left_on_bday = False
-        $ persistent._mas_player_bday_date -= 1
+        # we are not leaving and need to reset these
+        if persistent._mas_player_bday_left_on_bday:
+            persistent._mas_player_bday_left_on_bday = False
+            persistent._mas_player_bday_date -= 1
 
-    if persistent._mas_f14_on_date:
-        $ persistent._mas_f14_on_date = False
-        $ persistent._mas_f14_date_count -= 1
+        if persistent._mas_f14_on_date:
+            persistent._mas_f14_on_date = False
+            persistent._mas_f14_date_count -= 1
 
-    if persistent._mas_bday_on_date:
-        $ persistent._mas_bday_on_date = False
-        $ persistent._mas_bday_date_count -= 1
+        if persistent._mas_bday_on_date:
+            persistent._mas_bday_on_date = False
+            persistent._mas_bday_date_count -= 1
     return
 
 
 # empty desk. This one includes file checking every 1 second
 label mas_dockstat_empty_desk:
-    #NOTE: this needs to be done prior to a spaceroom call otherwise it doesn't update
-    #Make sure O31 effects show
-    if persistent._mas_o31_in_o31_mode:
-        $ mas_globals.show_vignette = True
-        #If weather isn't thunder, we need to make it so (done so we don't have needless sets)
-        if mas_current_weather != mas_weather_thunder:
-            $ mas_changeWeather(mas_weather_thunder, True)
-
-
-    # TODO: else this with the o31 mode
-    # set weather here
-    # TODO: run the yet-to-be-made weather alg running function etc
-    $ set_to_weather = mas_shouldRain()
-    if set_to_weather is not None:
-        $ mas_changeWeather(set_to_weather)
-        $ skip_setting_weather = True
-
     # reset zoom before showing spaceroom
     $ store.mas_sprites.reset_zoom()
 
     call spaceroom(hide_monika=True, scene_change=True)
-    $ mas_from_empty = True
 
-    $ checkout_time = store.mas_dockstat.getCheckTimes()[0]
+    python:
+        mas_from_empty = True
 
-    if mas_isD25Season() and persistent._mas_d25_deco_active:
-        $ store.mas_d25ShowVisuals()
+        checkout_time = store.mas_dockstat.getCheckTimes()[0]
 
-    if mas_confirmedParty() and mas_isMonikaBirthday():
-        $ persistent._mas_bday_visuals = True
-        $ store.mas_surpriseBdayShowVisuals(cake=not persistent._mas_bday_sbp_reacted)
+        if mas_isD25Season() and persistent._mas_d25_deco_active:
+            store.mas_d25ShowVisuals()
 
-    #NOTE: elif'd so we don't try and show two types of visuals here
-    elif persistent._mas_player_bday_decor:
-        $ store.mas_surpriseBdayShowVisuals()
+        if mas_confirmedParty() and mas_isMonikaBirthday():
+            persistent._mas_bday_visuals = True
+            store.mas_surpriseBdayShowVisuals(cake=not persistent._mas_bday_sbp_reacted)
 
+        #NOTE: elif'd so we don't try and show two types of visuals here
+        elif persistent._mas_player_bday_decor:
+            store.mas_surpriseBdayShowVisuals()
+
+    #FALL THROUGH
 
 label mas_dockstat_empty_desk_preloop:
+    python:
+        import store.mas_dockstat as mas_dockstat
 
-    # setup ui hiding
-    $ import store.mas_dockstat as mas_dockstat
-    $ mas_OVLHide()
-    $ mas_calRaiseOverlayShield()
-    $ mas_calShowOverlay()
-    $ disable_esc()
-    $ mas_enable_quit()
-    $ promise = mas_dockstat.monikafind_promise
+        #Setup ui hiding
+        mas_OVLHide()
+        mas_calRaiseOverlayShield()
+        mas_calShowOverlay()
+        disable_esc()
+        mas_enable_quit()
+        promise = mas_dockstat.monikafind_promise
+
+        #Make sure O31 effects show
+        if persistent._mas_o31_in_o31_mode:
+            mas_globals.show_vignette = True
+            #If weather isn't thunder, we need to make it so (done so we don't have needless sets)
+            if mas_current_weather != mas_weather_thunder:
+                mas_changeWeather(mas_weather_thunder, True)
+
+        else:
+            #Now setup weather
+            mas_startupWeather()
+            skip_setting_weather = True
+
+    call spaceroom(scene_change=True, hide_monika=True)
 
 label mas_dockstat_empty_desk_from_empty:
 
-    # begin the find thread
-    if promise.ready:
-        $ promise.start()
+    python:
+        #Begin the find thread
+        if promise.ready:
+            promise.start()
 
-    # wait 1 seconds before checking again
-    $ renpy.pause(1.0, hard=True)
+        #wait 1 seconds before checking again
+        renpy.pause(1.0, hard=True)
 
-    # check for surprise visuals
-    if mas_confirmedParty() and mas_isMonikaBirthday():
-        $ persistent._mas_bday_visuals = True
-        $ store.mas_surpriseBdayShowVisuals(cake=not persistent._mas_bday_sbp_reacted)
+        #Check for surprise visuals
+        if mas_confirmedParty() and mas_isMonikaBirthday():
+            persistent._mas_bday_visuals = True
+            store.mas_surpriseBdayShowVisuals(cake=not persistent._mas_bday_sbp_reacted)
 
-    # check for monika
-    if promise.done():
-        # we have a result! lets get and then check if we found anything.
-        $ _status, _data_line = promise.get()
-        $ mas_dockstat.retmoni_status = _status
-        $ mas_dockstat.retmoni_data = _data_line
-        $ mas_dockstat.triageMonika(True)
+        #Check for monika
+        if promise.done():
+            # we have a result! lets get and then check if we found anything.
+            _status, _data_line = promise.get()
+            mas_dockstat.retmoni_status = _status
+            mas_dockstat.retmoni_data = _data_line
+            mas_dockstat.triageMonika(True)
 
     # otherwise we still havent' found monika, so lets just continue
     # the loop

--- a/Monika After Story/game/zz_dockingstation.rpy
+++ b/Monika After Story/game/zz_dockingstation.rpy
@@ -2255,8 +2255,21 @@ label mas_dockstat_decrement_date_counts:
 
 # empty desk. This one includes file checking every 1 second
 label mas_dockstat_empty_desk:
-    # reset zoom before showing spaceroom
-    $ store.mas_sprites.reset_zoom()
+    python:
+        #Make sure O31 effects show
+        if persistent._mas_o31_in_o31_mode:
+            mas_globals.show_vignette = True
+            #If weather isn't thunder, we need to make it so (done so we don't have needless sets)
+            if mas_current_weather != mas_weather_thunder:
+                mas_changeWeather(mas_weather_thunder, True)
+
+        else:
+            #Now setup weather
+            mas_startupWeather()
+            skip_setting_weather = True
+
+        # reset zoom before showing spaceroom
+        store.mas_sprites.reset_zoom()
 
     call spaceroom(hide_monika=True, scene_change=True)
 
@@ -2289,20 +2302,6 @@ label mas_dockstat_empty_desk_preloop:
         disable_esc()
         mas_enable_quit()
         promise = mas_dockstat.monikafind_promise
-
-        #Make sure O31 effects show
-        if persistent._mas_o31_in_o31_mode:
-            mas_globals.show_vignette = True
-            #If weather isn't thunder, we need to make it so (done so we don't have needless sets)
-            if mas_current_weather != mas_weather_thunder:
-                mas_changeWeather(mas_weather_thunder, True)
-
-        else:
-            #Now setup weather
-            mas_startupWeather()
-            skip_setting_weather = True
-
-    call spaceroom(scene_change=True, hide_monika=True)
 
 label mas_dockstat_empty_desk_from_empty:
 

--- a/Monika After Story/game/zz_weather.rpy
+++ b/Monika After Story/game/zz_weather.rpy
@@ -807,12 +807,17 @@ init 800 python:
             if (
                 persistent._mas_current_weather == "auto"
                 or persistent._mas_current_weather not in mas_weather.WEATHER_MAP
+                or store.mas_isMoniHappy(lower=True)
             ):
                 set_to_weather = mas_shouldRain()
+                #In the case that the weather object no longer exists, we'll set current weather to auto
+                persistent._mas_current_weather = "auto"
 
             #Otherwise, we'll set to the persistent weather
             else:
                 set_to_weather = mas_weather.WEATHER_MAP.get(persistent._mas_current_weather)
+                #And since we have persistent weather, we know weather is forced
+                store.mas_weather.force_weather = True
 
             #Now set weather accordingly
             if set_to_weather is not None:

--- a/Monika After Story/game/zz_weather.rpy
+++ b/Monika After Story/game/zz_weather.rpy
@@ -796,11 +796,13 @@ init 800 python:
         Runs a weather startup alg, checking whether or not persistent weather should be used
         Sets weather accordingly
         """
-        #If the current bg doesn't support weather, we'll just return
-        if store.mas_current_background.disable_progressive:
-            return
-
-        elif not store.mas_weather.force_weather and not store.skip_setting_weather:
+        #If the current bg doesn't support weather, we don't do anything
+        #Same if we forced weather or we're to skip setting weather
+        if (
+            not store.mas_current_background.disable_progressive
+            and not store.mas_weather.force_weather
+            and not store.skip_setting_weather
+        ):
             #Let's check for persistent weather. If persistent is auto or no longer a thing, we revert to standard progressive
             if (
                 persistent._mas_current_weather == "auto"

--- a/Monika After Story/game/zz_weather.rpy
+++ b/Monika After Story/game/zz_weather.rpy
@@ -782,9 +782,10 @@ init 799 python:
             by_user - flag for if user changes weather or not
             set_persistent - whether or not we want to make this weather persistent
         """
-        #If the current background doesn't support weather, we'll just return here to be safe
+        #If the current background doesn't support weather, we set to def weather instead
+        #Since it has no sfx or anything
         if store.mas_current_background.disable_progressive:
-            return
+            new_weather = store.mas_weather_def
 
         if by_user is not None:
             mas_weather.force_weather = bool(by_user)

--- a/Monika After Story/game/zz_weather.rpy
+++ b/Monika After Story/game/zz_weather.rpy
@@ -753,7 +753,8 @@ init -1 python:
     store.mas_weather.loadMWData()
 
 # sets up weather
-init 800 python:
+#NOTE: MUST be before BGs
+init 799 python:
     def mas_setWeather(_weather):
         """
         Sets the initial weather.
@@ -781,6 +782,9 @@ init 800 python:
             by_user - flag for if user changes weather or not
             set_persistent - whether or not we want to make this weather persistent
         """
+        #If the current background doesn't support weather, we'll just return here to be safe
+        if store.mas_current_background.disable_progressive:
+            return
 
         if by_user is not None:
             mas_weather.force_weather = bool(by_user)


### PR DESCRIPTION
*Remember those old creepy test BGs from when we tested the original BG Framework PR? It's time to see them again...*

## Changes:
- `MASWeather`s and `MASBackground`s are now persistent, stored in `persistent._mas_current_weather` and `persistent._mas_current_background` respectively
- BG Change topic is now unlocked and properly locks/unlocks if there's at least two available backgrounds
- Changed the dockstat loop to use the preloop label properly, which also sets weather for when out of the room

## Testing:
- Verify that weather is now persistent
- Using the testcase bg set, verify BGs are now persistent
- Verify that changing bgs still keeps weather consistent
- Verify dockstat loop still works properly (both returning Monika before opening MAS and after)
- Verify that if the current persistent background is locked, if you say goodbye and reload, you're back in the spaceroom
- Verify that if the current persistent weather is not initialized, the weather returns to def when loading in.
- Verify no crashes