### PR TITLE
Unlock the submods screens w/ any submod installed

### DIFF
--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -704,7 +704,7 @@ screen navigation():
 
         textbutton _("Settings") action [ShowMenu("preferences"), SensitiveIf(renpy.get_screen("preferences") == None)]
 
-        if mas_ui.has_submod_settings:
+        if store.mas_submod_utils.submod_map:
             textbutton _("Submods") action [ShowMenu("submods"), SensitiveIf(renpy.get_screen("submods") == None)]
 
         if store.mas_windowreacts.can_show_notifs and not main_menu:

--- a/Monika After Story/game/zz_submods.rpy
+++ b/Monika After Story/game/zz_submods.rpy
@@ -9,14 +9,6 @@ init -989 python:
     #Run dependency checks
     store.mas_submod_utils.Submod._checkDependencies()
 
-init -990 python in mas_ui:
-    import store
-    has_submod_settings = len([
-        submod
-        for submod in store.mas_submod_utils.submod_map.values()
-        if submod.settings_pane is not None
-    ]) > 0
-
 init -991 python in mas_submod_utils:
     import re
     import store


### PR DESCRIPTION
This's minor one. In #5739 we allowed to show any submod on the submods screen. But the button to access the screen is still locked behind having a submod with a setting pane. So it's possible to have some submods w/o settings, and not have access to the submods screen.

### Testing:
 - verify no crashes.
 - verify that the button to access the screen is shown even if you have a submod w/o a setting pane defined.
 - verify the button is hidden if you have no submods installed.