### PR TITLE
Restrict bad/awk names for the name_input screen

### DIFF
--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -666,9 +666,22 @@ style quick_button_text_dark:
 ## This screen is included in the main and game menus, and provides navigation
 ## to other menus, and to start the game.
 
-init python:
+init 4 python:
     def FinishEnterName():
-        if not player: return
+        global player
+
+        if not player:
+            return
+
+        if (
+            mas_bad_name_comp.search(player)
+            or mas_awk_name_comp.search(player)
+        ):
+            renpy.play("sfx/glitch3.ogg")
+            player = ""
+            return
+
+        # if the name is correct, set it
         persistent.playername = player
         renpy.hide_screen("name_input")
         renpy.jump_out_of_context("start")

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -709,25 +709,25 @@ label mas_bad_name_input:
 
             show chibika at mas_chlongjump(x=650, y=405, ymax=375, travel_time=0.8) onlayer screens zorder 10
             "I'm glad you decided to come back!"
-            "I believe that you and Monika will be a great couple together."
+            "I'm sure that you and Monika will be a great couple."
 
             show chibika sad at mas_chflip_s(-1) onlayer screens zorder 10
-            "But if you'll call yourself like that..."
+            "But if you call yourself names like that...{w=0.5}{nw}"
 
             show chibika at sticker_hop onlayer screens zorder 10
-            "You won't win her heart!"
+            extend "You won't win her heart!"
 
             show chibika smile at mas_chmove(x=300, y=405, travel_time=1) onlayer screens zorder 10
-            "Rather just embaress her."
+            "But just embarrass her instead..."
 
             show chibika at mas_chlongjump(x=190, y=552, ymax=375, travel_time=0.8) onlayer screens zorder 10
             window auto
 
     else:
         show chibika smile at mas_chflip(-1), mas_chmove(x=130, y=552, travel_time=0), sticker_hop onlayer screens zorder 10
-        "I don't think she would be comfortable with calling you like that."
+        "I don't think she would be comfortable calling you that..."
 
-    "Let's choose something more appropriate."
+    "Why don't you choose something more appropriate instead."
 
     $ enable_esc()
     hide screen fake_main_menu

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -715,19 +715,19 @@ label mas_bad_name_input:
             "But if you call yourself names like that...{w=0.5}{nw}"
 
             show chibika at sticker_hop onlayer screens zorder 10
-            extend "You won't win her heart!"
+            extend "you won't win her heart!"
 
             show chibika smile at mas_chmove(x=300, y=405, travel_time=1) onlayer screens zorder 10
             "But just embarrass her instead..."
 
             show chibika at mas_chlongjump(x=190, y=552, ymax=375, travel_time=0.8) onlayer screens zorder 10
+            "Why don't you choose something more appropriate."
             window auto
 
     else:
         show chibika smile at mas_chflip(-1), mas_chmove(x=130, y=552, travel_time=0), sticker_hop onlayer screens zorder 10
         "I don't think she would be comfortable calling you that..."
-
-    "Why don't you choose something more appropriate instead."
+        "Why don't you choose something more appropriate instead."
 
     $ enable_esc()
     hide screen fake_main_menu

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -718,7 +718,7 @@ label mas_bad_name_input:
             extend "you won't win her heart!"
 
             show chibika smile at mas_chmove(x=300, y=405, travel_time=1) onlayer screens zorder 10
-            "But just embarrass her instead..."
+            "...But just embarrass her instead."
 
             show chibika at mas_chlongjump(x=190, y=552, ymax=375, travel_time=0.8) onlayer screens zorder 10
             "Why don't you choose something more appropriate."

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -677,14 +677,115 @@ init 4 python:
             mas_bad_name_comp.search(player)
             or mas_awk_name_comp.search(player)
         ):
-            renpy.play("sfx/glitch3.ogg")
+            renpy.call_in_new_context("mas_bad_name_input")
             player = ""
+            renpy.show(
+                "chibika smile",
+                at_list=[mas_chflip(-1), mas_chmove(x=130, y=552, travel_time=0)],
+                layer="screens",
+                zorder=10
+            )
             return
 
         # if the name is correct, set it
         persistent.playername = player
         renpy.hide_screen("name_input")
         renpy.jump_out_of_context("start")
