### PR TITLE
Unlock kiss topic

### DIFF
--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -1482,7 +1482,17 @@ label monika_date:
     return
 
 init 5 python:
-    addEvent(Event(persistent.event_database,eventlabel="monika_kiss",category=['romance'],prompt="Kiss me",pool=True,unlocked=True,aff_range=(mas_aff.NORMAL, None)))
+    addEvent(
+        Event(
+            persistent.event_database,
+            eventlabel="monika_kiss",
+            category=['romance'],
+            prompt="Kiss me",
+            pool=True,
+            unlocked=True,
+            aff_range=(mas_aff.NORMAL, None)
+        )
+    )
 
 label monika_kiss:
     if mas_isMoniEnamored(higher=True) and persistent._mas_first_kiss is not None:
@@ -7418,7 +7428,16 @@ label monika_how_soon:
     return
 
 init 5 python:
-    addEvent(Event(persistent.event_database,eventlabel="monika_marriage",category=['romance'],prompt="Will you marry me?",pool=True,aff_range=(mas_aff.NORMAL, None)))
+    addEvent(
+        Event(
+            persistent.event_database,
+            eventlabel="monika_marriage",
+            category=['romance'],
+            prompt="Will you marry me?",
+            pool=True,
+            aff_range=(mas_aff.NORMAL, None)
+        )
+    )
 
 label monika_marriage:
     $ mas_gainAffection()

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -1482,7 +1482,7 @@ label monika_date:
     return
 
 init 5 python:
-    addEvent(Event(persistent.event_database,eventlabel="monika_kiss",category=['romance'],prompt="Kiss me",pool=True,aff_range=(mas_aff.NORMAL, None)))
+    addEvent(Event(persistent.event_database,eventlabel="monika_kiss",category=['romance'],prompt="Kiss me",pool=True,unlocked=True,aff_range=(mas_aff.NORMAL, None)))
 
 label monika_kiss:
     if mas_isMoniEnamored(higher=True) and persistent._mas_first_kiss is not None:
@@ -7418,7 +7418,7 @@ label monika_how_soon:
     return
 
 init 5 python:
-    addEvent(Event(persistent.event_database,eventlabel="monika_marriage",category=['romance'],prompt="Will you marry me?",pool=True))
+    addEvent(Event(persistent.event_database,eventlabel="monika_marriage",category=['romance'],prompt="Will you marry me?",pool=True,aff_range=(mas_aff.NORMAL, None)))
 
 label monika_marriage:
     $ mas_gainAffection()
@@ -7437,8 +7437,8 @@ label monika_marriage:
     else:
         m 2wubsw "M-marriage?"
         m 4rksdlb "I think it's a bit too early for marriage..."
-        m 2ekbfa "I mean, I'm really happy that you want that, [player]."
-        m 2lkbsa "But I think I should get out of here before we can do that."
+        m 2ekbfa "I mean, I'm really happy that you want that, [player]..."
+        m 2lkbsa "But I think I should get out of here first."
         m 2lsbsa "Not only do I not want this place to be the spot where I get proposed to, but I want to be there when you finally give me an engagement ring."
         m 2dkbsu "I want that special moment to happen when we can finally be together..."
         m 1hubfa "So until then, save yourself for me, [player]~"

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -377,11 +377,13 @@ label v0_11_3(version="v0_11_3"):
     python:
         # give extra pool unlocks for recent players
         if mas_isFirstSeshPast(datetime.date(2020, 4, 4)):
-            # only 0.11.0 + week ago 
+            # only 0.11.0 + week ago
 
             # NOTE: multiply by 4 becaue everyone should already have level
-            #   number of pool unlocks given 
+            #   number of pool unlocks given
             persistent._mas_pool_unlocks += store.mas_xp.level() * 4
+
+        mas_unlockEVL("monika_kiss", "EVE")
 
     return
 


### PR DESCRIPTION
Closes #5744 

Currently `monika_kiss` is unlocked via the pool unlocking system, which means it's possible to get your first kiss and then not have this unlocked. This unlocks it by default, as having this topic available from the beginning serves as a teaser of what's to come. It also adds an aff_range prop of Normal+ to `monika_marriage`.

## Testing

-  verify on a new persistent made from 0.11.2 or older that does not have `monika_kiss` unlocked, that calling the update script unlocks it

- verify on a new persistent that `monika_kiss` is unlocked right away

