### PR TITLE
Lock weather if the startup background doesn't support it

### DIFF
--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -481,7 +481,8 @@ init 5 python:
             unlocked=False,
             rules={"no unlock": None},
             aff_range=(mas_aff.ENAMORED, None)
-        )
+        ),
+        restartBlacklist=True
     )
 
 label monika_change_background:

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -421,6 +421,10 @@ init -2 python in mas_background:
         """
         store.mas_lockEVL("mas_monika_islands", "EVE")
 
+        #Lock the weather is the background we are changing to does not support it
+        if _new.disable_progressive:
+            store.mas_lockEVL("monika_change_weather", "EVE")
+
 
 #START: bg defs
 init -1 python:


### PR DESCRIPTION
This locks the weather topic if the startup background does not support weather.

## Testing:
- Verify that the weather topic is locked if you start the game while on a background that does not support weather
- Verify that the weather topic still unlocks if you start the game while on a background that supports weather
- Verify no crashes