### PR TITLE
Added priority to the restart greeting

### DIFF
--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -3719,15 +3719,22 @@ label greeting_surprised2:
     return
 
 init 5 python:
+    # set a slightly higher priority than the open door gre has
+    ev_rules = dict()
+    ev_rules.update(MASPriorityRule.create_rule(49))
+
     addEvent(
         Event(
             persistent.greeting_database,
             eventlabel="greeting_back_from_restart",
             unlocked=True,
             category=[store.mas_greetings.TYPE_RESTART],
+            rules=ev_rules
         ),
         code="GRE"
     )
+
+    del[ev_rules]
 
 label greeting_back_from_restart:
     if mas_isMoniNormal(higher=True):


### PR DESCRIPTION
In the restart greeting she's expecting the player to come back soon. While in the open door one she's not (she's asking who is it/the door closed).
This way the open door greeting shouldn't override it.