### PR TITLE
Eval Greet Conditionals In Global Store

### DIFF
--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -181,7 +181,7 @@ init -1 python in mas_greetings:
             return False
 
         # conditional check
-        if ev.conditional is not None and not eval(ev.conditional):
+        if ev.conditional is not None and not eval(ev.conditional, store.__dict__):
             return False
 
         # otherwise, we passed all tests


### PR DESCRIPTION
Makes greetings consistent with farewells and topics by having their conditionals evaluated using the global store instead of the `mas_greetings` store.

I have not adjusted conditionals because it's the exact same fundamentally and requires update scripts to modify them.