### PR TITLE
Songs are now picked intelligently

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1657,6 +1657,9 @@ label ch30_minute(time_since_check):
         # split affection values prior to saving
         _mas_AffSave()
 
+        #Check if we need to lock/unlock the songs rand delegate
+        mas_songs.checkRandSongDelegate()
+
         # save the persistent
         renpy.save_persistent()
 
@@ -1974,7 +1977,7 @@ label ch30_reset:
         $ persistent._mas_filereacts_gift_aff_gained = 0
         $ persistent._mas_filereacts_last_aff_gained_reset_date = today
 
-    #Check if we need to unlock the songs rand delegate
+    #Check if we need to lock/unlock the songs rand delegate
     $ mas_songs.checkRandSongDelegate()
 
     #Now check the analysis ev


### PR DESCRIPTION
Random delegate for songs now respects repeat-conversation rules and picks more intelligently, using a priority toward unseen random songs over seen ones.

# Testing:
- Verify no crashes/other issues
- Verify songs are picked unseen first
- Verify that once out of unseen songs, they're just picked at random
- Verify that songs respect the repeat conversation flag