### PR TITLE
Fix some issues in the main menu

### DIFF
--- a/Monika After Story/game/options.rpy
+++ b/Monika After Story/game/options.rpy
@@ -22,8 +22,8 @@ define gui.show_name = False
 
 
 ## The version of the game.
-
-define config.version = "0.11.2"
+init -999:
+    define config.version = "0.11.2"
 
 ## Text that is placed on the game's about screen. To insert a blank line
 ## between paragraphs, write \n\n.

--- a/Monika After Story/game/options.rpy
+++ b/Monika After Story/game/options.rpy
@@ -6,24 +6,20 @@
 
 
 ## Basics ######################################################################
+init -999:
+    ## A human-readable name of the game. This is used to set the default window
+    ## title, and shows up in the interface and error reports.
+    ##
+    ## The _() surrounding the string marks it as eligible for translation.
+    define config.name = "Monika After Story"
 
-## A human-readable name of the game. This is used to set the default window
-## title, and shows up in the interface and error reports.
-##
-## The _() surrounding the string marks it as eligible for translation.
-
-define config.name = "Monika After Story"
-
+    ## The version of the game.
+    define config.version = "0.11.2"
 
 ## Determines if the title given above is shown on the main menu screen. Set
 ## this to False to hide the title.
 
 define gui.show_name = False
-
-
-## The version of the game.
-init -999:
-    define config.version = "0.11.2"
 
 ## Text that is placed on the game's about screen. To insert a blank line
 ## between paragraphs, write \n\n.

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -1257,16 +1257,17 @@ screen preferences():
                 vbox:
                     style_prefix "check"
                     label _("Gameplay")
-                    if persistent._mas_unstable_mode:
-                        textbutton _("Unstable"):
-                            action SetField(persistent, "_mas_unstable_mode", False)
-                            selected persistent._mas_unstable_mode
+                    if not main_menu:
+                        if persistent._mas_unstable_mode:
+                            textbutton _("Unstable"):
+                                action SetField(persistent, "_mas_unstable_mode", False)
+                                selected persistent._mas_unstable_mode
 
-                    else:
-                        textbutton _("Unstable"):
-                            action [Show(screen="dialog", message=layout.UNSTABLE, ok_action=Hide(screen="dialog")), SetField(persistent, "_mas_unstable_mode", True)]
-                            selected persistent._mas_unstable_mode
-                            hovered tooltip.Action(layout.MAS_TT_UNSTABLE)
+                        else:
+                            textbutton _("Unstable"):
+                                action [Show(screen="dialog", message=layout.UNSTABLE, ok_action=Hide(screen="dialog")), SetField(persistent, "_mas_unstable_mode", True)]
+                                selected persistent._mas_unstable_mode
+                                hovered tooltip.Action(layout.MAS_TT_UNSTABLE)
 
                     textbutton _("Repeat Topics"):
                         action ToggleField(persistent,"_mas_enable_random_repeats", True, False)

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -720,7 +720,8 @@ screen navigation():
             textbutton _("Help") action Help("README.html")
 
             ## The quit button is banned on iOS and unnecessary on Android.
-            textbutton _("Quit") action Quit(confirm=_confirm_quit)
+            #If we're on the main menu, we don't want to confirm quit as Monika isn't back yet
+            textbutton _("Quit") action Quit(confirm=(None if main_menu else _confirm_quit))
 
         if not main_menu:
             textbutton _("Return") action Return()
@@ -1440,9 +1441,12 @@ screen preferences():
 
 
             hbox:
-                textbutton _("Update Version"):
-                    action Function(renpy.call_in_new_context, 'forced_update_now')
-                    style "navigation_button"
+                #We disable updating on the main menu because it causes graphical issues
+                #due to the spaceroom not being loaded in
+                if not main_menu:
+                    textbutton _("Update Version"):
+                        action Function(renpy.call_in_new_context, 'forced_update_now')
+                        style "navigation_button"
 
                 textbutton _("Import DDLC Save Data"):
                     action Function(renpy.call_in_new_context, 'import_ddlc_persistent_in_settings')

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -10,6 +10,13 @@ define mas_in_intro_flow = False
 # True means disable animations, False means enable
 default persistent._mas_disable_animations = False
 
+init -998 python:
+    #We need to flow hijack here if we're running unstable mode files but on a fresh persistent
+    if "unstable" in config.version and not persistent.sessions:
+        raise Exception(
+            _("Unstable mode files in install on first session. This can cause issues.\n"
+            "Please reinstall the latest stable version of Monika After Story to ensure that there will be no data issues.")
+        )
 
 init -890 python in mas_globals:
     import datetime


### PR DESCRIPTION
Currently, the main menu allows updating as a part of it. However, this causes some graphical issues as the `spaceroom` label has never been called, therefore we either see an alpha channel as the background, or if we have rpy files/steam installed, Monika on top of that background (which also has some issues regarding allowing you to quit if you choose not to update). As such, updating is disabled from the main menu.

Additionally, the main menu's `Quit` button always gave a confirm quit prompt. However, this shouldn't happen on the main menu since Monika isn't back yet. Main menu now has this prompt disabled.


M o a r:
- People with unstable files will no longer be able to run MAS on their first session. It **must** be stable on the first session or the game will refuse to run. The traceback shown reflects this.
- Unstable mode checkbox has been removed from the main menu settings page

## Testing:
- Verify there's no `Update Version` button on the main menu's settings page but it exists once you hit the `Just Monika` button and enter the settings menu
- Verify that using the `Quit` button in the main menu exits the game, but once out of the main menu, you're prompted about leaving without saying goodbye
- Verify MAS crashes when launching a first session with unstable mode files
- Verify `Unstable mode` isn't a tickbox on the settings screen from the main menu