### PR TITLE
Better substitution for strings

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -7,6 +7,8 @@ init 1 python:
 
 ### Overrides of core renpy things
 python early in mas_overrides:
+    from store import *
+
     def dummy(*args, **kwargs):
         """
         Dummy function that does nothing

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -66,12 +66,15 @@ python early in mas_overrides:
                             scope_store_name = "renpy.{0}.".format(stores_names_list[0])
                             break
 
+                # if we got to this, you passed in something undefined
+                else:
+                    scope_store_name = ""
+
             # if you've not passed anything, use the base store
             elif first in kwargs:
                 scope_store_name = "renpy.store."
 
             # if we got to this, you passed in something undefined
-            # and eval will crash you
             else:
                 scope_store_name = ""
 

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -78,16 +78,12 @@ python early:
                 # split the string into its components
                 func_name, paren, args = field_name.partition("(")
 
-                # it still may include store modules, get the first if there's any
-                if "." in func_name:
-                    func_store_name, dot, func_name = func_name.partition(".")
-                    first = func_store_name
+                # it still may include store modules, try to split it
+                func_store_name, dot, func_name = func_name.partition(".")
 
-                # otherwise work with just function
-                else:
-                    func_store_name = ""
-                    dot = ""
-                    first = func_name
+                # with partition we'll always get the right bit in the first position
+                # be it store module or function
+                first = func_store_name
 
                 # now we find the store's name to use in eval
                 if isinstance(kwargs, renpy.substitutions.MultipleDict):


### PR DESCRIPTION
This fixes a bug that doesn't allow us to use negative indexes for some reason.
For example this will crash you. I fixed it.
```renpy
$ items = ["a", "b", "c"]
m "The last item is [items[-1]]"
```
Also allows us to make function calls via `eval`.
For example:
```renpy
$ def return_love(): return "love"
m "I [return_love()] you!"
```
It does support different stores and passing in arguments/keyword arguments.
```renpy
# All of these are valid options, it doesn't make sense, but for the sake of example lol
python in new_store:
    def there_re_s(number):
        if number > 1:
                return "There're"
        return "There's"
$ n = 2
m "[new_store.there_re_s(n)] [n] 'of smth'!"

# Or this
python in new_store:
    def return_monika(*args, **kwargs):
        return "Monika"
$ _line = renpy.substitute("My name is [return_monika('arg1', kwarg1='kwarg1', kwarg2=None)].", scope=new_store.__dict__)
```

### Testing:
- verify that base substitution still works.
- verify that we're able to use negative indexes for iterables.
- test calling function from the base store, custom stores, with arguments and w/o them. Using both the `say` statement and the `renpy.substitute` function.