### PR TITLE
Update farewells to work similar to greetings

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -3743,7 +3743,6 @@ init -991 python in mas_utils:
     mas_log.raw_write = True
     mas_log.write("VERSION: {0}\n".format(store.persistent.version_number))
 
-
     def weightedChoice(choice_weight_tuple_list):
         """
         Returns a random item based on weighting.
@@ -3759,7 +3758,13 @@ init -991 python in mas_utils:
         if not choice_weight_tuple_list:
             return None
 
+        #Firstly, sort the choice_weight_tuple_list
+        choice_weight_tuple_list.sort(key=lambda x: x[1])
+
+        #Now split our tuples into individual lists for choices and weights
         choices, weights = zip(*choice_weight_tuple_list)
+
+        #Some var setup
         total_weight = 0
         cumulative_weights = list()
 
@@ -3768,12 +3773,14 @@ init -991 python in mas_utils:
             total_weight += weight
             cumulative_weights.append(total_weight)
 
-        #Now bisect the cumulative weight using a random point
+        #NOTE: At first glance this useage of bisect seems incorrect, however it is used to find the closest weight
+        #To the randomly selected weight. This is used to return the appropriate choice.
         r_index = bisect(
             cumulative_weights,
             renpy.random.random() * total_weight
         )
 
+        #And return the weighted choice
         return choices[r_index]
 
 init -100 python in mas_utils:

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -3288,6 +3288,7 @@ init -991 python in mas_utils:
     #import tempfile
     from os.path import expanduser
     from renpy.log import LogFile
+    from bisect import bisect
 
     # LOG messges
     _mas__failrm = "[ERROR] Failed remove: '{0}' | {1}\n"
@@ -3743,6 +3744,37 @@ init -991 python in mas_utils:
     mas_log.write("VERSION: {0}\n".format(store.persistent.version_number))
 
 
+    def weightedChoice(choice_weight_tuple_list):
+        """
+        Returns a random item based on weighting.
+        NOTE: That weight essentially corresponds to the equivalent of how many times to duplicate the choice
+
+        IN:
+            choice_weight_tuple_list - List of tuples with the form (choice, weighting)
+
+        OUT:
+            random choice value picked using choice weights
+        """
+        #No items? Just return None
+        if not choice_weight_tuple_list:
+            return None
+
+        choices, weights = zip(*choice_weight_tuple_list)
+        total_weight = 0
+        cumulative_weights = list()
+
+        #Now we collect all the weights and geneate a cumulative and total weight amount
+        for weight in weights:
+            total_weight += weight
+            cumulative_weights.append(total_weight)
+
+        #Now bisect the cumulative weight using a random point
+        r_index = bisect(
+            cumulative_weights,
+            renpy.random.random() * total_weight
+        )
+
+        return choices[r_index]
 
 init -100 python in mas_utils:
     # utility functions for other stores.

--- a/Monika After Story/game/event-rules.rpy
+++ b/Monika After Story/game/event-rules.rpy
@@ -722,7 +722,7 @@ init -1 python:
         Probability rules are just integers that determine the probability of something being selected.
 
 
-        Probabilities lie between 1 and 10, with a default of 1
+        Probabilities must be greater than 1
 
         This value is designed to be used with mas_utils.weightedChoice, and acts essentially akin to duplicating
         the choice `probability` times in the list
@@ -734,9 +734,8 @@ init -1 python:
             """
             IN:
                 probability - the probability to set.
-                    If None is passed in, we use the default priority value.
-                    NOTE: If it is outside the bounds, it will be formatted to fit the bounds
-                    NOTE: 10 probability does NOT mean a 100% chance of selecting something
+                    If None is passed in, we use the default probability value.
+                    NOTE: If it is below 1 probability, is is set to 1
 
                 ev - Event to add this rule to. This will replace existing
                     rules of the same key.
@@ -744,9 +743,6 @@ init -1 python:
             """
             if probability is None:
                 probability = MASProbabilityRule.DEF_PROBABILITY
-
-            elif probability > 10:
-                probability = 10
 
             elif probability < 1:
                 probability = 1

--- a/Monika After Story/game/event-rules.rpy
+++ b/Monika After Story/game/event-rules.rpy
@@ -719,7 +719,8 @@ init -1 python:
         """
         Static class used to create probability rules.
 
