### PR TITLE
Reset consumable if it's prepping but it's not time to have

### DIFF
--- a/Monika After Story/game/zz_consumables.rpy
+++ b/Monika After Story/game/zz_consumables.rpy
@@ -1023,8 +1023,11 @@ init 5 python:
             #Verify persist data
             MASConsumable._validatePersistentData(_type)
 
+            if curr_cons:
+                curr_finish_prep_ev = mas_getEV(curr_cons.finish_prep_evl)
+
             #Reset if we're having a consumable we shouldn't be having now and we opened the game after its consume time
-            #or if we're still prepping something but we're past the consumable's prepping time
+            #or if we're still prepping something but the consumable's finish prepping event doesn't have conditionals
             if (
                 (
                     MASConsumable._isHaving(_type)
@@ -1035,7 +1038,8 @@ init 5 python:
                 )
                 or (
                     persistent._mas_current_consumable[_type]["prep_time"] is not None
-                    and curr_cons not in available_cons
+                    and curr_finish_prep_ev
+                    and curr_finish_prep_ev.conditional is None
                 )
             ):
                 MASConsumable._reset(_type)

--- a/Monika After Story/game/zz_consumables.rpy
+++ b/Monika After Story/game/zz_consumables.rpy
@@ -1043,11 +1043,18 @@ init 5 python:
             MASConsumable._validatePersistentData(_type)
 
             #Reset if we're having a consumable we shouldn't be having now and we opened the game after its consume time
+            #or if we're still prepping something but we're past the consumable's prepping time
             if (
-                MASConsumable._isHaving(_type)
-                and (
-                    not MASConsumable._isStillCons(_type)
-                    and mas_getCurrSeshStart() > persistent._mas_current_consumable[_type]["consume_time"]
+                (
+                    MASConsumable._isHaving(_type)
+                    and (
+                        not MASConsumable._isStillCons(_type)
+                        and mas_getCurrSeshStart() > persistent._mas_current_consumable[_type]["consume_time"]
+                    )
+                )
+                or (
+                    persistent._mas_current_consumable[_type]["prep_time"] is not None
+                    and curr_cons not in available_cons
                 )
             ):
                 MASConsumable._reset(_type)

--- a/Monika After Story/game/zz_consumables.rpy
+++ b/Monika After Story/game/zz_consumables.rpy
@@ -818,6 +818,53 @@ init 5 python:
                 cons_reset(MASConsumable._getCurrentFood())
 
         @staticmethod
+        def __shouldReset(_type, curr_cons, available_cons):
+            """
+            Checks if we should reset the current consumable type
+
+            CONDITIONS:
+                1. We're having a consumable we shouldn't be having now and we opened the game after its consume time or
+                2. We're still prepping something but
+                    - The consumable's finish prepping event doesn't have conditionals or
+                    - It's no longer time for this consumable
+
+            IN:
+                _type - type of consumable to reset
+                curr_cons - current_consumable (of _type)
+                available_cons - available consumables for the current time
+
+            OUT:
+                boolean:
+                    - True if we should reset the current consumable type
+                    - False otherwise
+            """
+            #If we have no consumable, then there's no point in doing anything
+            if not curr_cons:
+                return False
+
+            prep_ev = mas_getEV(curr_cons.finish_prep_evl)
+
+            return (
+                (
+                    MASConsumable._isHaving(_type)
+                    and (
+                        not MASConsumable._isStillCons(_type)
+                        and mas_getCurrSeshStart() > persistent._mas_current_consumable[_type]["consume_time"]
+                    )
+                )
+                or (
+                    persistent._mas_current_consumable[_type]["prep_time"] is not None
+                    and (
+                            (
+                                prep_ev
+                                and prep_ev.conditional is None
+                            )
+                        or curr_cons not in available_cons
+                    )
+                )
+            )
+
+        @staticmethod
         def _getCurrentDrink():
             """
             Gets the MASConsumable object for the current drink or None if we're not drinking
@@ -1023,25 +1070,8 @@ init 5 python:
             #Verify persist data
             MASConsumable._validatePersistentData(_type)
 
-            if curr_cons:
-                curr_finish_prep_ev = mas_getEV(curr_cons.finish_prep_evl)
-
-            #Reset if we're having a consumable we shouldn't be having now and we opened the game after its consume time
-            #or if we're still prepping something but the consumable's finish prepping event doesn't have conditionals
-            if (
-                (
-                    MASConsumable._isHaving(_type)
-                    and (
-                        not MASConsumable._isStillCons(_type)
-                        and mas_getCurrSeshStart() > persistent._mas_current_consumable[_type]["consume_time"]
-                    )
-                )
-                or (
-                    persistent._mas_current_consumable[_type]["prep_time"] is not None
-                    and curr_finish_prep_ev
-                    and curr_finish_prep_ev.conditional is None
-                )
-            ):
+            #Check if we should reset the current consumable type
+            if MASConsumable.__shouldReset(_type, curr_cons, available_cons):
                 MASConsumable._reset(_type)
 
             #If we're currently prepping/having anything, we don't need to do anything else

--- a/Monika After Story/game/zz_consumables.rpy
+++ b/Monika After Story/game/zz_consumables.rpy
@@ -564,25 +564,6 @@ init 5 python:
             #Increment cup count
             self.increment()
 
-        def isStillPrep(self, _now):
-            """
-            Checks if we're still prepping something of this type
-
-            IN:
-                _now - datetime.datetime object representing current time
-
-            OUT:
-                boolean:
-                    - True if we're still prepping something
-                    - False otherwise
-            """
-            _time = persistent._mas_current_consumable[self.consumable_type]["prep_time"]
-            return (
-                _time is not None
-                and _time.date() == _now.date()
-                and self.isDrinkTime(_time)
-            )
-
         def isConsTime(self, _now=None):
             """
             Checks if we're in the time range for this consumable

--- a/Monika After Story/game/zz_reactions.rpy
+++ b/Monika After Story/game/zz_reactions.rpy
@@ -1548,9 +1548,10 @@ label mas_reaction_hotchocolate:
             m 1hua "But for now, at least I can enjoy it here."
             m 1hub "Thanks again, [player]!"
 
-            #If we're currently brewing/drinking anything or if it's not winter, we won't have this
+            #If we're currently brewing/drinking anything, or it's not time for this consumable, or if it's not winter, we won't have this
             if (
-                not mas_isWinter()
+                not hotchoc.isConsTime()
+                or not mas_isWinter()
                 or bool(MASConsumable._getCurrentDrink())
             ):
                 m 3eua "I'll be sure to have some later!"


### PR DESCRIPTION
There is a chance for a consumable to have a `prep_time` but get stuck because the finish prepping event somehow either was not queued or lost its conditional. 

This adds an extra check in checking logic so that we can reset the consumable if we have a `prep_time` but the finish prep event has no conditionals. We now also reset the consumable if we started prepping the consumable but left and came back on a time where we shouldn't be able to have it.

## Testing:
- Verify that calling the logic resets the appropriate consumable type if a consumable has a `prep_time` but the finish prep event has no conditionals or it's no longer time to have this consumable.
  Note: A complete reset will only happen if there are no available consumables for the current time. If there are available consumables the logic will try to queue a new one.
- Verify no crashes.