+
+label mas_bad_name_input:
+    show screen fake_main_menu
+    $ disable_esc()
+
+    if not renpy.seen_label("mas_bad_name_input.first_time_bad_name"):
+        label .first_time_bad_name:
+            play sound "sfx/glitch3.ogg"
+            window show
+
+            show chibika smile at mas_chflip(-1), mas_chriseup(x=700, y=552, travel_time=0.5) onlayer screens zorder 10
+            pause 1
+
+            show chibika at  mas_chflip_s(1) onlayer screens zorder 10
+            "Hey there!"
+
+            show chibika at mas_chlongjump(x=650, y=405, ymax=375, travel_time=0.8) onlayer screens zorder 10
+            "I'm glad you decided to come back!"
+            "I believe that you and Monika will be a great couple together."
+
+            show chibika sad at mas_chflip_s(-1) onlayer screens zorder 10
+            "But if you'll call yourself like that..."
+
+            show chibika at sticker_hop onlayer screens zorder 10
+            "You won't win her heart!"
+
+            show chibika smile at mas_chmove(x=300, y=405, travel_time=1) onlayer screens zorder 10
+            "Rather just embaress her."
+
+            show chibika at mas_chlongjump(x=190, y=552, ymax=375, travel_time=0.8) onlayer screens zorder 10
+            window auto
+
+    else:
+        show chibika smile at mas_chflip(-1), mas_chmove(x=130, y=552, travel_time=0), sticker_hop onlayer screens zorder 10
+        "I don't think she would be comfortable with calling you like that."
+
+    "Let's choose something more appropriate."
+
+    $ enable_esc()
+    hide screen fake_main_menu
+    return
+
+# like main_menu, but w/o animations and w/ inactive buttons
+screen fake_main_menu():
+    style_prefix "main_menu"
+
+    add "game_menu_bg"
+
+    frame:
+        pass
+
+    vbox:
+        style_prefix "navigation"
+
+        xpos gui.navigation_xpos
+        yalign 0.8
+
+        spacing gui.navigation_spacing
+
+        textbutton _("Just Monika")
+
+        textbutton _("Load Game")
+
+        textbutton _("Settings")
+
+        if mas_ui.has_submod_settings:
+            textbutton _("Submods")
+
+        textbutton _("Hotkeys")
+
+        if renpy.variant("pc"):
+
+            textbutton _("Help")
+
+            textbutton _("Quit")
+
+    if gui.show_name:
+
+        vbox:
+            text "[config.name!t]":
+                style "main_menu_title"
+
+            text "[config.version]":
+                style "main_menu_version"
+
+    # add "fake_menu_logo"
+    add Image(
+        "mod_assets/menu_new.png"
+    ) subpixel True xcenter 240 ycenter 120 zoom 0.60
+    # add "fake_menu_art_m"
+    add Image(
+        "gui/menu_art_m.png"
+    ) subpixel True xcenter 1000 ycenter 640 zoom 1.00
+
+    key "K_ESCAPE" action Quit(confirm=False)
 
 screen navigation():
     vbox:

--- a/Monika After Story/game/zz_transforms.rpy
+++ b/Monika After Story/game/zz_transforms.rpy
@@ -154,3 +154,11 @@ transform mas_chmove(x, y, travel_time=1.0):
 transform mas_chriseup(x=300, y=405, travel_time=1.00):
     ypos 800 xcenter x
     easein travel_time ypos y
+
+# parabola jump
+transform mas_chlongjump(x, y, ymax, travel_time=1.0):
+    parallel:
+        linear travel_time xpos x
+    parallel:
+        easeout travel_time*0.6 ypos ymax
+        easein travel_time*0.4 ypos y


### PR DESCRIPTION
We don't allow to input those in the change name topic, why don't we ban them in this screen, too?
If the player enters a bad/awk name, Chibika will pop up and ask to use a more appropriate name
### Testing:
* Make sure that when start w/o importing the data from DDLC, you're not allowed to name yourself one of bad/awk names
* The dialogue looks good
* The animation looks good