### PR TITLE
Add Game topics to the restart blacklist

### DIFF
--- a/Monika After Story/game/zz_games.rpy
+++ b/Monika After Story/game/zz_games.rpy
@@ -113,7 +113,8 @@ init 5 python:
             prompt="Pong",
             unlocked=True
         ),
-        code="GME"
+        code="GME",
+        restartBlacklist=True
     )
 
 label mas_pong:
@@ -147,7 +148,8 @@ init 5 python:
             eventlabel="mas_hangman",
             prompt="[mas_games.HANGMAN_NAME]"
         ),
-        code="GME"
+        code="GME",
+        restartBlacklist=True
     )
 
 label mas_hangman:
@@ -161,7 +163,8 @@ init 5 python:
             eventlabel="mas_piano",
             prompt="Piano"
         ),
-        code="GME"
+        code="GME",
+        restartBlacklist=True
     )
 
 label mas_piano:

--- a/Monika After Story/game/zz_games.rpy
+++ b/Monika After Story/game/zz_games.rpy
@@ -133,7 +133,8 @@ init 5 python:
                 "and mas_timePastSince(persistent._mas_chess_timed_disable, datetime.timedelta(hours=1))"
             )
         ),
-        code="GME"
+        code="GME",
+        restartBlacklist=True
     )
 
 label mas_chess:


### PR DESCRIPTION
If you crash during a game, it's possible that you'll end up in an infinite crash loop since the games will end up re-queuing when re-entering the spaceroom. This fixes that by adding the games to the restart blacklist.

## Testing:
- Verify that crashing during a game and loading back in doesn't return you to the game