### PR TITLE
Fixing up timed-text events

### DIFF
--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -2666,9 +2666,6 @@ label monika_aiwfc:
             m 3hub "Make sure you have your volume up!"
             m 1huu ".{w=0.5}.{w=0.5}.{nw}"
 
-    #Get current song
-    $ curr_song = songs.current_track
-
     call monika_aiwfc_song
 
     #NOTE: This must be a shown count check as this dialogue should only be here on first viewing of this topic
@@ -2684,10 +2681,6 @@ label monika_aiwfc:
         m 1ekbsa "You'll always be the only gift I'll ever need."
         m 1ekbfa "I love you~"
 
-    #Since the lullaby can slip in here because of the queue, we need to make sure we don't play that
-    if curr_song != store.songs.FP_MONIKA_LULLABY:
-        $ play_song(curr_song, fadein=1.0)
-
     #Unlock the song
     $ mas_unlockEVL("mas_song_aiwfc", "SNG")
     return "no_unlock|love"
@@ -2695,22 +2688,7 @@ label monika_aiwfc:
 
 label monika_aiwfc_song:
 
-    #Disable text speed, escape button and music button for this
-    $ mas_disableTextSpeed()
-    $ disable_esc()
-    $ mas_MUMURaiseShield()
-
-    # always unmute the music channel (or at least attempt to)
-    # TODO: there should probably be handling for sayori name case.
-    if songs.getVolume("music") == 0.0:
-        $ renpy.music.set_volume(1.0, channel="music")
-
-    # save background sound for later
-    $ amb_vol = songs.getVolume("backsound")
-
-    $ play_song(None, 1.0)
-    $ renpy.music.set_volume(0.0, 1.0, "background")
-    $ renpy.music.set_volume(0.0, 1.0, "backsound")
+    call mas_timed_text_events_prep
 
     $ play_song("mod_assets/bgm/aiwfc.ogg",loop=False)
     m 1eub "{i}{cps=9}I don't want{/cps}{cps=20} a lot{/cps}{cps=11} for Christmas{w=0.09}{/cps}{/i}{nw}"
@@ -2745,15 +2723,8 @@ label monika_aiwfc_song:
     m 4hksdlb "{i}{cps=10}What more{/cps}{cps=15} can I{/cps}{cps=8} doooo?{w=0.3}{/cps}{/i}{nw}"
     m 4ekbfb "{i}{cps=20}Cause baby{/cps}{cps=12} all I want for Christmas{w=0.3} is yoooooooou~{w=2.3}{/cps}{/i}{nw}"
     m "{i}{cps=9}Yoooooooou, baaaaby~{w=2.5}{/cps}{/i}{nw}"
-    stop music fadeout 0.5
 
-    #Now we re-enable text speed, escape button and music button
-    $ mas_resetTextSpeed()
-    $ enable_esc()
-    $ mas_MUMUDropShield()
-
-    $ renpy.music.set_volume(amb_vol, 1.0, "background")
-    $ renpy.music.set_volume(amb_vol, 1.0, "backsound")
+    call mas_timed_text_events_wrapup
     return
 
 init 5 python:

--- a/Monika After Story/game/script-songs.rpy
+++ b/Monika After Story/game/script-songs.rpy
@@ -1039,7 +1039,7 @@ label mas_monika_plays_or(skip_leadin=False):
         $ gen = "their"
 
     window hide
-    call mas_timed_text_events_wrapup
+    call mas_timed_text_events_prep
     $ mas_temp_zoom_level = store.mas_sprites.zoom_level
     call monika_zoom_transition_reset(1.0)
     show monika at rs32

--- a/Monika After Story/game/script-songs.rpy
+++ b/Monika After Story/game/script-songs.rpy
@@ -316,16 +316,11 @@ init 5 python:
     )
 
 label mas_song_aiwfc:
-    #Get current song
-    $ curr_song = songs.current_track
     if store.songs.hasMusicMuted():
         m 3eua "Don't forget to turn your in-game volume up, [player]."
 
     call monika_aiwfc_song
 
-    #Since the lullaby can slip in here because of the queue, we need to make sure we don't play that
-    if curr_song != store.songs.FP_MONIKA_LULLABY:
-        $ play_song(curr_song, fadein=1.0)
     return
 
 init 5 python:
@@ -938,7 +933,7 @@ label mas_monika_plays_yr(skip_leadin=False):
             m 3eua "Sure, let me just get the piano.{w=0.5}.{w=0.5}.{nw}"
 
     window hide
-    $ mas_RaiseShield_piano()
+    call mas_timed_text_events_prep
     $ mas_temp_zoom_level = store.mas_sprites.zoom_level
     call monika_zoom_transition_reset(1.0)
     show monika at rs32
@@ -1014,9 +1009,8 @@ label mas_monika_plays_yr(skip_leadin=False):
     show monika 1eua at ls32 zorder MAS_MONIKA_Z
     pause 1.0
     call monika_zoom_transition(mas_temp_zoom_level,1.0)
