### PR TITLE
Hemis runs seasonal prog points

### DIFF
--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -13297,6 +13297,11 @@ label monika_hemispheres:
             m 3rksdld "Like the terrible travel conditions, having to shovel it..."
             call monika_snow_nogets_snow
 
+    python:
+        #Now that hemi has changed, set the current season and run prog points
+        persistent._mas_current_season = store.mas_seasons._seasonalCatchup(
+            persistent._mas_current_season
+        )
     return "derandom|rebuild_ev"
 
 # player has snow, hemisphere version

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -469,6 +469,9 @@ label v0_11_3(version="v0_11_3"):
         for pool_label in pool_unlock_list:
             mas_unlockEVL(pool_label,"EVE")
 
+        #Fix the islands event
+        if not mas_isWinter() and not seen_event("greeting_ourreality"):
+            mas_unlockEVL("greeting_ourreality", "GRE")
     return
 
 #0.11.1


### PR DESCRIPTION
Fixed an issue which caused the islands greeting to not unlock.

Issue was caused because of `mas_seasonalCheck` running ever minute, which sets current season and doesn't run a seasonal catchup, meaning that the spring prog point was being skipped completely and therefore, topics never locked/unlocked appropriately.

By adding a seasonalCatchup call to `monika_hemispheres`, we fix this as now we change the season in the topic itself and by doing so, run all appropriate prog points.

# Testing:
- Verify that using the hemispheres topic changes `persistent._mas_current_season` at the end of the topic and that appropriate prog points are run
- Verify that the update script unlocks the islands greet if it's not winter right now and it hasn't been seen yet