### PR TITLE
fix dockstat log crash and separate monika file gen logs

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -3483,6 +3483,34 @@ init -991 python in mas_utils:
                 outfile.close()
 
 
+    def logcreate(filepath, append=False, flush=False, addversion=False):
+        """
+        Creates a log at the given filepath. 
+        This also opens the log and sets raw_write to True.
+        This also adds per version number if desired
+
+        IN:
+            filepath - filepath of the log to create (extension is added)
+            append - True will append to the log. False will overwrite
+                (Default: False)
+            flush - True will flush every operation, False will not
+                (Default: False)
+            addversion - True will add the version, False will not
+                You dont need this if you create the log in runtime,
+                (Default: False)
+
+        RETURNS: created log object. 
+        """
+        new_log = getMASLog(filepath, append=append, flush=flush)
+        new_log.open()
+        new_log.raw_write = True
+        if addversion:
+            new_log.write("VERSION: {0}\n".format(
+                store.persistent.version_number
+            ))
+        return new_log
+
+
     def logrotate(logpath, filename):
         """
         Does a log rotation. Log rotations contstantly increase. We defualt

--- a/Monika After Story/game/zz_dockingstation.rpy
+++ b/Monika After Story/game/zz_dockingstation.rpy
@@ -2054,7 +2054,7 @@ init 200 python in mas_dockstat:
 
         if checkin_len != checkout_len:
             # mis match logs, please log this.
-            rd_log.write(
+            mas_utils.writelog(
                 (
                     "[WARNING]: checkin is {0}, checkout is {1}. "
                     "Going to pop.\n"

--- a/Monika After Story/game/zz_dockingstation.rpy
+++ b/Monika After Story/game/zz_dockingstation.rpy
@@ -199,6 +199,7 @@ init -45 python:
         ERR_SEND = "Failure sending package '{0}'."
         ERR_SIGN = "Failure to request signature for package '{0}'."
         ERR_SIGNP = "Package '{0}' does not match checksum."
+        ERR_CREATE = "Failed to create directory '{0}'"
 
         ## constants returned from smartUnpack (status constants)
         ## these are bit-based
@@ -239,21 +240,18 @@ init -45 python:
                 try:
                     os.makedirs(self.station)
                 except Exception as e:
-                   mas_utils.writelog(self.ERR.format(
+                   store.mas_utils.writelog(self.ERR.format(
                        self.ERR_CREATE.format(self.station),
                        str(self),
                        repr(e)
                    ))
                    self.enabled = False
 
-
-
         def __str__(self):
             """
             toString
             """
             return "DS: [{0}]".format(self.station)
-
 
         def checkForPackage(self, package_name, check_read=True):
             """
@@ -371,7 +369,7 @@ init -45 python:
             ]
 
 
-        def getPackage(self, package_name):
+        def getPackage(self, package_name, log=None):
             """
             Gets a package from the docking station
 
@@ -379,6 +377,9 @@ init -45 python:
 
             IN:
                 package_name - The filename we are looking for
+                log - log to write messages to, if needed
+                    If None, we use mas_log
+                    (Default: None)
 
             RETURNS:
                 open file descriptor to the package (READ BYTES mode)
@@ -399,11 +400,17 @@ init -45 python:
                 package = open(package_path, "rb")
 
             except Exception as e:
-                mas_utils.writelog(self.ERR.format(
+                msg = self.ERR.format(
                     self.ERR_OPEN.format(package_name),
                     str(self),
                     repr(e)
-                ))
+                )
+
+                if log is None:
+                    mas_utils.writelog(msg)
+                else:
+                    log.write(msg)
+                    
                 if package is not None:
                     package.close()
                 return None
@@ -624,7 +631,8 @@ init -45 python:
                     contents=None,
                     lines=0,
                     b64=True,
-                    bs=None
+                    bs=None,
+                    log=None
             ):
             """
             Combines parts of signForPackage and _unpack in a way that is very
@@ -650,6 +658,9 @@ init -45 python:
                 b64 - True means the package is encoded in base64
                     (Default: True)
                 bs - blocksize to use. By default, we use B64_READ_SIZE