-    $ mas_DropShield_piano()
+    call mas_timed_text_events_wrapup
     window auto
-    $ play_song(None, 1.0)
 
     return
 
@@ -1045,7 +1039,7 @@ label mas_monika_plays_or(skip_leadin=False):
         $ gen = "their"
 
     window hide
-    $ mas_RaiseShield_piano()
+    call mas_timed_text_events_wrapup
     $ mas_temp_zoom_level = store.mas_sprites.zoom_level
     call monika_zoom_transition_reset(1.0)
     show monika at rs32
@@ -1104,8 +1098,7 @@ label mas_monika_plays_or(skip_leadin=False):
     show monika 1eua at ls32 zorder MAS_MONIKA_Z
     pause 1.0
     call monika_zoom_transition(mas_temp_zoom_level,1.0)
-    $ mas_DropShield_piano()
+    call mas_timed_text_events_wrapup
     window auto
-    $ play_song(None, 1.0)
 
     return

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -10493,15 +10493,9 @@ label monika_grad_speech_ignored_lock:
     return
 
 label monika_grad_speech:
-    # clear selected track
-    $ play_song(None, fadeout=1.0)
-    $ songs.current_track = songs.FP_NO_SONG
-    $ songs.selected_track = songs.FP_NO_SONG
-    #play some grad music
-    play music "mod_assets/sounds/amb/PaC.ogg" fadein 1.0
-    $ mas_MUMURaiseShield()
-    #Disable text speed
-    $ mas_disableTextSpeed()
+    call mas_timed_text_events_prep
+
+    $ play_song("mod_assets/bgm/PaC.ogg",loop=False)
 
     m 2dsc "Ahem...{w=0.7}{nw}"
     m ".{w=0.3}.{w=0.3}.{w=0.6}{nw}"
@@ -10563,11 +10557,7 @@ label monika_grad_speech:
     m 4hub "{w=0.2}We did it everyone!{w=0.7} Thanks for listening~{w=0.6}{nw}"
     m 2hua "{w=0.2}.{w=0.3}.{w=0.3}.{w=1}{nw}"
 
-    #stop grad music
-    $ mas_MUMUDropShield()
-    stop music fadeout 1.0
-    #Re-enable text speed
-    $ mas_resetTextSpeed()
+    call mas_timed_text_events_wrapup
     return
 
 init 5 python:

--- a/Monika After Story/game/special-effects.rpy
+++ b/Monika After Story/game/special-effects.rpy
@@ -433,3 +433,26 @@ init python:
 transform mas_smooth_transition:
     i11 # this one may not be needed but I keep it just in case
     function zoom_smoothly
+
+label mas_timed_text_events_prep:
+    $ renpy.pause(0.5)
+    $ mas_RaiseShield_timedtext()
+    $ curr_song = songs.current_track
+    $ play_song(None, 1.0)
+    $ amb_vol = songs.getVolume("backsound")
+    $ renpy.music.set_volume(0.0, 1.0, "background")
+    $ renpy.music.set_volume(0.0, 1.0, "backsound")
+    return
+
+label mas_timed_text_events_wrapup:
+    $ renpy.pause(0.5)
+    $ mas_DropShield_timedtext()
+
+    if curr_song != store.songs.FP_MONIKA_LULLABY:
+        $ play_song(curr_song, 1.0)
+    else:
+        $ play_song(None, 1.0)
+
+    $ renpy.music.set_volume(amb_vol, 1.0, "background")
+    $ renpy.music.set_volume(amb_vol, 1.0, "backsound")
+    return

--- a/Monika After Story/game/special-effects.rpy
+++ b/Monika After Story/game/special-effects.rpy
@@ -434,6 +434,7 @@ transform mas_smooth_transition:
     i11 # this one may not be needed but I keep it just in case
     function zoom_smoothly
 
+# labels to handle the prep and wrap up for timed text events
 label mas_timed_text_events_prep:
     $ renpy.pause(0.5)
     $ mas_RaiseShield_timedtext()

--- a/Monika After Story/game/special-effects.rpy
+++ b/Monika After Story/game/special-effects.rpy
@@ -436,24 +436,41 @@ transform mas_smooth_transition:
 
 # labels to handle the prep and wrap up for timed text events
 label mas_timed_text_events_prep:
-    $ renpy.pause(0.5)
-    $ mas_RaiseShield_timedtext()
-    $ curr_song = songs.current_track
-    $ play_song(None, 1.0)
-    $ amb_vol = songs.getVolume("backsound")
-    $ renpy.music.set_volume(0.0, 1.0, "background")
-    $ renpy.music.set_volume(0.0, 1.0, "backsound")
+    python:
+        renpy.pause(0.5)
+
+        # raise shield
+        mas_RaiseShield_timedtext()
+
+        # store/stop current music and background/sounds
+        curr_song = songs.current_track
+        play_song(None, 1.0)
+        amb_vol = songs.getVolume("backsound")
+        renpy.music.set_volume(0.0, 1.0, "background")
+        renpy.music.set_volume(0.0, 1.0, "backsound")
+
+        # store and disable auto-forward pref
+        afm_pref = renpy.game.preferences.afm_enable
+        renpy.game.preferences.afm_enable = False
+
     return
 
 label mas_timed_text_events_wrapup:
