### PR TITLE
Limit TNL to a max value

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1714,7 +1714,7 @@ label ch30_reset:
 
         if persistent._mas_xp_tnl < 0:
             persistent._mas_xp_tnl = store.mas_xp.XP_LVL_RATE
-        elif int(persistent._mas_xp_tnl) > int(store.mas_xp.XP_LVL_RATE):
+        elif int(persistent._mas_xp_tnl) > (2* int(store.mas_xp.XP_LVL_RATE)):
             # likely time travel
             persistent._mas_xp_tnl = 2 * store.mas_xp.XP_LVL_RATE
 

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1714,6 +1714,9 @@ label ch30_reset:
 
         if persistent._mas_xp_tnl < 0:
             persistent._mas_xp_tnl = store.mas_xp.XP_LVL_RATE
+        elif int(persistent._mas_xp_tnl) > int(store.mas_xp.XP_LVL_RATE):
+            # likely time travel
+            persistent._mas_xp_tnl = 2 * store.mas_xp.XP_LVL_RATE
 
         if persistent._mas_xp_hrx < 0:
             persistent._mas_xp_hrx = 0.0


### PR DESCRIPTION
also open to suggestions for how much to penalize tt

**NOTE:** no need for update script since this is ch30 reset.

# Key changes
* limits `persistent._mas_xp_tnl` to up to 2 times the natural level rate.

# Testing
1. set `persistent._mas_xp_tnl` to some value larger than the xp level rate (420). 
2. Verify that your tnl is set to twice 420 upon a restart.