+                    (Default: None)
+                log - log to write messages to, if needed. 
+                    If None, we use mas_log
                     (Default: None)
 
             RETURNS: tuple of the following format
@@ -741,11 +752,16 @@ init -45 python:
 
 
             except Exception as e:
-                mas_utils.writelog(self.ERR.format(
+                msg = self.ERR.format(
                     self.ERR_READ.format(package_name),
                     str(self),
                     repr(e)
-                ))
+                )
+
+                if log is None:
+                    mas_utils.writelog(msg)
+                else:
+                    log.write(msg)
 
                 if contents is None:
                     # only close our internal contents if we made it
@@ -757,8 +773,16 @@ init -45 python:
                 # always close package after this
                 package.close()
 
-            # now to check checksums
-            if checklist.hexdigest() != pkg_slip:
+            # get checksum and log
+            chk = checklist.hexdigest()
+            msg = "chk: {0}\n".format(chk)
+            if log is None:
+                mas_utils.writelog(msg)
+            else:
+                log.write(msg)
+
+            # now check checksum
+            if chk != pkg_slip:
                 # no match? uh oh, lets return stuff anyway
                 return (ret_val | self.PKG_C, _contents)
 
@@ -1192,7 +1216,7 @@ init -11 python in mas_dockstat:
                 )
 
             except Exception as e:
-                mas_utils.writelog(
+                rd_log.write(
                     "[ERROR] failed to decode '{0}' | {1}\n".format(
                         b64_name,
                         str(e)
@@ -1299,6 +1323,9 @@ init 200 python in mas_dockstat:
     import random
     import datetime
 
+    cr_log_path = "log/mfgen"
+    rd_log_path = "log/mfread"
+
     # we set these during init phase if we found a monika
     retmoni_status = None
     retmoni_data = None
@@ -1348,7 +1375,7 @@ init 200 python in mas_dockstat:
         ]) + END_DELIM)
 
 
-    def _buildMetaDataPer(_outbuffer):
+    def _buildMetaDataPer(_outbuffer, log):
         """
         Writes out the persistent's data into the given buffer
 
@@ -1356,6 +1383,7 @@ init 200 python in mas_dockstat:
 
         OUT:
             _outbuffer - buffer to write persistent data to
+            log - log to write messages to, if needed
 
         RETURNS:
             True on success, False if failed
@@ -1369,7 +1397,7 @@ init 200 python in mas_dockstat:
             return True
 
         except Exception as e:
-            mas_utils.writelog(
+            log.write(
                 "[ERROR]: failed to pickle data: {0}\n".format(repr(e))
             )
             return False
@@ -1519,7 +1547,7 @@ init 200 python in mas_dockstat:
 
         return on_fail
 
-    def generateMonika(dockstat):
+    def generateMonika(dockstat, logpath):
         """
         Generates / writes a monika blob file.
 
@@ -1528,6 +1556,7 @@ init 200 python in mas_dockstat:
 
         IN:
             dockstat - the docking station to generate Monika in
+            logpath - path of log to write messagse to
 
         RETURNS:
             checksum of monika