-        Priority rules are just integers that determine the probability of something being selected.
+        Probability rules are just integers that determine the probability of something being selected.
+
 
         Probabilities lie between 1 and 10, with a default of 1
         """
@@ -746,7 +747,7 @@ init -1 python:
             elif probability < 1:
                 probability = 1
 
-            if type(probability) is not int:
+            if not store.mas_ev_data_ver._verify_int(probability, allow_none=False):
                 raise Exception(
                     "'{0}' is not a valid in priority".format(probability)
                 )

--- a/Monika After Story/game/event-rules.rpy
+++ b/Monika After Story/game/event-rules.rpy
@@ -721,9 +721,9 @@ init -1 python:
 
         Priority rules are just integers that determine the probability of something being selected.
 
-        Probabilities lie between 1 and 100, with a default of 20
+        Probabilities lie between 1 and 10, with a default of 1
         """
-        DEF_PROBABILITY = 20
+        DEF_PROBABILITY = 1
 
         @staticmethod
         def create_rule(probability, ev=None):
@@ -740,8 +740,8 @@ init -1 python:
             if probability is None:
                 probability = MASProbabilityRule.DEF_PROBABILITY
 
-            elif probability > 100:
-                probability = 100
+            elif probability > 10:
+                probability = 10
 
             elif probability < 1:
                 probability = 1

--- a/Monika After Story/game/event-rules.rpy
+++ b/Monika After Story/game/event-rules.rpy
@@ -723,6 +723,9 @@ init -1 python:
 
 
         Probabilities lie between 1 and 10, with a default of 1
+
+        This value is designed to be used with mas_utils.weightedChoice, and acts essentially akin to duplicating
+        the choice `probability` times in the list
         """
         DEF_PROBABILITY = 1
 
@@ -733,7 +736,8 @@ init -1 python:
                 probability - the probability to set.
                     If None is passed in, we use the default priority value.
                     NOTE: If it is outside the bounds, it will be formatted to fit the bounds
-                    NOTE: 100 probability does NOT mean a 100% chance of selecting something
+                    NOTE: 10 probability does NOT mean a 100% chance of selecting something
+
                 ev - Event to add this rule to. This will replace existing
                     rules of the same key.
                     (Default: None)
@@ -749,7 +753,7 @@ init -1 python:
 
             if not store.mas_ev_data_ver._verify_int(probability, allow_none=False):
                 raise Exception(
-                    "'{0}' is not a valid in priority".format(probability)
+                    "'{0}' is not a valid in probability".format(probability)
                 )
 
             rule = {EV_RULE_PROBABILITY: probability}

--- a/Monika After Story/game/event-rules.rpy
+++ b/Monika After Story/game/event-rules.rpy
@@ -14,6 +14,7 @@ init -1 python:
     EV_RULE_FAREWELL_RANDOM = "farewell_random"
     EV_RULE_AFF_RANGE = "affection_range"
     EV_RULE_PRIORITY = "rule_priority"
+    EV_RULE_PROBABILITY = "rule_probability"
 
 
     # special constants for numerical repeat rules
@@ -713,6 +714,63 @@ init -1 python:
             """
             return ev.rules.get(EV_RULE_PRIORITY, MASPriorityRule.DEF_PRIORITY)
 
+
+    class MASProbabilityRule(object):
+        """
+        Static class used to create probability rules.
+
+        Priority rules are just integers that determine the probability of something being selected.
+
+        Probabilities lie between 1 and 100, with a default of 20
+        """
+        DEF_PROBABILITY = 20
+
+        @staticmethod
+        def create_rule(probability, ev=None):
+            """
+            IN:
+                probability - the probability to set.
+                    If None is passed in, we use the default priority value.
+                    NOTE: If it is outside the bounds, it will be formatted to fit the bounds
+                    NOTE: 100 probability does NOT mean a 100% chance of selecting something
+                ev - Event to add this rule to. This will replace existing
+                    rules of the same key.
+                    (Default: None)
+            """
+            if probability is None:
+                probability = MASProbabilityRule.DEF_PROBABILITY
+
+            elif probability > 100:
+                probability = 100
+
+            elif probability < 1:
+                probability = 1
+
+            if type(probability) is not int:
+                raise Exception(
+                    "'{0}' is not a valid in priority".format(probability)
+                )
+
+            rule = {EV_RULE_PROBABILITY: probability}
+
+            if ev:
+                ev.rules.update(rule)
+
+            return rule
+
+
+        @staticmethod
+        def get_probability(ev):
+            """
+            Gets the probability of the given event.
+
+            IN:
+                ev - event to get probability of
+
+            OUT:
+                The probability of the given event, or def if no ProbilityRule is found
+            """
+            return ev.rules.get(EV_RULE_PROBABILITY, MASProbabilityRule.DEF_PROBABILITY)
 
 init python:
     # these rules are NOT actually event rules since they don't create rule

