### PR TITLE
mas_gender/mas_preferred name queue by time not exp

### DIFF
--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -11,7 +11,7 @@ init 5 python:
         Event(
             persistent.event_database,
             eventlabel="mas_gender",
-            conditional="store.mas_xp.level() >= 1",
+            start_date=mas_getFirstSesh() + datetime.timedelta(minutes=30),
             action=EV_ACT_QUEUE
         )
     )
@@ -60,6 +60,12 @@ label mas_gender:
     $ mas_unlockEVL("monika_gender_redo","EVE")
     # set pronouns
     call mas_set_gender
+
+    #Set up the preferredname topic
+    python:
+        preferredname_ev = mas_getEV("mas_preferredname")
+        if preferredname_ev:
+            preferredname_ev.start_date = datetime.datetime.now() + datetime.timedelta(hours=2)
     return "love"
 
 init 5 python:
@@ -578,11 +584,11 @@ init 5 python:
         Event(
             persistent.event_database,
             eventlabel="mas_preferredname",
-            conditional="store.mas_xp.level() >= 2",
             action=EV_ACT_QUEUE
         )
     )
     #NOTE: This unlocks the player name change event
+    #NOTE: This gets its start_date from mas_gender
 
 label mas_preferredname:
     m 1euc "I've been wondering about your name."

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -13,7 +13,8 @@ init 5 python:
             eventlabel="mas_gender",
             start_date=mas_getFirstSesh() + datetime.timedelta(minutes=30),
             action=EV_ACT_QUEUE
-        )
+        ),
+        skipCalendar=True
     )
     #NOTE: This unlocks the monika_gender_redo event
 
@@ -585,7 +586,8 @@ init 5 python:
             persistent.event_database,
             eventlabel="mas_preferredname",
             action=EV_ACT_QUEUE
-        )
+        ),
+        skipCalendar=True
     )
     #NOTE: This unlocks the player name change event
     #NOTE: This gets its start_date from mas_gender

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -472,13 +472,12 @@ label v0_11_3(version="v0_11_3"):
         #Handle the preferred name and gender change topics again
         gender_ev = mas_getEV("mas_gender")
         if gender_ev:
-            preferredname_ev = mas_getEV("mas_preferredname")
-
             #Remove the gender ev's conditional
             gender_ev.conditional = None
 
-            #If we have the preferredname ev, we need to remove the conditional anyway
+            preferredname_ev = mas_getEV("mas_preferredname")
             if preferredname_ev:
+                #If we have the preferredname ev, we need to remove the conditional anyway
                 preferredname_ev.conditional = None
 
             #If the gender topic has a last seen and the preferredname ev hasn't been seen yet

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -469,6 +469,27 @@ label v0_11_3(version="v0_11_3"):
         for pool_label in pool_unlock_list:
             mas_unlockEVL(pool_label,"EVE")
 
+        #Handle the preferred name and gender change topics again
+        gender_ev = mas_getEV("mas_gender")
+        if gender_ev:
+            preferredname_ev = mas_getEV("mas_preferredname")
+
+            #Remove the gender ev's conditional
+            gender_ev.conditional = None
+
+            #If we have the preferredname ev, we need to remove the conditional anyway
+            if preferredname_ev:
+                preferredname_ev.conditional = None
+
+            #If the gender topic has a last seen and the preferredname ev hasn't been seen yet
+            #We need to set up its start date
+            if gender_ev.last_seen:
+                if preferredname_ev and not preferredname_ev.last_seen:
+                    preferredname_ev.start_date = gender_ev.last_seen + datetime.timedelta(hours=2)
+
+            #If the gender topic has not been seen, then it needs its start_date set up
+            else:
+                gender_ev.start_date = mas_getFirstSesh() + datetime.timedelta(minutes=30)
     return
 
 #0.11.1


### PR DESCRIPTION
For people who play for around 1-2 hours a day, these topics take *forever* to show up, to the point where it doesn't make sense.

As such, we've opted to use time for this instead. The `mas_gender` topic should now show 30 minutes after the first session, and the `mas_preferredname` topic should show up 2 hours after seeing `mas_gender`.

# Testing:
- Verify that on fresh persistents, the gender topic is set to be queued at half an hour after the first session
- Verify that after seeing `mas_gender`, the `mas_preferredname` topic is set to queue two hours after `mas_gender`
- Verify that on existing persistents, if you haven't seen `mas_gender` yet, the topic's `conditional` is removed and it's given a `start_date` after `call`ing `v0_11_3`
- Verify that on existing persistents, if you *have* seen `mas_gender`, the topic has no `start_date`, no `conditional`, or `action`, and if you haven't seen `mas_preferredname`, it now has a `start_date` of 2 hours after the `last_seen` of the `mas_gender` topic. If you have seen `mas_preferredname`, then it also has no `start_date`, `conditional`, or `action`