@@ -1538,9 +1567,13 @@ init 200 python in mas_dockstat:
         ASSUMES:
             blocksize - this is a constant in this store
         """
+        cr_log = store.mas_utils.logcreate(logpath, flush=True)
+
+        cr_log.write("\n\nCreating Monika in: {0}\n".format(dockstat.station))
+
         # sanity check regarding the filepath
         if "temp" in dockstat.station.lower():
-            mas_utils.writelog("[ERROR] temp directory found, aborting.\n")
+            cr_log.write("[ERROR] temp directory found, aborting.\n")
             return False
 
         ### other stuff we need
@@ -1552,7 +1585,7 @@ init 200 python in mas_dockstat:
         NUM_DELIM = "|num|"
 
         ### write metadata
-        if not _buildMetaDataPer(moni_buffer):
+        if not _buildMetaDataPer(moni_buffer, cr_log):
             # if we failed to do this via persistent, then we'll use the old
             # style instead
             _buildMetaDataList(moni_buffer)
@@ -1568,7 +1601,7 @@ init 200 python in mas_dockstat:
             moni_buffer.write(moni_chr.read())
 
         except Exception as e:
-            mas_utils.writelog("[ERROR] mbase copy failed | {0}".format(
+            cr_log.write("[ERROR] mbase copy failed | {0}\n".format(
                 repr(e)
             ))
             moni_buffer.close()
@@ -1693,7 +1726,7 @@ init 200 python in mas_dockstat:
             moni_sum = checklist.hexdigest()
 
         except Exception as e:
-            mas_utils.writelog("[ERROR] monibuffer write failed | {0}".format(
+            cr_log.write("[ERROR] monibuffer write failed | {0}\n".format(
                 repr(e)
             ))
 
@@ -1728,7 +1761,7 @@ init 200 python in mas_dockstat:
         moni_pkg = dockstat.getPackage("monika")
         if moni_pkg is None:
             # ALERT ALERT HOW DID WE FAIL
-            mas_utils.writelog("[ERROR] monika not found.")
+            cr_log.write("[ERROR] monika not found.\n")
             mas_utils.trydel(moni_path)
             return False
 
@@ -1736,19 +1769,20 @@ init 200 python in mas_dockstat:
         moni_slip = dockstat.createPackageSlip(moni_pkg, blocksize)
         if moni_slip is None:
             # ALERT ALERT WE FAILED AGAIN
-            mas_utils.writelog("[ERROR] monika could not be validated.")
+            cr_log.write("[ERROR] monika could not be validated.\n")
             mas_utils.trydel(moni_path)
             return False
 
         if moni_slip != moni_sum:
             # WOW SRS THIS IS BAD
-            mas_utils.writelog(
-                "[ERROR] monisums didn't match, did we have write failure?"
+            cr_log.write(
+                "[ERROR] monisums didn't match, did we have write failure?\n"
             )
             mas_utils.trydel(moni_path)
             return -1
 
         # otherwise, we managed to create a monika! Congrats!
+        cr_log.write("chk: {0}\n".format(moni_sum))
         return moni_sum
 
 
@@ -1762,21 +1796,31 @@ init 200 python in mas_dockstat:
         global retmoni_status, retmoni_data
 
         # try to find this monika
-        retmoni_status, retmoni_data = findMonika(dockstat)
+        retmoni_status, retmoni_data = findMonika(dockstat, rd_log_path, True)
 
 
-    def findMonika(dockstat):
+    def findMonika(dockstat, logpath, at_init):
         """
         Attempts to find monika in the giving docking station
 
         IN:
             dockstat - MASDockingStation to use
+            logpath - path of log to write messages to
+            at_init - True if we are in init, False if not
 
         RETURNS: tuple of the following format:
             [0]: MAS_PKG_* constants depending on the state of monika
             [1]: either list of data or persistent object of data. Will be
                 None if no data or errors occured
         """
+        rd_log = store.mas_utils.logcreate(
+            logpath,
+            append=not at_init,
+            flush=True
+        )
+
+        rd_log.write("\n\nFinding Monika in: {0}\n".format(dockstat.station))
+
         END_DELIM = "|||"
         PER_DELIM = "per|"
         ret_code = 0
@@ -1785,7 +1829,8 @@ init 200 python in mas_dockstat:
             "monika",
             store.persistent._mas_moni_chksum,
             lines=-1,
-            bs=b64_blocksize
+            bs=b64_blocksize,
+            log=rd_log
         )
 
         if (status & (dockstat.PKG_E | dockstat.PKG_N)) > 0:
@@ -1808,7 +1853,7 @@ init 200 python in mas_dockstat:
 
         # because the console may have shit, we should just attempt to parse
         # the data as persistent first, and then as a backup, try non-persist.
-        per_data = parseMoniDataPer(real_data)
+        per_data = parseMoniDataPer(real_data, rd_log)
 
         if per_data is None:
             # this isn't a persistent. Let's try backup strats
@@ -1835,7 +1880,7 @@ init 200 python in mas_dockstat:
 
         if (status & dockstat.PKG_C) > 0:
             # we found a different monika (or corrupted monika)
-            mas_utils.writelog(
+            rd_log.write(
                 "[!] I found a corrupt monika! {0}\n".format(status)
             )
             return (ret_code | MAS_PKG_FO, real_data)
@@ -1844,7 +1889,7 @@ init 200 python in mas_dockstat:
         return (ret_code | MAS_PKG_F, real_data)
 
 
-    def parseMoniData(data_line):
+    def parseMoniData(data_line, log):
         """
         Parses monika data into its components
 