-    $ renpy.pause(0.5)
-    $ mas_DropShield_timedtext()
+    python:
+        renpy.pause(0.5)
 
-    if curr_song != store.songs.FP_MONIKA_LULLABY:
-        $ play_song(curr_song, 1.0)
-    else:
-        $ play_song(None, 1.0)
+        # drop shield
+        mas_DropShield_timedtext()
 
-    $ renpy.music.set_volume(amb_vol, 1.0, "background")
-    $ renpy.music.set_volume(amb_vol, 1.0, "backsound")
+        # restart song/sounds that were playing before event
+        if curr_song != store.songs.FP_MONIKA_LULLABY:
+            play_song(curr_song, 1.0)
+        else:
+            play_song(None, 1.0)
+        renpy.music.set_volume(amb_vol, 1.0, "background")
+        renpy.music.set_volume(amb_vol, 1.0, "backsound")
+
+        # restor auto-forward pref
+        renpy.game.preferences.afm_enable = afm_pref
+
     return

--- a/Monika After Story/game/zz_poems.rpy
+++ b/Monika After Story/game/zz_poems.rpy
@@ -234,6 +234,7 @@ label mas_showpoem(poem=None, paper=None, background_action_label=None):
     play sound page_turn
 
     window hide
+    $ afm_pref = renpy.game.preferences.afm_enable
     $ renpy.game.preferences.afm_enable = False
 
     #Handle the poem screen we use
@@ -251,8 +252,9 @@ label mas_showpoem(poem=None, paper=None, background_action_label=None):
     #And hide it
     hide screen mas_generic_poem
 
-
     with Dissolve(.5)
+
+    $ renpy.game.preferences.afm_enable = afm_pref
     window auto
 
     #Flag this poem as seen

--- a/Monika After Story/game/zz_shields.rpy
+++ b/Monika After Story/game/zz_shields.rpy
@@ -182,7 +182,7 @@ init python:
     ################## Piano mode workflow ####################################
     # used when Monika plays her piano
 
-    def mas_DropShield_piano():
+    def mas_DropShield_timedtext():
         """
         Enables:
             - text speed
@@ -190,6 +190,7 @@ init python:
             - Music button + hotkey
             - Music Menu
             - Calendar overlay
+            - Window hiding
 
         Shows:
             - hotkey buttons
@@ -199,8 +200,9 @@ init python:
         mas_MUMUDropShield()
         mas_calDropOverlayShield()
         HKBShowButtons()
+        mas_hotkeys.no_window_hiding = False
 
-    def mas_RaiseShield_piano():
+    def mas_RaiseShield_timedtext():
         """
         Disables:
             - text speed
@@ -208,6 +210,7 @@ init python:
             - Music button + hotkey
             - Music Menu
             - Calendar overlay
+            - Window hiding
 
         Hides:
             - hotkey buttons
@@ -217,6 +220,7 @@ init python:
         mas_MUMURaiseShield()
         mas_calRaiseOverlayShield()
         HKBHideButtons()
+        mas_hotkeys.no_window_hiding = True
 
 
 ################################## GENERALIZED ################################


### PR DESCRIPTION
The main thing here is the addition of not allowing the UI hide (aka right-clicking) during timed-text events, such as YR/OR/AWIFC/Grad speech. Even for the ones that had no text box or any other UI, right-clicking during them would cause Monika to essentially freeze in place, waiting for a left-click while the music would continue on. This would lead to the music finishing way before she was done playing the piano for example, or being stuck there forever if the user didn't know what was happening and never left-clicked. This now adds `mas_hotkeys.no_window_hiding` sets to the old piano shields, and renames those to `mas_DropShield_timedtext()` and `mas_RaiseShield_timedtext()` and uses them for the aforementioned events.

In addition, I have gone into those events and made them all work consistently in regards to shields, what we do with the current song being played, and how we play and stop the music that is related to the events thru the creation of labels `mas_timed_text_events_prep` and ` mas_timed_text_events_wrapup`. I also moved `PaC.ogg` from the ambient folder and moved it to the `bgm` folder like the other music files, and now use the `playSong` function for it.

## Testing

For the 4 aforementioned timed-text events:

-  verify that the proper shields are raised and lowered for all ways to access them.

- verify that that right-clicking during them does not hide the UI nor freeze Monika for topics that have no UI visible.

- verify that text speeds are still properly set, locked, and reset, as well as if there is a song being played before the event, that it's stopped and then played again after the event.

- verify the old issue with the lullaby and scary story music has not returned.