--- a/Monika After Story/game/script-farewells.rpy
+++ b/Monika After Story/game/script-farewells.rpy
@@ -71,7 +71,7 @@ init -1 python in mas_farewells:
             return False
 
         #Conditional check (Since it's ideally least likely to be used)
-        if ev.conditional is not None and not eval(ev.conditional):
+        if ev.conditional is not None and not store.eval(ev, store.__dict__):
             return False
 
         # otherwise, we passed all tests
@@ -104,10 +104,10 @@ init -1 python in mas_farewells:
         # now filter
         for ev_label, ev in fare_db.iteritems():
             if _filterFarewell(
-                    ev,
-                    curr_priority,
-                    aff,
-                    check_time
+                ev,
+                curr_priority,
+                aff,
+                check_time
             ):
                 # change priority levels and stuff if needed
                 ev_priority = store.MASPriorityRule.get_priority(ev)

--- a/Monika After Story/game/script-farewells.rpy
+++ b/Monika After Story/game/script-farewells.rpy
@@ -317,15 +317,26 @@ init 5 python:
             persistent.farewell_database,
             eventlabel="bye_going_to_sleep",
             unlocked=True,
-            rules = rules
+            rules=rules
         ),
         code="BYE"
     )
     del rules
 
 label bye_going_to_sleep:
+    #TODO: TC-O things
     if mas_isMoniNormal(higher=True):
-        m 1esa "Are you going to sleep, [player]?"
+        m 1esa "Are you going to sleep, [player]?{nw}"
+        $ _history_list.pop()
+        menu:
+            m "Are you going to sleep, [player]?{fast}"
+
+            "Yeah.":
+                m 1eka "I'll be seeing you in your dreams."
+
+            "Not yet.":
+                m 1eka "Okay. {w=0.3}Have a good evening~"
+
         m 1eka "I'll be seeing you in your dreams."
 
     elif mas_isMoniUpset():
@@ -751,18 +762,30 @@ init 5 python:
             persistent.farewell_database,
             eventlabel="bye_goodnight",
             unlocked=True,
-            rules = rules
+            rules=rules
         ),
         code="BYE"
     )
     del rules
 
 label bye_goodnight:
+    #TODO: Dlg flow for TC-O things
     if mas_isMoniNormal(higher=True):
-        m 1eua "Goodnight, [player]."
-        m 1eka "I'll see you tomorrow, okay?"
-        m 3eka "Remember, 'sleep tight, don't let the bedbugs bite,' ehehe."
-        m 1ekbfa "I love you~"
+        m 3eka "Going to sleep?{nw}"
+        $ _history_list.pop()
+        menu:
+            m "Going to sleep?{fast}"
+
+            "Yeah.":
+                m 1eua "Goodnight, [player]."
+                m 1eka "I'll see you tomorrow, okay?"
+                m 3eka "Remember, 'sleep tight, don't let the bedbugs bite,' ehehe."
+                m 1ekbfa "I love you~"
+
+            "Not yet.":
+                m 1eka "Okay, [player]..."
+                m 3hub "Enjoy your evening!"
+                m 3rksdlb "Try not to stay up too late, ehehe~"
 
     elif mas_isMoniUpset():
         m 2esc "Goodnight."

--- a/Monika After Story/game/script-farewells.rpy
+++ b/Monika After Story/game/script-farewells.rpy
@@ -311,7 +311,7 @@ label bye_take_care:
 init 5 python:
     rules = dict()
     rules.update(MASSelectiveRepeatRule.create_rule(hours=[0,20,21,22,23]))
