### PR TITLE
ily2 TT protection

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -3485,7 +3485,7 @@ init -991 python in mas_utils:
 
     def logcreate(filepath, append=False, flush=False, addversion=False):
         """
-        Creates a log at the given filepath. 
+        Creates a log at the given filepath.
         This also opens the log and sets raw_write to True.
         This also adds per version number if desired
 
@@ -3499,7 +3499,7 @@ init -991 python in mas_utils:
                 You dont need this if you create the log in runtime,
                 (Default: False)
 
-        RETURNS: created log object. 
+        RETURNS: created log object.
         """
         new_log = getMASLog(filepath, append=append, flush=flush)
         new_log.open()
@@ -6732,7 +6732,7 @@ init python:
         """
         if check_time is None:
             check_time = datetime.datetime.now()
-        return persistent._mas_last_monika_ily is not None and (check_time - persistent._mas_last_monika_ily) <= pass_time
+        return persistent._mas_last_monika_ily is not None and abs(check_time - persistent._mas_last_monika_ily) <= pass_time
 
     def mas_ILY(set_time=None):
         """

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -6732,7 +6732,13 @@ init python:
         """
         if check_time is None:
             check_time = datetime.datetime.now()
-        return persistent._mas_last_monika_ily is not None and abs(check_time - persistent._mas_last_monika_ily) <= pass_time
+
+        # if a backward TT is detected here, return False and reset persistent._mas_last_monika_ily
+        if persistent._mas_last_monika_ily is None or persistent._mas_last_monika_ily > check_time:
+            persistent._mas_last_monika_ily = None
+            return False
+
+        return (check_time - persistent._mas_last_monika_ily) <= pass_time
 
     def mas_ILY(set_time=None):
         """

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -6718,20 +6718,17 @@ style jpn_text:
 
 # functions related to ily2
 init python:
-    def mas_passedILY(pass_time, check_time=None):
+    def mas_passedILY(pass_time):
         """
         Checks whether we are within the appropriate time since the last time
         Monika told the player 'ily' which is stored in persistent._mas_last_monika_ily
         IN:
             pass_time - a timedelta corresponding to the time limit we want to check against
-            check_time - the time at which we want to check, will typically be datetime.datetime.now()
-                which is the default
 
         RETURNS:
             boolean indicating if we are within the time limit
         """
-        if check_time is None:
-            check_time = datetime.datetime.now()
+        check_time = datetime.datetime.now()
 
         # if a backward TT is detected here, return False and reset persistent._mas_last_monika_ily
         if persistent._mas_last_monika_ily is None or persistent._mas_last_monika_ily > check_time:


### PR DESCRIPTION
Currently, if you TT backward right after a topic that returns "love" (or uses `MAS_ILY()`), the `I love you!` menu prompt will be stuck on `I love you too!` until you click it or say goodbye due to the `check_time` (in this case the current time) in `mas_passedILY()` being less than `persistent._mas_last_monika_ily`, therefore always making it less than 10 secs since she said 'I love you.' This adds a check so if `check_time` is before  `persistent._mas_last_monika_ily`, we return False and reset  `persistent._mas_last_monika_ily`.

## Testing

- verify the `I love you!`/`I love you too!` main menu prompt works as expected during normal usage.

- verify if you TT backward right after something that returns "love", `I love you too!` is not the prompt.