### PR TITLE
cleans persistent mtimes if in future

### DIFF
--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -159,6 +159,41 @@ init -999 python in mas_ev_data_ver:
             return self.verifier(value, self.allow_none)
 
 
+init -998 python in mas_ev_data_ver:
+    import time
+    import renpy
+    import store
+
+    def _verify_per_mtime():
+        """
+        verifies persistent data and ensure mod times are not in the future
+        """
+        curr_time = time.time()
+
+        # check renpy persistent mtime
+        if renpy.persistent.persistent_mtime > curr_time:
+            renpy.persistent.persistent_mtime = curr_time
+
+        # then save location mtime
+        if renpy.loadsave.location is not None:
+            locs = renpy.loadsave.location.locations
+            if locs is not None and len(locs) > 0 and locs[0] is not None:
+                if locs[0].persistent_mtime > curr_time:
+                    locs[0].persistent_mtime = curr_time
+
+        # then individual mtimes
+        for varkey in store.persistent._changed:
+            if store.persistent._changed[varkey] > curr_time:
+                store.persistent._changed[varkey] = curr_time
+
+    # verify
+    try:
+        _verify_per_mtime()
+        valid_times = True
+    except:
+        valid_times = False
+        renpy.log("failed to verify mtimes")
+
 init -950 python in mas_ev_data_ver:
     import store
 


### PR DESCRIPTION
This may also fix any TT data loss issues. (see below testing for explanation)

# Key Changes
* sets `renpy.persistent.persistent_mtime`, `renpy.loadsave.location[...].persistent_mtime`, and all mtimes in `persistent._changed` to the current time if they are in the future. this should prevent any instance of data on disk overriding data in memory. hopefully thats not bad.

# Testing
* verify no crashes in normal operation (or when any `renpy.save_persistent` is called)
* try TT, and verify no crashes either

## renpy persistent saving
The stock `renpy.save_persistent` function calls `renpy.persistent.update`, which loads a copy of the persistent from disk. This then runs a function called `renpy.persistent.merge`. It turns out that persistent data consist of two items per value: a time of modification and the value itself.

In TT-to-the-past, or even time zone changing scenarios, when data is changed in-game, the modification times are set to the current time as normal. However, since the current time is earlier than the modification time on disk, the `merge` function will prefer the disk data, resulting in in-game data being lost. 

The fact that this could occur in timezone scenarios means that this may be a cause of general data loss. In theory that should be fixed with these changes, but there may be calls to the internal update/merge functions by renpy code that we cannot stop, so this may not be a 100% solution.