-    rules.update(MASProbabilityRule.create_rule(6))
+    rules.update(MASPriorityRule.create_rule(50))
     addEvent(
         Event(
             persistent.farewell_database,
@@ -745,7 +745,7 @@ label bye_goodevening:
 init 5 python:
     rules = dict()
     rules.update(MASSelectiveRepeatRule.create_rule(hours=[0,20,21,22,23]))
-    rules.update(MASProbabilityRule.create_rule(6))
+    rules.update(MASPriorityRule.create_rule(50))
     addEvent(
         Event(
             persistent.farewell_database,

--- a/Monika After Story/game/script-farewells.rpy
+++ b/Monika After Story/game/script-farewells.rpy
@@ -211,7 +211,7 @@ label bye_leaving_already:
     m 1ekc "Aw, leaving already?"
     m 1eka "It's really sad whenever you have to go..."
     m 3eua "Just be sure to come back as soon as you can, okay?"
-    m "I love you so much, [player]. Stay safe!"
+    m 3hua "I love you so much, [player]. Stay safe!"
     return 'quit'
 
 init 5 python:

--- a/Monika After Story/game/script-farewells.rpy
+++ b/Monika After Story/game/script-farewells.rpy
@@ -337,8 +337,6 @@ label bye_going_to_sleep:
             "Not yet.":
                 m 1eka "Okay. {w=0.3}Have a good evening~"
 
-        m 1eka "I'll be seeing you in your dreams."
-
     elif mas_isMoniUpset():
         m 2esc "Going to sleep, [player]?"
         m "Goodnight."

--- a/Monika After Story/game/script-farewells.rpy
+++ b/Monika After Story/game/script-farewells.rpy
@@ -38,10 +38,10 @@ init -1 python in mas_farewells:
         #   eval in this order:
         #   1. unlocked
         #   2. not pooled
-        #   3. aff_range unlocked
-        #   4. conditional
-        #   5. priority (lower or same is True)
-        #   6. all rules
+        #   3. aff_range
+        #   4. priority (lower or same is True)
+        #   5. all rules
+        #   6. conditional
         #       NOTE: this is never cleared. Please limit use of this
         #           property as we should aim to use lock/unlock as primary way
         #           to enable or disable greetings.
@@ -58,10 +58,6 @@ init -1 python in mas_farewells:
         if not ev.checkAffection(aff):
             return False
 
-        #Conditional check
-        if ev.conditional is not None and not eval(ev.conditional):
-            return False
-
         #Priority check
         if store.MASPriorityRule.get_priority(ev) > curr_pri:
             return False
@@ -72,6 +68,10 @@ init -1 python in mas_farewells:
             and store.MASNumericalRepeatRule.evaluate_rule(check_time, ev, defval=True)
             and store.MASGreetingRule.evaluate_rule(ev, defval=True)
         ):
+            return False
+
+        #Conditional check (Since it's ideally least likely to be used)
+        if ev.conditional is not None and not eval(ev.conditional):
             return False
 
         # otherwise, we passed all tests

--- a/Monika After Story/game/script-farewells.rpy
+++ b/Monika After Story/game/script-farewells.rpy
@@ -71,7 +71,7 @@ init -1 python in mas_farewells:
             return False
 
         #Conditional check (Since it's ideally least likely to be used)
-        if ev.conditional is not None and not store.eval(ev, store.__dict__):
+        if ev.conditional is not None and not eval(ev.conditional, store.__dict__):
             return False
 
         # otherwise, we passed all tests

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -495,7 +495,11 @@ label v0_11_3(version="v0_11_3"):
                 gender_ev.start_date = mas_getFirstSesh() + datetime.timedelta(minutes=30)
 
         #Unlock the leaving already fare
-        mas_showEVL("bye_leaving_already", "BYE", _random=True)
+        leaving_already_ev = mas_getEV("bye_leaving_already")
+        if leaving_already_ev:
+            leaving_already_ev.random = True
+            leaving_already_ev.conditional = "mas_getSessionLength() <= datetime.timedelta(minutes=20)"
+
     return
 
 #0.11.1

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -493,6 +493,9 @@ label v0_11_3(version="v0_11_3"):
             #If the gender topic has not been seen, then it needs its start_date set up
             else:
                 gender_ev.start_date = mas_getFirstSesh() + datetime.timedelta(minutes=30)
+
+        #Unlock the leaving already fare
+        mas_showEVL("bye_leaving_already", "BYE", _random=True)
     return
 
 #0.11.1


### PR DESCRIPTION
Farewells used an outdated method for selection. This PR updates them to use a similar selection algorithm to greetings.

In addition to this, I have also created a new rule type, `MASProbabilityRule`, which is a number between 1 and 10 (since this is designed to work with the function *store.mas_utils.*`weightedChoice()`

An analogy for how the function works is as follows:
Priority number essentially corresponds to the amount of times the choice given is repeated in the list for a `random.choice` to pick from.

So a probability rule with value 10 doesn't mean it's guaranteed to be selected, however it is more likely.

I have also rerandomed `bye_leaving_already` and added a conditional for it to show for sessions under 20 minutes in length.

## Testing:
- Verify that farewells work properly
- Verify that farewells still follow time rules
- Verify that it's possible to get generic farewells during ranges of time rules
- Verify no crashes