### PR TITLE
Make renpy loader consistent across OSes

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -6,7 +6,6 @@ init 1 python:
     persistent.steam = "steamapps" in config.basedir.lower()
 
 python early:
-    import re
     import singleton
     me = singleton.SingleInstance()
     # define the zorders
@@ -34,7 +33,7 @@ python early:
         if renpy.config.reject_backslash and "\\" in name:
             raise Exception("Backslash in filename, use '/' instead: %r" % name)
 
-        name = re.sub(r'/+', '/', name)
+        name = renpy.re.sub(r'/+', '/', name)
 
         for p in renpy.loader.get_prefixes():
             rv = renpy.loader.load_core(p + name)


### PR DESCRIPTION
Linking [#9](https://github.com/multimokia/MAS-Submods/issues/9) From my submods repository.

Renpy's loader struggles to load things correctly when given a full filepath (this causes issues in loading from a `MASDockingStation` object or when using `renpy.config.basedir` as it strips the `/` character before the directory.

This PR removes the `lstrip` function from key loader functions and allows it to work as it does on Windows, on other OSes.

# Testing:
- Verify Windows loading still works correctly (songs/sounds/etc.)
- Verify Linux can load from basedir (try putting an mp3 file in the basedir or a subfolder in the basedir and then use `play_song(renpy.config.basedir + "/path/to/song.mp3")`
- [Need Community Help] - I cannot get a MacOS VM working for myself to test this like I've tested the previous one.
  - If any community member has a Mac or a functional MacOS VM, please help testing this PR.
  - That or @aldoram5 if you could help out, that'd be appreciated.