### PR TITLE
Better Sanity Checks for Undo Action Rules

### DIFF
--- a/Monika After Story/game/event-rules.rpy
+++ b/Monika After Story/game/event-rules.rpy
@@ -835,12 +835,16 @@ init python:
             OUT:
                 True if we are past the stored end date and we need to
             """
+            #If the ev doesn't exist, we cannot do any work. This should be removed
+            if not ev:
+                return None
+
             #NOTE: This should be used AFTER init 7
             _start_date, _end_date = persistent._mas_undo_action_rules.get(ev.eventlabel, (None, None))
 
             #Check for invalid data
-            if not ev or not _start_date or not _end_date:
-                #This ev doesn't exist and/or it doesn't exist in the rules dict. We should set this to be removed
+            if not _start_date or not _end_date:
+                #No start or end date? That can't be right. We should remove this
                 return None
 
             #Need to turn


### PR DESCRIPTION
#5892 
No idea why we didn't check if ev before accessing its attributes before...

# Testing:
- Create a new event object and give it an undo action rule
- Load in with that event
- Say goodbye, then remove the event
- When loading in again, verify no crashes and that the eventlabel is removed from the `persistent._mas_undo_action_rules` dict.