@@ -1852,6 +1897,7 @@ init 200 python in mas_dockstat:
 
         IN:
             data_line - PIPE delimeted data line
+            log - log to write messages to, if needed
 
         RETURNS: list of the following format:
             [0]: datetime of first sessin
@@ -1876,13 +1922,13 @@ init 200 python in mas_dockstat:
             return data_list[:6]
 
         except Exception as e:
-            mas_utils.writelog("[ERROR]: Moni Data parse fail: {0}\n".format(
+            log.write("[ERROR]: Moni Data parse fail: {0}\n".format(
                 repr(e)
             ))
             return None
 
 
-    def parseMoniDataPer(data_line):
+    def parseMoniDataPer(data_line, log):
         """
         Parses persitent data into a persitent object.
 
@@ -1890,6 +1936,7 @@ init 200 python in mas_dockstat:
 
         IN:
             data_line - the data portion that may contain a persitent
+            log - log to write messages to, if needed
 
         RETURNS: a persistent object, or None if failure
         """
@@ -1902,7 +1949,7 @@ init 200 python in mas_dockstat:
             return cPickle.loads(codecs.decode(data_line + b'='*4, "base64"))
 
         except Exception as e:
-            mas_utils.writelog(
+            log.write(
                 "[ERROR]: persistent unpickle failed: {0}\n".format(repr(e))
             )
             return None
@@ -2007,7 +2054,7 @@ init 200 python in mas_dockstat:
 
         if checkin_len != checkout_len:
             # mis match logs, please log this.
-            mas_utils.writelog(
+            rd_log.write(
                 (
                     "[WARNING]: checkin is {0}, checkout is {1}. "
                     "Going to pop.\n"
@@ -2112,13 +2159,13 @@ init 205 python in mas_dockstat:
     # runs monika file generation
     monikagen_promise = mas_threading.MASAsyncWrapper(
         generateMonika,
-        [store.mas_docking_station]
+        [store.mas_docking_station, cr_log_path]
     )
 
     # runs monika file check
     monikafind_promise = mas_threading.MASAsyncWrapper(
         findMonika,
-        [store.mas_docking_station]
+        [store.mas_docking_station, rd_log_path, False]
     )
 
     # other important vars for this

--- a/Monika After Story/game/zz_dockingstation.rpy
+++ b/Monika After Story/game/zz_dockingstation.rpy
@@ -1216,7 +1216,7 @@ init -11 python in mas_dockstat:
                 )
 
             except Exception as e:
-                rd_log.write(
+                mas_utils.writelog(
                     "[ERROR] failed to decode '{0}' | {1}\n".format(
                         b64_name,
                         str(e)


### PR DESCRIPTION
#5767 #5746 

# Key Changes
* adds a definition for `ERR_CREATE` in dockstat
* adds new logs for monika file generation (`log/mfgen.txt)` and reading `(log/mfread.txt`). These logs are only written to upon file gen or read, so they don't get overwritten in standard gameplay.
* adds `mas_utils.logcreate` function for creating general mas logs using the renpy log framework.

# Testing
* verify no crash when taking monika out or loading her in
* verify that the `mfgen.txt` log is only written to when using a monika file gen farewell. This means that subsequent restarts of the game and usage of other farewells should **not** overwrite this file.
* verify that `mfread.txt` log is only written to starting mod while monika is in a file state. This menas that normal starts of the game should **not** overwrite this file. This file is also logged to repeatedly  if the monika file is not found or not parsed correctly.