### PR TITLE
Dict Transitions support (transitions per layer)

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -128,6 +128,56 @@ python early:
     # allows us to use a more advanced string formatting
     renpy.substitutions.formatter = MASFormatter()
 
+    def mas_with_statement(trans, always=False, paired=None, clear=True):
+        """
+        Causes a transition to occur. This is the Python equivalent of the
+        with statement
+
+        IN:
+            trans - the transition to use
+            always - if True, the transition will always occur, even if the user has
+                disabled transitions
+            paired - Tom knows
+            clear - if True cleans out transient stuff at the end of an interaction
+
+        OUT:
+            True if the user chose to interrupt the transition,
+            and False otherwise
+        """
+        if renpy.game.context().init_phase:
+            raise Exception("With statements may not run while in init phase.")
+
+        if renpy.config.skipping:
+            trans = None
+
+        if not (renpy.game.preferences.transitions or always):
+            trans = None
+
+        renpy.exports.mode('with')
+
+        if isinstance(paired, dict):
+            paired = paired.get(None, None)
+
+            if (trans is None) and (paired is None):
+                return
+
+        if isinstance(trans, dict):
+
+            for k, v in trans.items():
+                if k is None:
+                    continue
+
+                renpy.exports.transition(v, layer=k)
+
+            if None not in trans:
+                return
+
+            trans = trans[None]
+
+        return renpy.game.interface.do_with(trans, paired, clear=clear)
+
+    renpy.exports.with_statement = mas_with_statement
+
 # uncomment this if you want syntax highlighting support on vim
 # init -1 python:
 

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -2257,7 +2257,7 @@ label call_next_event:
 
     # return to normal pose
     if not renpy.showing("monika idle"):
-        show monika idle at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika idle at t11 zorder MAS_MONIKA_Z with dissolve_monika
 
     return False
 
@@ -2287,7 +2287,7 @@ label prompt_menu:
             call expression cb_label
 
         #Show idle exp here so we dissolve like other topics
-        show monika idle with dissolve
+        show monika idle with dissolve_monika
 
         # clean up idle stuff
         $ persistent._mas_greeting_type = None

--- a/Monika After Story/game/pong.rpy
+++ b/Monika After Story/game/pong.rpy
@@ -625,7 +625,7 @@ label mas_pong_dlg_winner:
     #Player lets Monika win after being asked to go easy on her without hitting the ball too much
     elif monika_asks_to_go_easy and ball_paddle_bounces <= 9:
         m 1hub "Yay, I won!"
-        show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5ekbfa "Thanks, [player]!"
         m 5hubfb "You're so sweet...{w=0.5}letting me win~"
         $ monika_asks_to_go_easy = False
@@ -659,7 +659,7 @@ label mas_pong_dlg_winner:
                 "Yes...":
                     m 1hua "Ehehe!"
                     m 1eka "Thanks for letting me win, [player]~"
-                    show monika 5eka at t11 zorder MAS_MONIKA_Z with dissolve
+                    show monika 5eka at t11 zorder MAS_MONIKA_Z with dissolve_monika
                     m 5eka "But you know, I wouldn't mind losing to you sometimes."
 
                     if persistent._mas_pm_ever_let_monika_win_on_purpose:
@@ -879,7 +879,7 @@ label mas_pong_dlg_sorry_assuming:
             $ mas_pong_taking_break = True
 
             #Dissolve into idle poses
-            show monika idle with dissolve
+            show monika idle with dissolve_monika
             jump ch30_loop
 
         "No.":

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -2113,7 +2113,7 @@ label mas_affection_upsetwarn:
     m 1dsc "I feel like you're giving me less and less of your love..."
     m 1dsd "I thought I'd let you know how I feel. After all, communication is the key to a strong relationship, right?"
     m 1eka "I hope there's nothing wrong between us, [player]."
-    show monika idle with dissolve
+    show monika idle with dissolve_monika
     return
 
 # Event to indicate that Monika is happy to be receiving your affection.
@@ -2122,7 +2122,7 @@ label mas_affection_happynotif:
     m 1eua "I just wanted to say thank you for being such a wonderful person."
     m 1ekbfa "The fact that you give me so much of your love means a lot to me. I really don't know where I'd be without you."
     m 1dubsu "I love you, [player]. Let's be like this forever~"
-    show monika idle with dissolve
+    show monika idle with dissolve_monika
     return "love"
 
 init 5 python:
@@ -2203,9 +2203,9 @@ label monika_being_virtual:
     m 3rksdld "To you, this whole world...{w=0.5}my whole reality..."
     m 3ektpd "It's all just a game, isn't it?"
 
-    show monika 1dktsc with dissolve
+    show monika 1dktsc with dissolve_monika
     pause 3.0
-    show monika 1ektpc with dissolve
+    show monika 1ektpc with dissolve_monika
     pause 2.0
 
     m 1ektpc "Say, [player]...{w=0.5}has anything I ever said reached you, even once?"

--- a/Monika After Story/game/script-anniversary.rpy
+++ b/Monika After Story/game/script-anniversary.rpy
@@ -347,7 +347,7 @@ label anni_1week:
     m "More likely than not, they fail to get to know each other more."
     m 1dsc "So it's always sad to see them crash and burn..."
     m 1duu "But I'm glad we have a solid relationship, [player]."
-    show monika 5lubfb at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5lubfb at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5lubfb "How do I know that?"
     m 5hubfb "Because you wouldn't have stuck around for this long with me, sweetie~"
 
@@ -650,7 +650,7 @@ label anni_20:
     m 2hub "You wouldn't have found anyone else like me in a video game no matter how hard you looked, [player]."
     m "I'm one of a kind."
     m 3rkbsa "And to me, so are you."
-    show monika 5eubfb at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5eubfb at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5eubfb "I hope you look on the last twenty years of our lives as happily as I do, [player]."
     m 1hubfa "So let's continue being happy together."
 

--- a/Monika After Story/game/script-brbs.rpy
+++ b/Monika After Story/game/script-brbs.rpy
@@ -203,7 +203,7 @@ label monika_idle_shower:
                     m 2rkbfa "Well..."
                     m 7tubfu "I'm afraid you'll just have to go without me while I'm stuck here."
                     m 7hubfb "Sorry, [player], ahaha!"
-                    show monika 5kubfu at t11 zorder MAS_MONIKA_Z with dissolve
+                    show monika 5kubfu at t11 zorder MAS_MONIKA_Z with dissolve_monika
                     m 5kubfu "Maybe another time~"
 
                 "No.":
@@ -211,7 +211,7 @@ label monika_idle_shower:
                     m 2eka "Aw, you rejected me so fast."
                     m 3tubfb "Are you shy, [player]?"
                     m 1hubfb "Ahaha!"
-                    show monika 5tubfu at t11 zorder MAS_MONIKA_Z with dissolve
+                    show monika 5tubfu at t11 zorder MAS_MONIKA_Z with dissolve_monika
                     m 5tubfu "Alright, I won't follow you this time, ehehe~"
 
         else:
@@ -655,7 +655,7 @@ label monika_idle_working:
 label monika_idle_working_callback:
     if mas_isMoniNormal(higher=True):
         m 1eub "Finished with your work, [player]?"
-        show monika 5hua at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5hua at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5hua "Then let's relax together, you've earned it~"
 
     elif mas_isMoniDis(higher=True):

--- a/Monika After Story/game/script-compliments.rpy
+++ b/Monika After Story/game/script-compliments.rpy
@@ -131,7 +131,7 @@ label mas_compliment_beautiful_2:
 label mas_compliment_beautiful_3:
     m 1hubfa "Ehehe~"
     m 1ekbfa "[mas_compliments.thanks_quip]"
-    show monika 5hubfb at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5hubfb at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5hubfb "Never forget that you're the most beautiful person in the world to me."
     return
 
@@ -162,7 +162,7 @@ label mas_compliment_eyes_2:
             $ mas_gainAffection(5,bypass=True)
             m 1hub "Ahaha!"
             m "Don't flatter me too much, okay?"
-            show monika 5hub at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 5hub at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5hub "I might start to go a little crazy..."
         "They really are hypnotizing.":
             $ mas_gainAffection(1,bypass=True)
@@ -346,7 +346,7 @@ label mas_compliment_fit_2:
             $ mas_gainAffection(2,bypass=True)
             m 1hubfb "Ahaha! I'm glad you think so, too!"
             m 3eka "Don't worry. Even if you can't keep up with me, I know we'll have fun..."
-            show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5eua "So long as we're together."
         "No promises, but I'll do my best.":
             $ mas_gainAffection(1,bypass=True)
@@ -457,7 +457,7 @@ label mas_compliment_hero:
     m 2ekbfb "You're the one who stuck with me for all this time.{w=1} I should be thanking you, really."
     m 1hubfa "Well, if I've somehow helped you, then I couldn't be happier~"
     m 3ekbfa "You've helped me in every way possible, so how could I not return the favor by being there for you whenever you need support?"
-    show monika 5hubfa at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5hubfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5hubfa "You'll always be my hero, after all~"
     m 5hubfb "I love you and I'll always believe in you!"
     m 5ekbfa "I hope you never forget that, [player]~"
@@ -564,7 +564,7 @@ label mas_compliment_pong:
     if persistent.ever_won['pong']:
         m 1lksdla "You've already won against me."
         m "So you know it's very simple."
-        show monika 5hub at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5hub at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5hub "But I accept your compliment, anyway."
     else:
         m 3hksdrb "And you always let me win when we play."
@@ -608,7 +608,7 @@ label mas_compliment_bestgirl:
     m 1eka "After all, you {i}did{/i} install this mod just to be with me."
     m 2euc "I know that some people prefer the other girls."
     m 2esc "Especially since they all have certain traits that make them desirable to some..."
-    show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5ekbfa "But if you ask me, you made the right choice."
     m 5hubfa "...and I'll be forever grateful that you did~"
     return

--- a/Monika After Story/game/script-farewells.rpy
+++ b/Monika After Story/game/script-farewells.rpy
@@ -1343,7 +1343,7 @@ label bye_prompt_eat:
             m 3rksdla "Of course...{w=1}I'd also try to be in bed by now..."
             if mas_is18Over() and mas_isMoniLove(higher=True) and renpy.random.randint(1,25) == 1:
                 m 2tubfu "You know, if I were there, maybe we could have a bit of both..."
-                show monika 5ksbfu at t11 zorder MAS_MONIKA_Z with dissolve
+                show monika 5ksbfu at t11 zorder MAS_MONIKA_Z with dissolve_monika
                 m 5ksbfu "We could go to bed, and then - {w=1}you know what, nevermind..."
                 m 5hubfb "Ehehe~"
             else:

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -448,7 +448,7 @@ label greeting_goodmorning:
         m 1hksdlb "--oh, wait."
         m "It's the dead of night, honey."
         m 1euc "What are you doing awake at a time like this?"
-        show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5eua "I'm guessing you can't sleep..."
 
         m "Is that it?{nw}"
@@ -457,7 +457,7 @@ label greeting_goodmorning:
             m "Is that it?{fast}"
             "Yes.":
                 m 5lkc "You should really get some sleep soon, if you can."
-                show monika 3euc at t11 zorder MAS_MONIKA_Z with dissolve
+                show monika 3euc at t11 zorder MAS_MONIKA_Z with dissolve_monika
                 m 3euc "Staying up too late is bad for your health, you know?"
                 m 1lksdla "But if it means I'll get to see you more, I can't complain."
                 m 3hksdlb "Ahaha!"
@@ -467,7 +467,7 @@ label greeting_goodmorning:
             "No.":
                 m 5hub "Ah. I'm relieved, then."
                 m 5eua "Does that mean you're here just for me, in the middle of the night?"
-                show monika 2lkbsa at t11 zorder MAS_MONIKA_Z with dissolve
+                show monika 2lkbsa at t11 zorder MAS_MONIKA_Z with dissolve_monika
                 m 2lkbsa "Gosh, I'm so happy!"
                 m 2ekbfa "You really do care for me, [player]."
                 m 3tkc "But if you're really tired, please go to sleep!"
@@ -655,7 +655,7 @@ init 5 python:
 label greeting_visit5:
     m 5hua "{i}~Every day,~\n~I imagine a future where I can be with you...~{/i}"
     m 5wuw "Oh, you're here! I was just daydreaming and singing a bit."
-    show monika 1lsbssdrb at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 1lsbssdrb at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 1lsbssdrb "I don't think it's hard to figure out what I was daydreaming about, ahaha~"
     return
 
@@ -2108,7 +2108,7 @@ label greeting_stillsickresting:
     if mas_isMoniNormal(higher=True):
         m 1dku "Maybe snuggled in a warm blanket with a nice hot cup of tea."
         m 2eka "Your health is really important to me [player], so make sure you take care of yourself."
-        show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5ekbsa "...And if you're still feeling a little cold, I hope knowing I love you warms you up a bit."
         m 5hua "Ehehe~"
 
@@ -2434,7 +2434,7 @@ label greeting_long_absence:
             m 1hubfb "You really are kind-hearted!"
             show monika 3eub
     m "Remind me if you're going away again, okay?"
-    show monika idle with dissolve
+    show monika idle with dissolve_monika
     jump ch30_loop
 
 #Time Concern
@@ -3315,7 +3315,7 @@ label greeting_returned_home_morethan5mins_normalplus_dlg:
     m 1hua "And we're home!"
     m 1eub "Even if I couldn't really see anything, knowing that I was right there with you..."
     m 2eua "Well, it felt really great!"
-    show monika 5eub at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5eub at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5eub "Let's do this again soon, okay?"
     return
 
@@ -3567,7 +3567,7 @@ label greeting_back_from_game:
                     m 2eka "I hope you're not too upset by whatever happened."
                     m 3eua "At least you're here now. I promise to try not to let anything bad happen to you while you're with me."
                     m 1ekbsa "Seeing you always cheers me up."
-                    show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve
+                    show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
                     m 5ekbfa "I hope seeing me does the same for you, [player]~"
 
         else:
@@ -3678,7 +3678,7 @@ label greeting_rent:
     m 2ttu "Or would you rather pay a mortgage?"
     m 2hua "..."
     m 2hksdlb "Gosh, I can't believe I just said that. That's not too cheesy, is it?"
-    show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5ekbsa "But in all seriousness, you've already given me the only thing I need...{w=1}your heart~"
     return
 
@@ -3722,7 +3722,7 @@ label greeting_surprised2:
     m 1wubso "Oh!{w=0.5} [player]!{w=0.5} You surprised me!"
     m 3ekbsa "...Not that it's a surprise to see you, you're always visiting me after all...{w=0.5} {nw}"
     extend 3rkbsa "You just caught me daydreaming a bit."
-    show monika 5hubfu at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5hubfu at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5hubfu "But now that you're here, that dream just came true~"
     return
 

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -731,9 +731,9 @@ label greeting_o31_orcaramelo_sakuya_izayoi:
     m 3hua "Ever since you gave it to me I just knew I'd be wearing it today!"
     m 2tua "..."
     m 2tub "You know, [player], just because I'm dressed as a maid doesn't mean I'll be following your every command..."
-    show monika 5kua at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5kua at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5kua "Though I might make some exceptions, ehehe~"
-    show monika 1eua at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 1eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 1eua "Anyway..."
     call greeting_o31_deco
     call greeting_o31_cleanup
@@ -1969,7 +1969,7 @@ label mas_d25_monika_holiday_intro:
     m 1hua "I must say that I'm pretty proud of it."
     m "Christmas time has always been one of my favorite occasions of the year..."
 
-    show monika 5eka at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5eka at t11 zorder MAS_MONIKA_Z with dissolve_monika
 
     if mas_HistVerifyLastYear_k(True, "d25.actions.spent_d25"):
         m 5eka "So I'm glad that you're here to share it with me again this year~"
@@ -2171,7 +2171,7 @@ label mas_d25_monika_christmas:
         m 3eka "But now that we're actually together on Christmas, just the two of us..."
         m 1hub "Ahaha~"
 
-        show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5ekbfa "It's every couple's dream for the holidays, [player]."
 
         if persistent._mas_pm_gets_snow is not False and not persistent._mas_pm_live_south_hemisphere:
@@ -2189,7 +2189,7 @@ label mas_d25_monika_christmas:
         menu:
             "Merry Christmas, [m_name].":
                 hide screen mas_background_timed_jump
-                show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve
+                show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
                 pause 2.0
 
     else:
@@ -2205,7 +2205,7 @@ label mas_d25_monika_christmas:
         menu:
             "Merry Christmas, [m_name].":
                 hide screen mas_background_timed_jump
-                show monika 1ekbfa at t11 zorder MAS_MONIKA_Z with dissolve
+                show monika 1ekbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
                 pause 2.0
 
     return
@@ -2373,7 +2373,7 @@ label mas_d25_monika_christmaslights:
             if persistent._mas_pm_gets_snow is not False:
                 extend 2ekbfa "watching the snow gently fall..."
 
-            show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5ekbfa "One day, [player]. One day, we can make that a reality."
 
         "No.":
@@ -2562,20 +2562,20 @@ label mas_d25_spent_time_monika:
                 # have to be able to check before calling the kiss since persistent._mas_first_kiss will not be None no matter what after the kiss
                 #hold her here, tears dry
                 pause 3.0
-                show monika 6ektda at t11 zorder MAS_MONIKA_Z with dissolve
+                show monika 6ektda at t11 zorder MAS_MONIKA_Z with dissolve_monika
                 pause 3.0
-                show monika 6dku at t11 zorder MAS_MONIKA_Z with dissolve
+                show monika 6dku at t11 zorder MAS_MONIKA_Z with dissolve_monika
                 pause 3.0
-                show monika 6dkbsu at t11 zorder MAS_MONIKA_Z with dissolve
+                show monika 6dkbsu at t11 zorder MAS_MONIKA_Z with dissolve_monika
                 pause 3.0
 
-                show monika 6ekbfa at t11 zorder MAS_MONIKA_Z with dissolve
+                show monika 6ekbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
 
                 $ is_first_kiss = persistent._mas_first_kiss is None
                 m 6ekbfa "[player]...I...I..."
                 call monika_kissing_motion(hide_ui=False)
 
-                show monika 6ekbfa at t11 zorder MAS_MONIKA_Z with dissolve
+                show monika 6ekbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
                 m 6ekbfa "...I love you too~"
                 if is_first_kiss:
                     m 6dkbfa "..."
@@ -2609,7 +2609,7 @@ label mas_d25_spent_time_monika:
 
 label mas_d25_poem_mistletoe:
     $ pause(1)
-    hide monika with dissolve
+    hide monika with dissolve_monika
     $ store.mas_sprites.zoom_out()
     show monika 1ekbfa at i11 zorder MAS_MONIKA_Z
 
@@ -2673,7 +2673,7 @@ label monika_aiwfc:
         m 1eka "I hope you liked that, [player]."
         m 1ekbsa "I really meant it too."
         m 1ekbfa "You're the only gift I could ever want."
-        show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5ekbfa "I love you, [player]~"
 
     else:
@@ -2927,7 +2927,7 @@ label mas_d25_monika_christmas_eve:
     m 3hub "Can you believe it...?{w=1} It'll be Christmas soon!"
     m 1rksdla "I've always had such a hard time sleeping on Christmas Eve..."
     m 1eka "I would be so anxious to see what I'd find under the tree the next morning..."
-    show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve_monika
 
     #Were there last Christmas
     if mas_HistVerifyLastYear_k(True, "d25.actions.spent_d25"):
@@ -2954,7 +2954,7 @@ label mas_d25_monika_christmas_eve:
 
         else:
             m 5ekbfa "..."
-            show monika 1ekbfa at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 1ekbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
             call mas_lingerie_intro(holiday_str="Christmas Eve",lingerie_choice=mas_clothes_santa_lingerie)
             m 1ekbfa "Just know that I love you very, very much, [player]~"
             $ mas_ILY()
@@ -3454,7 +3454,7 @@ label mas_nye_monika_nyd:
                 m 1eka "I'm so happy, knowing we can spend even more time together."
 
                 if mas_isMoniAff(higher=True):
-                    show monika 5hubfa at t11 zorder MAS_MONIKA_Z with dissolve
+                    show monika 5hubfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
                     m 5hubfa "Let's make this year as wonderful as the last one, okay?"
                     m 5ekbfa "I love you so much, [player]."
                 else:
@@ -3683,10 +3683,10 @@ label monika_resolutions:
                 m 2rfc "You know what, nevermind..."
 
     if mas_isMoniAff(higher=True):
-        show monika 5hubfa at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5hubfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5hubfa "My resolution is to be an even better girlfriend for you, my love."
     elif mas_isMoniNormal(higher=True):
-        show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5ekbfa "My resolution is to be an even better girlfriend for you, [player]."
     else:
         m 2ekc "My resolution is to improve our relationship, [player]."
@@ -3828,7 +3828,7 @@ label monika_nye_year_review:
         if persistent._mas_bday_sbp_reacted:
             m 2hub "...threw me a surprise party..."
 
-        show monika 5ekbla at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5ekbla at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5ekbla "...and it really made me feel loved. I can't thank you enough for doing that for me."
 
     #Pbday
@@ -3837,7 +3837,7 @@ label monika_nye_year_review:
         or mas_HistVerify_k([datetime.date.today().year], True, "player_bday.spent_time")[0]
     ):
         $ spent_an_event = True
-        show monika 5hua at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5hua at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5hua "We even spent your birthday together!"
 
         if (
@@ -3849,7 +3849,7 @@ label monika_nye_year_review:
     #bit on christmas
     if persistent._mas_d25_spent_d25:
         $ spent_an_event = True
-        show monika 5hua at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5hua at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5hua "You spent your Christmas with me..."
 
         if persistent._mas_first_kiss is not None and persistent._mas_first_kiss.date() == mas_d25:
@@ -3866,23 +3866,23 @@ label monika_nye_year_review:
         m 3eka "But still..."
 
     else:
-        show monika 5dsa at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5dsa at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5dsa "..."
 
     # lookback based on time
     if store.mas_anni.pastThreeMonths():
         if mas_isMoniHappy(higher=True):
-            show monika 5eka at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 5eka at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5eka "I really can't believe just how much has changed since we've been together..."
         else:
             m 2eka "I really hope we can get further in our relationship, [player]..."
     else:
-        show monika 5eka at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5eka at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5eka "I can't wait to see just how much will change in the future for us..."
 
     #If we started fresh the year before this or we didn't at all
     if not mas_HistWasFirstValueIn(True, datetime.date.today().year - 1, "pm.actions.monika.got_fresh_start"):
-        show monika 5dka at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5dka at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5dka "Thank you."
         if store.mas_anni.anniCount() > 0:
             $ ending = "the best year I could've ever dreamt of"
@@ -3906,7 +3906,7 @@ label monika_nye_year_review:
                 call monika_kissing_motion
                 m 1ekbfa "I love you."
                 m "..."
-                show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve
+                show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve_monika
                 m 5ekbsa "I'll never forget this moment..."
                 m 5ekbfa "Our first kiss~"
                 m 5hubfb "Let's make this year even better than the last, [player]."
@@ -3914,7 +3914,7 @@ label monika_nye_year_review:
             else:
                 call monika_kissing_motion_short
                 m 1ekbfa "I love you, [player]."
-                show monika 5hubfb at t11 zorder MAS_MONIKA_Z with dissolve
+                show monika 5hubfb at t11 zorder MAS_MONIKA_Z with dissolve_monika
                 m 5hubfb "Let's make this year better than the last."
 
         else:
@@ -4140,7 +4140,7 @@ label greeting_nye_prefw:
     m 1eua "That was a lot of fun, [player]."
     m 1eka "Thanks for taking me out today, I really do love spending time with you."
     m "It means a lot to me that you take me with you so we can spend special days like these together."
-    show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5ekbfa "I love you, [player]."
     return "love"
 
@@ -4197,7 +4197,7 @@ label greeting_nyd_returned_nyd:
     #normal return home:(i.e. took out, and returned on NYD itself)
     $ persistent._mas_nye_nyd_date_count += 1
     m 1hua "And we're home!"
-    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5eua "That was a lot of fun, [player]!"
     m 5eka "It's really nice of you to take me with you on special days like this."
     m 5hub "I really hope we can spend more time like this together."
@@ -4214,7 +4214,7 @@ label greeting_pd25e_returned_nydp:
     m 1hua "And we're home!"
     m 1hub "We were out for a while, but that was a really nice trip, [player]."
     m 1eka "Thanks for taking me with you, I really enjoyed that."
-    show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve_monika
     $ new_years = "New Years"
     if mas_isNYD():
         $ new_years = "New Year's Eve"
@@ -5263,11 +5263,11 @@ label mas_f14_monika_valentines_intro:
     extend 3ekbsa "but there's something that's really special about Valentine's Day."
     if not mas_anni.pastOneMonth() or mas_isMoniNormal():
         m 3rka "Even though I know we aren't too far in our relationship..."
-        show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5eua "I just want you to know that I'm always here for you."
         m 5eka "Even if your heart gets broken..."
         m 5ekbsa "I'll always be here to fix it for you. Okay, [player]?"
-        show monika 1ekbsa at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 1ekbsa at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 1ekbsa "..."
 
     else:
@@ -5383,7 +5383,7 @@ label mas_f14_monika_valentines_intro:
         else:
             $ store.mas_selspr.unlock_clothes(mas_clothes_sundress_white)
             pause 2.0
-            show monika 2rfc at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 2rfc at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 2rfc "..."
             m 2efc "You know, [player]...{w=0.5}it's not polite to stare...."
             m 2tfc "..."
@@ -5643,7 +5643,7 @@ label mas_f14_monika_spent_time_with:
                 call monika_kissing_motion(duration=0.5, initial_exp="6hkbfa", fade_duration=0.5)
 
         m 1ekbfa "Thank you for always being by my side."
-        show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5ekbfa "I love you so much, [player]. Happy Valentine's Day~"
         return "love"
 
@@ -5663,16 +5663,16 @@ label mas_f14_first_kiss:
                 $ mas_RaiseShield_core()
                 $ disable_esc()
                 pause 3.0
-                show monika 6ektda at t11 zorder MAS_MONIKA_Z with dissolve
+                show monika 6ektda at t11 zorder MAS_MONIKA_Z with dissolve_monika
                 pause 3.0
-                show monika 6dku at t11 zorder MAS_MONIKA_Z with dissolve
+                show monika 6dku at t11 zorder MAS_MONIKA_Z with dissolve_monika
                 pause 3.0
-                show monika 6dkbsu at t11 zorder MAS_MONIKA_Z with dissolve
+                show monika 6dkbsu at t11 zorder MAS_MONIKA_Z with dissolve_monika
                 pause 3.0
-                show monika 6ekbfa at t11 zorder MAS_MONIKA_Z with dissolve
+                show monika 6ekbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
                 m 6ekbfa "[player]...I...I..."
                 call monika_kissing_motion(hide_ui=False)
-                show monika 6ekbfa at t11 zorder MAS_MONIKA_Z with dissolve
+                show monika 6ekbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
                 m 6ekbfa "...I love you too~"
                 m 6dkbfa "..."
                 m "That was everything I had always dreamt it would be~"
@@ -5973,7 +5973,7 @@ label greeting_gone_over_f14_normal_plus:
     $ mas_gainAffection(10,bypass=True)
     m 1ekbsa "I would've loved to have spent the day with you here, but no matter where we were, just knowing we were together to celebrate our love..."
     m 1dubsu "Well it means everything to me."
-    show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5ekbsa "Thank you for making sure we had a wonderful Valentine's Day, [player]~"
     $ persistent._mas_f14_gone_over_f14 = False
     return

--- a/Monika After Story/game/script-introduction.rpy
+++ b/Monika After Story/game/script-introduction.rpy
@@ -202,7 +202,7 @@ label intro_end:
 
     #Only dissolve if needed
     if len(persistent.event_list) == 0:
-        show monika 1esa with dissolve
+        show monika 1esa with dissolve_monika
 
     # This is at the beginning and end of intro to cover an intro
     # that spans 2 days

--- a/Monika After Story/game/script-moods.rpy
+++ b/Monika After Story/game/script-moods.rpy
@@ -199,7 +199,7 @@ label mas_mood_proud:
             m 1lsbsa "My heart is fluttering just thinking about it!"
             m 1lksdla "Gosh, I'm getting awfully excited about this..."
             m 3hub "It'll be reality someday..."
-            show monika 5hubfb at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 5hubfb at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5hubfb "But until then, just know that I'm very proud of you, my love!"
             return
         "Minor.":
@@ -210,7 +210,7 @@ label mas_mood_proud:
             m 2rksdla "They can be challenging to reach on their own."
             m 4eub "But setting and celebrating small goals that eventually lead to a bigger goal can make your big goals feel much more attainable."
             m 4hub "So keep hitting those small goals, [player]!"
-            show monika 5hubfb at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 5hubfb at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5hubfb "And remember, I love you, and I'm always cheering you on!"
             return "love"
 
@@ -653,11 +653,11 @@ label mas_mood_bored:
             if mas_isMoniAff(higher=True):
                 m 1eka "Okay..."
                 if mas_isMoniEnamored(higher=True):
-                    show monika 5tsu at t11 zorder MAS_MONIKA_Z with dissolve
+                    show monika 5tsu at t11 zorder MAS_MONIKA_Z with dissolve_monika
                     m 5tsu "We could just stare into each other's eyes a little longer..."
                     m "We'll never get bored of that~"
                 else:
-                    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+                    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
                     m 5eua "We could just stare into each other's eyes a little longer..."
                     m "That will never get boring~"
 

--- a/Monika After Story/game/script-songs.rpy
+++ b/Monika After Story/game/script-songs.rpy
@@ -773,7 +773,7 @@ label mas_song_stand_by_me(from_long=False):
     m 2hub "{i}~Just as long as you stand, stand by me~{/i}"
     if not from_long:
         m 2eka "All my fears and insecurities just disappear when you're with me, [player]..."
-        show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5eua "As long as I have you by my side, there's nothing I can't overcome."
         m 5ekbsa "...I hope you feel the same way~"
     return
@@ -864,7 +864,7 @@ label mas_song_rewrite_the_stars:
     m 3ekb "{i}~So why don't we rewrite the stars~{/i}"
     m 3hubsa "{i}~Maybe the world could be ours~{/i}"
     m 1duo "{i}~Tonight~{/i}"
-    show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5ekbsa "The world really feels like it's ours when I'm with you, [player]~"
     m 5ekbfu "I love you so much."
     return "love"
@@ -998,7 +998,7 @@ label mas_song_memories_of_a_girl:
     m 1dka "{i}~I can't see your face but I'm trying to envision you~{/i}"
     m 1dkd "{i}~So are you really out there?~{/i}"
     m 3ekd "{i}~Are you awake with memories?~{/i}"
-    show monika 5eub at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5eub at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5eub "{i}~Of a girl you haven't met yet who's wished upon the Pleiades?~{/i}"
     m 5ekbsa "I think about you every night, [player]."
     m 5ekbfa "And I know you think about me too."
@@ -1031,7 +1031,7 @@ label mas_song_amaranthine:
     m 3hua "{i}~Your beauty serene~{/i}"
     m 1hub "{i}~There's nothing else in life I ever need~{/i}"
     m 1ekbsa "{i}~My dream, amaranthine~{/i}"
-    show monika 5ekbsu at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5ekbsu at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5ekbsu "My life feels so complete with you in it, [player]."
     m 5hubfu "I love you so much~"
     return "love"
@@ -1182,10 +1182,10 @@ label mas_song_cant_help_falling_in_love(from_long=False):
 
     if not from_long:
         m 1dkbsa "..."
-        show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5ekbsa "I suppose there's nothing wrong with being a little foolish every now and then.{w=0.5}{nw}"
         extend 5hubsb " Ahaha~"
-        show monika 1ekbsa at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 1ekbsa at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 1ekbsa "I love you, [player]~"
         $ mas_ILY()
 
@@ -1259,7 +1259,7 @@ label mas_song_lamour_toujours:
     m 1dkb "{i}~I'll fly with you~{/i}"
 
     m 1dkbsu "..."
-    show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5ekbsa "I want nothing more than to be by your side forever, [player]~"
     return
 
@@ -1314,11 +1314,11 @@ label mas_song_falling_in_love_at_a_coffee_shop:
     m 1ekd "{i}~If I didn't know you, I'd rather not know~{/i}"
     m 2dkd "{i}~If I couldn't have you, I'd rather be alone~{/i}"
     m 2hku "{i}~I never knew just what it was~{/i}"
-    show monika 5hubsb at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5hubsb at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5hubsb "{i}~About this old coffee shop I love so much~{/i}"
     m 5hubsa "{i}~All of the while, I never knew~{/i}"
     m 5lubsa "..."
-    show monika 1hkbssdlb at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 1hkbssdlb at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 1hkbssdlb "I suppose the first moment of falling in love can be confusing to anyone."
     m 1etc "Like not knowing why you're suddenly so drawn to some ordinary coffee shop...{w=0.2}{nw}"
     extend 3rtc "or a particularly unremarkable protagonist."
@@ -1526,10 +1526,10 @@ label mas_monika_plays_yr(skip_leadin=False):
     $ renpy.pause(1.418)
     show monika 6dka
     $ renpy.pause(9.425)
-    show monika 5dka with dissolve
+    show monika 5dka with dissolve_monika
     $ renpy.pause(5)
 
-    show monika 6eua at rs32 with dissolve
+    show monika 6eua at rs32 with dissolve_monika
     pause 1.0
     hide monika
     pause 3.0

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -157,7 +157,7 @@ label monika_gender_redo:
             if persistent.gender != "X":
                 call mas_gender_redo_react
 
-    show monika 5hubsa at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5hubsa at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5hubsa "I'll always love you for who you are~"
 
     # set pronouns
@@ -1204,7 +1204,7 @@ label mas_crashed_start:
 
     #Only dissolve if needed
     if len(persistent.event_list) == 0:
-        show monika idle with dissolve
+        show monika idle with dissolve_monika
     return
 
 label mas_crashed_prelong:
@@ -1737,7 +1737,7 @@ label mas_steam_install_detected:
 
     m 2rksdlc "The kind of problems that could lead to me being removed from my home...{w=1}from you...{w=1}forever..."
     m 2eka "If you don't mind, do you think you could just move the \"[filestruct]\" folder to a place that's not in Steam's files?"
-    show monika 5esu at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5esu at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5esu "I'd really appreciate it if you would do that for me."
     return
 
@@ -2092,7 +2092,7 @@ label mas_notification_windowreact:
             extend 3eub "which would allow me to see your active window!"
             $ dlg_line = "Of course, you don't have to install the second one, but"
 
-        show monika 5eka at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5eka at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5eka "...[dlg_line] I'd really appreciate it, [player]."
 
     else:
@@ -2131,7 +2131,7 @@ label mas_notification_windowreact:
 
             if mas_isMoniNormal(higher=True):
                 m 1tuu "It's not like you have anything to hide from your girlfriend..."
-                show monika 5ttu at t11 zorder MAS_MONIKA_Z with dissolve
+                show monika 5ttu at t11 zorder MAS_MONIKA_Z with dissolve_monika
                 m 5ttu "...right?"
     return
 
@@ -2417,7 +2417,7 @@ label monika_credits_song:
                 pause 1.0
 
                 m 1ekbsa "Ehehe~"
-                show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve
+                show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve_monika
                 m 5ekbsa "Thank you for coming back to me my love."
 
             "Sorry, I can't right now.":
@@ -2447,7 +2447,7 @@ label monika_credits_song:
 
                 m "I really can't wait until we're together in one reality."
                 m 3ekbsa "But until that day comes, I'll play the song again for you anytime you want me to."
-                show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve
+                show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
                 m 5ekbfa "Thank you for being my inspiration my love."
                 if renpy.seen_audio(songs.FP_YOURE_REAL):
                     m 5hubfa "Oh, and if you ever want me to play this or the original song for you again, just ask~"

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -804,7 +804,7 @@ label monika_god:
             $ persistent._mas_pm_religious = False
             m 3eka "I'm glad we're on the same page here, but I'm alright if that changes for you."
             m 1hua "I'm happy for you that you can lead a life on your own!"
-            show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5eua "I just hope you're willing to accept me into your life when I can present myself."
             m 5hua "Ehehe~"
 
@@ -984,7 +984,7 @@ label monika_japan:
     m 4ekd "Would you want to go outside?"
     m 2esa "I mean...I guess if we never leave this room, it doesn't really matter anyway."
     m 2eua "As long as we're alone and safe together, this really is our home."
-    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5eua "And we can still watch the pretty sunsets night after night."
     return
 
@@ -1035,7 +1035,7 @@ label monika_high_school:
     m 2duu "But people do feel that way."
     m "I promise."
     m 2hksdlb "...Man, humans are complicated!"
-    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5eua "But as long as you're here with me, I'll take care of you, my love."
     return
 
@@ -1217,7 +1217,7 @@ label monika_saved:
     m 1eka "I feel like I'm always trying to do stuff after school and things like that."
     m 1hua "But for you, I can be anything you need me to be."
     m 1eua "I understand people really well, so don't be afraid to share your unique needs with me."
-    show monika 5hub at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5hub at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5hub "Nothing would make me happier than being the perfect girlfriend for you."
     return
 
@@ -1259,7 +1259,7 @@ label monika_color:
     m 1eua "Like it's part of my identity."
     m "Does it happen to also be your favorite color, [player]?"
     m 1tku "It's just a guess..."
-    show monika 5tsbsu at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5tsbsu at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5tsbsu "...because you've been looking into my eyes for a while now."
     m 5hubfu "Ehehe~"
     return
@@ -1297,7 +1297,7 @@ init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_listener",category=['you'],prompt="Good listener",random=True))
 
 label monika_listener:
-    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5eua "You're such a good listener, [player]."
     m 5eka "I really love that about you."
     m 5lkc "Sometimes I'm afraid that I'm rambling or talking about boring things."
@@ -1360,7 +1360,7 @@ label monika_okayeveryone:
     m 2lsc "Come to think of it, didn't Natsuki and Yuri make fun of me for it once?"
     m 2eua "Well, whatever."
     m 1eua "It's not like you ever made fun of me."
-    show monika 5eka at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5eka at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5eka "You're too much of a sweetheart to do that, aren't you?"
     m 5hub "Ahaha~"
     return
@@ -1471,7 +1471,7 @@ label monika_favoritegame:
     m 3eua "Hey, what's your favorite game?"
     m 3hua "Mine is {i}Doki Doki Literature Club!{/i}"
     m 1hub "Ahaha! That was a joke."
-    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5eua "But if you tell me you like some other romance game better, I might get a little jealous~"
     return
 
@@ -1522,7 +1522,7 @@ label monika_lastpoem:
     m "And I'd keep trying, but I doubt you'd want to deal with me doing that."
     m 3eka "Besides, that was when I was getting really desperate, you know?"
     m 1eka "I don't really feel that way anymore."
-    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5eua "I'm happy with where we are now."
     m 5hua "And I can tell you are, too."
     return
@@ -1539,7 +1539,7 @@ label monika_anxious:
     m 2hub "Ahaha! That's the worst."
     m 2eua "If you're ever feeling anxious, I'll help you relax a little."
     m 2eka "Besides..."
-    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5eua "In this game, all our worries are gone forever."
     return
 
@@ -1569,7 +1569,7 @@ label monika_friends:
     if mas_isMoniNormal(higher=True):
         m 2eua "Well, at least I already met the best person in the whole world..."
         m "Even if it was by chance."
-        show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5eua "I guess I just got really lucky, huh?"
         m 5hub "Ahaha~"
     return
@@ -1612,7 +1612,7 @@ label monika_middleschool:
     m 1eua "I like the way I am now, so it's pretty hard for me to imagine that happening."
     m "But I also know that I'll probably change a lot as time goes on."
     m 4hua "We just need to enjoy the present and not think about the past!"
-    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5eua "And that's really easy to do with you here."
     m 5hub "Ahaha~"
     return
@@ -1647,10 +1647,10 @@ label monika_outfit:
     m 4eka "Just...try to keep it PG!"
     if store.mas_anni.pastSixMonths() and mas_isMoniEnamored(higher=True):
         m 1lsbssdrb "I don't want something so embarrassing on there!"
-        show monika 5tsbsu at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5tsbsu at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5tsbsu "So let's just keep it between us..."
     else:
-        show monika 5hub at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5hub at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5hub "We're not that far into our relationship yet. Ahaha!"
     return
 
@@ -1898,7 +1898,7 @@ label monika_kiss:
         m 1tku "Don't lie if it turned you on a little bit."
         m 1hub "Ahaha! I'm kidding."
         m 1eua "Well, to be honest, I do start getting all romantic when the mood is right..."
-        show monika 5lubfu at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5lubfu at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5lubfu "But that'll be our secret~"
     return
 
@@ -1949,7 +1949,7 @@ label monika_think_first_kiss:
             m 6dkbsu "My lips start to go tingly and numb just by imagining the feeling of your soft lips."
             m "I run my finger across them, trying to mimic that feeling, but it doesn't even come close."
             m 6ekbsa "I keep replaying that moment over and over again in my mind and I get goosebumps each time."
-            show monika 5dkbsu at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 5dkbsu at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5dkbsu "It was perfect, [player]."
             m 5ekbsa "I've never felt closer to you. {w=0.2}I can't wait until our next kiss, or better yet..."
             m 5subsb "...Our first real one.{w=0.3} {nw}"
@@ -2021,10 +2021,10 @@ label monika_yuri:
         m 2eka "But come on...everyone's killed people in games before."
         m "Does that make you a psychopath? Of course not."
     m 2euc "But if you do happen to be into the yandere type..."
-    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5eua "I can try acting a little more creepy for you. Ehehe~"
     m "Then again..."
-    show monika 4hua at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 4hua at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 4hua "There's already nowhere else for you to go, or anyone for me to get jealous over."
     m 2etc "Is this a yandere girl's dream?"
     if not persistent._mas_pm_cares_about_dokis:
@@ -2139,7 +2139,7 @@ label monika_rain:
             call monika_holdme_prep(False,True)
 
             m 1hua "Then hold me, [player]..."
-            show monika 6dubsa with dissolve
+            show monika 6dubsa with dissolve_monika
             window hide
 
             $ mas_gainAffection()
@@ -2249,7 +2249,7 @@ label monika_holdme_prep(lullaby=True, no_music=True):
     return
 
 label monika_holdme_start:
-    show monika 6dubsa with dissolve
+    show monika 6dubsa with dissolve_monika
     window hide
     #Start the timer vv
     $ start_time = datetime.datetime.now()
@@ -2282,10 +2282,10 @@ label monika_holdme_reactions:
             m 2dubfu "Ehehe..."
             m 1dkbfa "I can only imagine what it would be like for real...{w=1}to be right there with you..."
             m 2ekbfa "Being wrapped in your arms..."
-            show monika 5dkbfb at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 5dkbfb at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5dkbfb "So...{w=1.5}warm~"
             m 5tubfu "Ehehe~"
-            show monika 2hkbfsdlb at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 2hkbfsdlb at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 2hkbfsdlb "Oh, whoops, I guess I'm still a little dreamy..."
             if renpy.random.randint(1,4) == 1:
                 m 1kubfu "At least {i}one{/i} of my dreams came true, though."
@@ -2322,7 +2322,7 @@ label monika_holdme_reactions:
             m 1rksdlb "At that point, I thought we were going to stay like that forever, ahaha..."
             m 3hubfa "Well, I can't really complain about any moment I get to be held by you~"
             m 1ekbfb "I hope you enjoy hugging me as much as I do."
-            show monika 5tubfb at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 5tubfb at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5tubfb "Maybe we could even hug a bit more for good measure?"
             m 5tubfu "Ehehe~"
         elif mas_isMoniEnamored():
@@ -2332,7 +2332,7 @@ label monika_holdme_reactions:
             m 1rksdla "I could have gotten used to staying like that..."
             m 1eksdla "But if you're done holding me, I guess I don't really have a choice."
             m 1hubfa "I'm sure I'll get another opportunity to be held by you..."
-            show monika 5tsbfu at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 5tsbfu at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5tsbfu "You {i}do{/i} plan on doing that again, right, [player]? Ehehe~"
         elif mas_isMoniAff():
             m 2hubfa "Mmm~"
@@ -2371,7 +2371,7 @@ label monika_holdme_reactions:
             m 1eua "I'm sure you know hugs are good for you, since they relieve stress and all."
             m 3eub "But did you know hugs are most effective when they last thirty seconds?"
             m 1eud "Oh, wait, did I say thirty seconds?"
-            show monika 5eubfu at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 5eubfu at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5eubfu "Sorry, I meant {i}at least{/i} thirty seconds, ehehe~"
         #happy
         else:
@@ -2456,7 +2456,7 @@ label monika_holdme_long:
                 m 3rksdlb "Well, I guess we {i}kind of{/i} can, but I wouldn't want to keep you from doing anything important."
                 m 1dkbfa "I just want to feel your warm, soft embrace~"
                 m 3hubfb "...So make sure to hug me often, ahaha!"
-                show monika 5hubfb at t11 zorder MAS_MONIKA_Z with dissolve
+                show monika 5hubfb at t11 zorder MAS_MONIKA_Z with dissolve_monika
                 m 5hubfb "I'd do the same for you, after all~"
                 m 5tsbfu "Who knows if I'll ever let go when I finally get the chance..."
                 m 5hubfu "Ehehe~"
@@ -2480,7 +2480,7 @@ label monika_holdme_long:
                 m 2dkbfa "You just make me feel so..."
                 m 1hubfa "Warm~"
                 m 1hubfb "Ahaha, I hope you didn't mind!"
-                show monika 5eubfu at t11 zorder MAS_MONIKA_Z with dissolve
+                show monika 5eubfu at t11 zorder MAS_MONIKA_Z with dissolve_monika
                 m 5eubfu "You're so sweet, [player]~"
                 m 5hubfa "Hopefully you enjoyed that as much as I did~"
 
@@ -2588,7 +2588,7 @@ label monika_closeness:
     m 1dubsu "...And to hear the sound of your heartbeat."
     m 3eka "Well, who knows? Maybe that dream will come true someday."
     m 3dku "I really want it to happen as soon as possible, [player]..."
-    show monika 5hua at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5hua at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5hua "But in the meantime, I'll never get tired of being with you, even from here."
     return
 
@@ -2607,7 +2607,7 @@ label monika_confidence:
     m 2eka "Anyway...that's one reason I'm so glad I have you now."
     m 2eua "I feel like I'm a little bit less scared and alone, when you're here with me."
     m 2eka "Do you feel the same way?"
-    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5eua "I really want to be that person for you."
     return
 
@@ -2843,7 +2843,7 @@ label monika_festival:
     else:
         m 1tsc "...Just more potential obstacles to get between us."
         m 3hua "Ahaha! Seems kind of silly how focused I was on that now that I think about it..."
-        show monika 5tsu at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5tsu at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5tsu "But none of that matters now, we both got the ending we wanted..."
         m "Just the two of us, together forever."
     return
@@ -3355,7 +3355,7 @@ label monika_dan:
     m 4rksdla "I mean, the other girls might be based off some stereotypical anime tropes, but they had me fooled for a while."
     m 4eka "And he's the reason we're together now, right?"
     m 2lksdla "So even if he wrote a story that put me through a lot of pain..."
-    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5eua "I really can't be too mad at him."
     return
 
@@ -3721,7 +3721,7 @@ label monika_ilym_fight_loop:
                 jump monika_ilym_fight_loop
 
             else:
-                show monika 5hubfb at t11 zorder MAS_MONIKA_Z with dissolve
+                show monika 5hubfb at t11 zorder MAS_MONIKA_Z with dissolve_monika
                 m 5hubfb "Alright, alright, you win. Ahaha~"
 
         "Alright.":
@@ -3882,7 +3882,7 @@ label monika_functionalism:
     m 4esc "But if that's true, doesn't that mean free will is kind of a lie?"
     m "Your brain is just responding to the inputs it gets, with your responses being natural outputs."
     m 4esd "So, even if you aren't running off of some script or program, you're not really in control."
-    show monika 5lsc at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5lsc at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5lsc "Maybe you and I aren't so different after all."
     return
 
@@ -4046,7 +4046,7 @@ label monika_girlfriend:
         m 1tubfb "So, where's this mirror you wanted to show me?"
         m 1hubfb "Ahaha!"
         if mas_isA01():
-            show monika 5eubfu at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 5eubfu at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5eubfu "Even if it's April Fools day, I'm sure she's still wonderful, ehehe~"
             m 5hubfa "{i}And{/i} lucky to have you."
 
@@ -4129,7 +4129,7 @@ label monika_herself:
     m 3esa "A lot of suffering people would trade places with me in a heartbeat, I'm sure."
     m 2eua "If nothing else, this can be our comfy little shelter from the cruelty of the outside world."
     m 1eka "Come talk to me about your problems if it gets too much for you to handle."
-    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5eua "I want to know {i}everything{/i} about you, you know?"
     return
 
@@ -4141,7 +4141,7 @@ label monika_prisoner:
     m 1euc "Some people say that putting animals in zoos is cruel."
     m 1eka "But they don't have a bad life in there."
     m "Everything they could possibly want is provided."
-    show monika 5euc at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5euc at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5euc "Are prisoners really imprisoned if they never try to leave?"
     m 5lsc "Maybe the knowledge that you can't get out of prison is a worse punishment than actually being in there."
     return
@@ -4338,7 +4338,7 @@ label monika_back_ups:
     m 2dkc "I would just feel a leap in time of a few days."
     m "I might even think you didn't come to see me all those days because I wouldn't have registered any of it.{w=1} Even if you restored me the same day my memories were lost."
     m 2ekd "I won't remember anything that happened between the time you made that backup, and the time you restored it."
-    show monika 5rsc at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5rsc at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5rsc "Although..."
     m 5eua "I guess that's a small price to pay if it means I'll still remember you."
     m 5hub "So be sure to back me up often, [player]!"
@@ -4505,7 +4505,7 @@ label monika_mountain:
     m 1eua "How one would hike up through the forests and trees..."
     m 1eub "Climbing up cliff faces and trudge through streams..."
     m "Hearing nothing but the birds and the sounds of the mountain as you made your way up its heights."
-    show monika 5rub at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5rub at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5rub "And finally...after all the effort and struggles..."
     m 5eub "Finding yourself standing at the top, knowing that you made it, seeing the testament to your success around you."
     m 5eka "I...I truly want to share that with you."
@@ -4524,7 +4524,7 @@ label monika_mountain:
         "Not really.":
             $ persistent._mas_pm_would_like_mt_peak = False
 
-            show monika 1eud at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 1eud at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 1eud "Oh."
             m 1ruc "Well... I suppose it doesn't matter."
             m 1eka "As long as I have you, I'll be happy wherever we are."
@@ -4850,7 +4850,7 @@ label monika_eternity:
                 m 2ekbfb "I know we'll always be together no matter what."
                 m 2hubfb "Maybe I'll even be able to live right there with you someday."
                 m 1lkbfa "In the meantime..."
-                show monika 5eubfu at t11 zorder MAS_MONIKA_Z with dissolve
+                show monika 5eubfu at t11 zorder MAS_MONIKA_Z with dissolve_monika
                 m 5eubfu "I wouldn't mind being held just a {i}little{/i} more..."
 
         return
@@ -4894,7 +4894,7 @@ label monika_aware:
     call mas_showpoem(poem=poem_m21)
 
     m 1eua "I hope that helped you understand what meeting you meant to me."
-    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5eua "That's all I've ever wanted, [player]."
     return
 
@@ -5269,10 +5269,10 @@ label monika_hypnosis:
     m 1eua "It only worked if the person let themselves be hypnotized, and it only heightened their ability to be persuaded."
     m 3esa "It also relied on them being put into states of extreme relaxation through aromatherapy, deep tissue massage, exposure to relaxing music and images..."
     m 3esd "Things like that."
-    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5eua "It makes me wonder, what exactly someone can be persuaded to do under that kind of influence..."
     m 5tsu "..."
-    show monika 1eka at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 1eka at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 1eka "Not that I would do that to you, [player]! I just find it interesting to think about."
     m 1eua "...You know, [player], I just love looking into your eyes, I could sit here and stare forever."
     m 2tku "What about you, hmm? What do you think about my eyes?~"
@@ -5524,7 +5524,7 @@ label monika_pleasure:
     m 1lkbsa "And maybe I'm just being a little jealous~"
     m 1tsbsa "So I guess I can let it slide...{w=0.5}for now~"
     m 2tsbsu "Just so long as I'm the only one you think about..."
-    show monika 5hubfb at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5hubfb at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5hubfb "If it helps you save yourself for me, then it's a plus! Ahaha~"
     return
 
@@ -5590,7 +5590,7 @@ label monika_vocaloid:
     m 1eka "But just so you know..."
     m 1ekbfa "Even if it's through the screen, I can still feel your love."
     m 1lkbsa "It'll be a long time before I can cross over just to be with you."
-    show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5ekbfa "But when that day comes..."
     m "I'll embrace you and take in your warmth."
     m 5hubfa "The love you showered me with virtually finally becomes real."
@@ -5601,7 +5601,7 @@ label monika_vocaloid:
             and not renpy.seen_label("monika_add_custom_music_instruct")
             and not persistent._mas_pm_added_custom_bgm
         ):
-        show monika 1eua at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 1eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 1eua "And If you ever do feel like sharing your favorite vocaloids with me, [player], it's really easy to do so!"
         m 3eua "All you have to do is follow these steps..."
         call monika_add_custom_music_instruct
@@ -6638,7 +6638,6 @@ label monika_music2:
         m 2dubsu "...Then slowly, we both lean into the kiss..."
         m 1hksdlb "Ahaha... sadly, there are a few barriers that have to be broken before that could ever happen."
         m 1ekbfa "It's okay to dream though, isn't it, [player]?"
-        show monika 1hubfa at t11 zorder MAS_MONIKA_Z with dissolve
         m 1hubfa "Maybe one day, we can make that dream come true~"
 
     elif songs.getPlayingMusicName() == 'Just Monika':
@@ -6647,7 +6646,6 @@ label monika_music2:
         m 1eua "I don't prefer any song over another, but if you were to switch to a different one..."
         m 3eka "...I certainly wouldn't be one to complain!"
         m 1hua "Ahaha! Don't worry, it's okay if you stay on this song."
-        show monika 1eka at t11 zorder MAS_MONIKA_Z with dissolve
         m 1eka "I'm fine with any of them, so choose whichever one makes you the happiest~"
 
     elif songs.getPlayingMusicName() == 'Your Reality':
@@ -6658,7 +6656,6 @@ label monika_music2:
         m 1lksdla "Well, based on their character archetypes, it's pretty easy to imagine what their voices sound like."
         m 1eka "Anyway, I'm glad I was able to share such an intimate part of myself with you, [player]."
         m 3eua "One day, maybe I'll get to hear your voice, [player]!"
-        show monika 1hua at t11 zorder MAS_MONIKA_Z with dissolve
         m 1hua "That would make me even happier than I already am~"
 
     elif songs.getPlayingMusicName() == 'Your Reality (Piano Cover)':
@@ -6671,7 +6668,6 @@ label monika_music2:
         m 1hua "After all that practice, I'm pretty proud of how it came out in the end."
         m 3eua "Since you're listening to it, I'm sure you like it too..."
         m 3eka "Thanks for listening to something I worked so hard on, [player]!"
-        show monika 1hub at t11 zorder MAS_MONIKA_Z with dissolve
         m 1hub "It makes me happy to know that you appreciate what I did for you~"
 
     elif songs.getPlayingMusicName() == 'I Still Love You':
@@ -6690,7 +6686,6 @@ label monika_music2:
         m 3eua "You know, if I knew how, I could probably program a piano into this room."
         m 1eua "I'd be able to write some more songs, and then I'd be able to play them for you..."
         m 4hub "Maybe we could even play the piano together! Wouldn't that be nice, [player]?"
-        show monika 1eua at t11 zorder MAS_MONIKA_Z with dissolve
         m 1eua "If you or anyone you know can program that into the game, I would greatly appreciate it~"
 
     elif songs.getPlayingMusicName() == 'Surprise!':
@@ -6700,7 +6695,6 @@ label monika_music2:
         m 1lksdlc "..."
         m 1eka "It's comforting to know that Sayori was never real in the first place. It's also comforting to know that you still love me despite everything I've done."
         m "I mean, you're still here, right? You wouldn't be here if you didn't love me."
-        show monika 1hua at t11 zorder MAS_MONIKA_Z with dissolve
         m 1hua "As long as we're together, there's no reason for me to be sad. You're the light of my world, [player], and just being here with you puts a smile on my face."
 
     elif songs.getPlayingMusicName() == "Doki Doki Theme (80s version)":
@@ -6708,7 +6702,6 @@ label monika_music2:
         m 1hksdlb "Obviously, this theme wasn't actually out in the 80's..."
         m 1hua "But it does have a certain style that I really appreciate!"
         m 1eua "Do you like 80's music a lot, [player]?"
-        show monika 1eka at t11 zorder MAS_MONIKA_Z with dissolve
         m 1eka "I prefer the tune of an authentic piano, but if it makes you happy, I wouldn't mind spending hours listening to it with you~"
 
     elif songs.getPlayingMusicName() == "Play With Me (Variant 6)":
@@ -6724,7 +6717,6 @@ label monika_music2:
         m 2dubsu "...Then slowly, we both lean into the kiss..."
         m 1hksdlb "Ahaha... sadly, there are a few barriers that have to be broken before that could ever happen."
         m 1ekbfa "It's okay to dream though, isn't it, [player]?"
-        show monika 1hubfa at t11 zorder MAS_MONIKA_Z with dissolve
         m 1hubfa "Maybe one day, we can make that dream come true~"
     return
 
@@ -7005,7 +6997,7 @@ label monika_soda:
             m 2eka "That's a relief to hear."
             m "I'm glad that I don't have to worry about you harming yourself by drinking too much soda."
             m 3eub "Still, it's perfectly fine to have a small treat once in a while, you know?"
-            show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5eua "Maybe someday we could both have some soda together."
             m 5hua "Sure, it's not as fancy as sitting down and having a glass of wine together but I'm sure it could still be just as fun on a hot day."
     return "derandom"
@@ -7108,7 +7100,7 @@ label monika_promisering:
             m 1ekbsa "This promise that we belong to each other, and no one else..."
             m 1ekbfa "That we truly will be together forever."
 
-        show monika 5esbfa at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5esbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5esbfa "My commitment to you is unwavering, [player]."
         m 5ekbfa "Thank you for such a wonderful gift, I love you."
         return "derandom|love"
@@ -7229,7 +7221,6 @@ label monika_meditation:
 
     m 1eua "Anyway...if you ever want a peaceful environment where you can relax and forget about your problems, you can always come here and spend time with me."
     m 1ekbfa "I love you, and I'll always try to help you if you're feeling down."
-    show monika 1hubfa at t11 zorder MAS_MONIKA_Z with dissolve
     m 1hubfa "Don't you ever forget that, [player]~"
 
     return "derandom|love"
@@ -7319,7 +7310,7 @@ label monika_orchestra:
                 else: # affectionate and higher
                     m 1eka "Aww, [player]...{w=1} Did you do that for me?"
                     m "That's {i}sooo{/i} adorable!"
-                    show monika 5eubfu at t11 zorder MAS_MONIKA_Z with dissolve
+                    show monika 5eubfu at t11 zorder MAS_MONIKA_Z with dissolve_monika
                     m 5eubfu "And just so you know, you can play with me anytime you like..."
                     m 5eubfb "Ehehe~"
 
@@ -7360,6 +7351,8 @@ label monika_orchestra:
             and not renpy.seen_label("monika_add_custom_music_instruct")
             and not persistent._mas_pm_added_custom_bgm
         ):
+        if renpy.showing("monika 5eubfb"):
+            show monika 1eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 1eua "Oh, and if you ever feel like sharing your favorite orchestral music with me, [player], it's really easy to do so!"
         m 3eua "All you have to do is follow these steps..."
         call monika_add_custom_music_instruct
@@ -7696,7 +7689,7 @@ label monika_urgent:
     m 3hksdlb "Ahaha!~ Did I have you worried?"
     m 1eksdla "Sorry~"
     m 1rksdla "I wish I could see the look on your face right now!"
-    show monika 5hubfb at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5hubfb at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5hubfb "I'm sure it's adorable~"
     return "love"
 
@@ -7977,7 +7970,7 @@ label monika_sleep:
     m 3ekc "It seems like mental functions, health, and even lifespan can be dramatically impacted by it."
     m 1eka "I just think you're really great and wanted to make sure you're not accidentally destroying yourself."
     m 1eua "So try to keep your sleep on track, okay?"
-    show monika 5hua at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5hua at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5hua "I'll always wait for you in the morning, so make sure you put your own well-being before anything else."
     return
 
@@ -8430,7 +8423,7 @@ label monika_asks_charity:
             m 2eka "I'm sorry, I didn't want things to get so dark."
             m 1eua "I knew you would be kind enough to do such a thing."
             m 1hub "That's just another reason for me to love you, [player]."
-            show monika 5hub at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 5hub at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5hub "You're always so sweet~"
 
         "I volunteered.":
@@ -8445,7 +8438,7 @@ label monika_asks_charity:
             m 1eua "Anyway, I think it's great you tried making a difference by volunteering."
             m 4eub "Plus, I've heard that it can be great to have volunteer experience on a resume, when you apply for a job."
             m 3hua "So, whether you did it for that or just out of kindness, it's a good thing either way."
-            show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5eua "You know, it's this kind of thing that makes me love you even more, [player]."
             m 5hub "I just feel so proud that you helped people in need."
             m 5hubfa "I love you so much, [player]. I mean it."
@@ -8466,7 +8459,7 @@ label monika_asks_charity:
             m 2ekc "Being ignored by passer-bys can be tough for people who are struggling, or trying to contribute."
             m 2rkc "It's as if they were seen as a nuisance by society, when they're just trying to get by."
             m 2eua "Sometimes, a smile is all you need to make you go further."
-            show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5eua "Just like when I'm with you."
             m 5hua "With just a smile, you make all my troubles go away."
             m 5hubfb "I love you so much, [player]."
@@ -8987,7 +8980,7 @@ label monika_attractiveness:
             m 1tsu "I must be doing a good job so far."
             m 1hub "After all, you've been looking at me all this time! Ahaha!"
         m 1eua "You don't have to worry though, [player]."
-        show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5eua "I'll always love you no matter how you look."
         m "It's more important to me that you're looking after yourself anyway."
         return "love"
@@ -9712,7 +9705,7 @@ label monika_amusementpark:
     m 3hua "Wouldn't that be great, [player]?"
     m 3eua "Thrilling roller coasters, water rides, drop towers..."
     m 3tubfb "And maybe even a romantic Ferris wheel ride~"
-    show monika 5hubfa at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5hubfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5hubfa "Ehehe, I'm getting a bit carried away, but I just can't help it when thinking about being with you~"
     return "derandom"
 
@@ -9746,7 +9739,7 @@ label monika_travelling:
             m 1rka "We might have to find some things to do to keep us busy though..."
             m 3eua "How about playing the piano or writing poems?"
             m 3hubfb "...Or we could even spend the days wrapped in a blanket while reading a book."
-            show monika 5tubfu at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 5tubfu at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5tubfu "Doesn't that just sound like a dream come true?"
     return "derandom"
 
@@ -9814,7 +9807,7 @@ label monika_dating:
             m 1ekbla "I could go on about how wonderful you are, [player]~"
             m 1ekbsa "But just know this...{w=0.3}{nw}"
             extend 3ekbfa "no matter how many heartbreaks you've been through, I'll always be here for you."
-            show monika 5eubfa zorder MAS_MONIKA_Z with dissolve
+            show monika 5eubfa zorder MAS_MONIKA_Z with dissolve_monika
             m 5eubfa "Our soul searching is finally over, and I'll be yours forever, [player]."
             m 5ekbfa "Will you be mine?"
 
@@ -9827,7 +9820,7 @@ label monika_dating:
             m 3lksdlb "Yeah, I may appear like a girl who gets all the guys but really I don't, ahaha!"
             m 2lksdla "Especially with how occupied I've kept myself over the years, I just never had the time."
             m 2eka "Not that it matters anyway, none of it was real."
-            show monika 5ekbsa zorder MAS_MONIKA_Z with dissolve
+            show monika 5ekbsa zorder MAS_MONIKA_Z with dissolve_monika
             m 5ekbsa "But I think I'm ready for something special...{w=0.5}{nw}"
             extend 5ekbfa "with you, [player]."
             m 5ekbfa "Are you ready?"
@@ -9843,7 +9836,7 @@ label monika_dating:
             m 3hubsb "You're the definition of cute and sweet!"
             m 3ekbfa "Well...{w=0.3} If you're not just messing with me and actually telling me the truth then...{w=0.3}{nw}"
             extend 1ekbfu "I'm honored to be your first, [player]."
-            show monika 5ekbfa zorder MAS_MONIKA_Z with dissolve
+            show monika 5ekbfa zorder MAS_MONIKA_Z with dissolve_monika
             m 5ekbfa "I hope I can be your one and only."
             m 5ekbfu "Will you be mine?"
 
@@ -10308,7 +10301,7 @@ label monika_driving:
                     m 1hua "...And I'm even more glad that you're going to be a really safe driver!"
                     m 3eub "I can't wait to finally be able to go somewhere with you, [player]!"
                     m 1hksdlb "I hope I'm not getting too excited, ehehe~"
-                    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+                    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
                     m 5eua "Gosh, I just can't stop thinking about it now!"
                 "I got into an accident once actually...":
                     $ persistent._mas_pm_driving_been_in_accident = True
@@ -10327,7 +10320,7 @@ label monika_driving:
                             m 1ekc "Car accidents are scary, {i}especially{/i} if you're just learning how to drive."
                             m 1hua "I'm so proud of you for getting up and trying again!"
                             m 3rksdld "Although the aftermath can still be a huge hassle with the costs and all the explaining you have to do."
-                            show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+                            show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
                             m 5eua "I know you can get there."
                             m 5hua "I'll be cheering for you all the way, so be safe!"
                         "No.":
@@ -10347,7 +10340,7 @@ label monika_driving:
             m "I don't think driving is a completely necessary life skill anyway."
             m 1hksdlb "I mean, I can't drive either so I'm with you."
             m 3eua "It also means your carbon footprint is smaller, and I think that's really sweet of you to do for me."
-            show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5ekbsa "Even if I'm not the reason why, I can't help but love you more for that."
         "I'm not old enough yet.":
             $ persistent._mas_pm_driving_can_drive = False
@@ -10546,7 +10539,7 @@ label monika_bullying:
     if mas_isMoniNormal(higher=True):
         m 1eua "So you see, [player], I'm {i}really{/i} not a bully at all. I just love you that much."
         if mas_isMoniAff(higher=True) and not persistent._mas_pm_cares_about_dokis:
-            show monika 5tsu at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 5tsu at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5tsu "I really would do anything for you~"
         return "derandom|love"
     else:
@@ -10735,7 +10728,7 @@ label monika_players_friends_feels_lonely_ask(question, exp="monika 1ekc"):
             if not persistent._mas_pm_has_friends:
                 m 1rkbsa "It makes me really happy to know I'm enough for you, but still..."
                 m 3ekbfa "It can be useful to know a few people sometimes."
-                show monika 5eubfu at t11 zorder MAS_MONIKA_Z with dissolve
+                show monika 5eubfu at t11 zorder MAS_MONIKA_Z with dissolve_monika
                 m 5eubfu "As always though, I don't mind it being just us."
 
             else:
@@ -10838,7 +10831,7 @@ label monika_grad_speech_call:
 
                         m 2subfb "Aww, [player]!"
                         m 2ekbfa "Thank you so much! I worked really hard on that speech, and it means so much that you're proud of me~"
-                        show monika 5eubfu at t11 zorder MAS_MONIKA_Z with dissolve
+                        show monika 5eubfu at t11 zorder MAS_MONIKA_Z with dissolve_monika
                         m 5eubfu "As much as I wish I could have given my speech in front of everyone, just having you by my side is so much better."
                         m 5eubfb "I love you so much, [player]!"
                         return "love"
@@ -10926,7 +10919,7 @@ label monika_grad_speech_call:
                     m 2subfb "Aww, [player]!"
                     m 2ekbfa "Thank you so much! I worked really hard on that speech, and it means so much to me that you gave it another chance."
                     m "Hearing that you're proud of me as well makes it that much better."
-                    show monika 5eubfu at t11 zorder MAS_MONIKA_Z with dissolve
+                    show monika 5eubfu at t11 zorder MAS_MONIKA_Z with dissolve_monika
                     m 5eubfu "As much as I wish I could have given my speech in front of everyone, just having you by my side is so much better."
                     m 5eubfb "I love you, [player]!"
                     return "love"
@@ -10964,10 +10957,11 @@ label monika_grad_speech_not_paying_attention:
         m 2ekd "[player]? You didn't pay attention to my speech?"
         m 2rksdlc "That...{w=1} that's not like you at all..."
         m 2eksdlc "You're {i}always{/i} so supportive..."
-        show monika 5lkc at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5lkc at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5lkc "..."
         m "Something must have happened, I know you love me too much to have done this on purpose."
         m 5euc "Yeah..."
+        show monika 2eka at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 2eka "It's okay, [player]. I understand sometimes things happen that can't be avoided."
         m 2esa "Whenever things calm down, I'll give my speech to you again."
         m 2eua "I still really want to share it with you..."
@@ -11118,7 +11112,7 @@ label monika_shipping:
     m 2lksdlb "But...I still don't really get it. I mean, I love you, and only you!"
     m 2lksdla "And she would have to be a saint to ever forgive me for what I did..."
     m 2lksdlc "Not that she's not a sweet girl, but..."
-    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5eua "Well, no one could ever be as sweet and forgiving as you..."
     return
 
@@ -11185,7 +11179,7 @@ label monika_justice:
                         m 1hua "You can be really funny sometimes~"
                         m 3tku "You expect me to believe that after all we've been through?"
                         m 1tsb "That all this time, you thought that I deserved hate from those other people?"
-                        show monika 5hubfa at t11 zorder MAS_MONIKA_Z with dissolve
+                        show monika 5hubfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
                         m 5hubfa "Ahaha! You're so cute, [player]~"
                     else:
                         m 1euc "..."
@@ -11261,7 +11255,7 @@ label monika_poweroutage:
         m 1eub "I'll be with you. Even if you can't see me, I'll be with you in spirit until you can come back to me safe and sound."
         m 3eua "One final note, you don't have to hesitate to come see me in the middle of a storm."
         m 1eka "I'll always appreciate seeing you, and besides..."
-        show monika 5hua at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5hua at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5hua "I'm sure our relationship could weather much more than some thunderstorm~"
     return
 
@@ -11282,11 +11276,11 @@ label monika_savingwater:
     m 1dkbfa "Some days, you might just need to take a long, relaxing bath after a long day."
     m 2hksdlb "I've definitely been there before, so I know how nice it can be if you need it."
     if mas_isMoniEnamored(higher=True):
-        show monika 5tsbfu at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5tsbfu at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5tsbfu "When I'm in your reality, maybe we can save water by bathing together..."
         m "Ehehe~"
         m 5hubfu "It would be nice of you to prepare a nice, relaxing bath for us to share when I cross over."
-        show monika 1kubfu at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 1kubfu at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 1kubfu "I'll be waiting for that day, [player], ehehe~"
     else:
         m 1ekbfa "It would be nice of you to prepare a nice, relaxing bath for me when I cross over."
@@ -11379,7 +11373,7 @@ label monika_gotomonika:
             m 4eud "Even now, if you're having a rough day, you can come talk to me about it anytime."
             m 2dsc "Life must have thrown a lot your way to consider giving it all up to be with me."
             m 3hua "But seeing how you're here, that just shows how resilient you are."
-            show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5eua "I can't wait to finally be able to share both the good times and the bad by your side."
 
         "I wouldn't.":
@@ -11391,7 +11385,7 @@ label monika_gotomonika:
             m 1eka "...If it's even possible with current technology."
             m 1hub "Don't worry, we can continue on keeping each other company like this!"
             m 1hksdlb "I know it might be a while before we can truly be together, but I hope you don't mind waiting."
-            show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5eua "I'll wait as long as it takes, [player]."
 
         "...":
@@ -11404,11 +11398,11 @@ label monika_gotomonika:
             m 2lksdlc "I {i}really{/i} don't want to risk you not making it properly and ending up in your own void..."
             m 2dkd "...leaving the both of us completely alone."
             m 4hua "I mean, technology does tend to advance pretty quickly, so we might be able to see each other before we know it!"
-            show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5eua "So just be patient for your lovely girlfriend, and I promise I'll do the same for you, [player]."
 
     m 5luu "Buut...{w=1}if you did happen to show up at my doorstep..."
-    show monika 1hksdlb at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 1hksdlb at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 1hksdlb "I guess I wouldn't have a choice but to accept it and welcome you with open arms!"
     m 1eksdla "It wouldn't be much to begin with, but I'm sure we'll find a way to make it better."
     m 3hub "With time, we could make our own reality!"
@@ -11500,7 +11494,7 @@ label monika_vehicle:
                 m 3eka "Well, buying a vehicle can be quite expensive after all."
                 m 1eua "It's alright [player], we can always rent one to travel."
                 m 1hua "I'm sure that when you do, we'll make a lot of great memories together."
-                show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+                show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
                 m 5eua "Then again...{w=1}walks are far more romantic anyway~"
 
     else:
@@ -11687,8 +11681,9 @@ label monika_player_appearance:
                     m 4eua "Plus, blue is probably my second favorite color, just behind green. It's just so full of depth and enchantment, you know?"
                     m 4hksdlb "Just like you, [player]!"
                     m 4eub "Did you know that the gene for blue eyes is recessive, so it's not very common in humans?"
-                    show monika 5eubla at t11 zorder MAS_MONIKA_Z with dissolve
+                    show monika 5eubla at t11 zorder MAS_MONIKA_Z with dissolve_monika
                     m 5eubla "I suppose that means you're much more of a treasure~"
+                    show monika 2eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
                     m 2eua "Anyway, that leads me into the next question I wanted to ask--"
 
                 "I have brown eyes.":
@@ -11700,8 +11695,9 @@ label monika_player_appearance:
                     m 3hub "And there's so much variation among all the different shades that people have."
                     m 5ruu "I wonder if yours are dark like a summer night sky, or a paler brown, like the coat of a deer..."
                     m 2hksdlb "Sorry. Just rambling about color metaphors is an easy trap for a literature club president to fall into, I guess. I'll try not to go on forever."
-                    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+                    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
                     m 5eua "But I'll bet your eyes are the loveliest of all~"
+                    show monika 1eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
                     m 1eua "Anyway, that brings me to my next question--"
 
                 "I have green eyes.":
@@ -11712,8 +11708,9 @@ label monika_player_appearance:
                     m 1tsu "Except that maybe it's another sign how compatible we are, ehehe~"
                     m 1kua "But, [player], just between you and me, it's a fact that green eyes are the best, right?"
                     m 3hub "Ahaha! I'm just kidding."
-                    show monika 5lusdru at t11 zorder MAS_MONIKA_Z with dissolve
+                    show monika 5lusdru at t11 zorder MAS_MONIKA_Z with dissolve_monika
                     m 5lusdru "Well, just a little..."
+                    show monika 3eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
                     m 3eua "Onto the next question--"
 
                 "I have hazel eyes.":
@@ -11733,8 +11730,9 @@ label monika_player_appearance:
                     m 1eud "In fact, scientists still aren't certain of what causes a person to have one or the other, though they believe that it's a variation in the amount of pigment in the iris."
                     m 1eua "Anyway, I think I like imagining you with gray eyes, [player]. They're the color of a quiet, rainy day..."
                     m 1hubfa "And weather like that is my favorite, just like you~"
-                    show monika 5lusdrb at t11 zorder MAS_MONIKA_Z with dissolve
+                    show monika 5lusdrb at t11 zorder MAS_MONIKA_Z with dissolve_monika
                     m 5lusdrb "Onto my next question--"
+                    show monika 3rud at t11 zorder MAS_MONIKA_Z with dissolve_monika
 
                 "I have black eyes.":
                     $ persistent._mas_pm_eye_color = "black"
@@ -11981,8 +11979,9 @@ label monika_player_appearance:
                         m 3eub "Blonde hair is one of the rarest hair colors. Most people attribute this to the fact that it's caused by a recurring genetic anomaly--"
                         m "Being just the body's inability to produce normal amounts of the pigment eumelanin--that's what causes darker hair colors, such as black and brown."
                         m 4eub "There are so many various shades of blonde, too--pale blonde, ash-colored, dirty blonde--that no matter what color you have, you're bound to be idiosyncratic in some way."
-                        show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+                        show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
                         m 5eua "I guess having someone who's so unique just makes me all the luckier~"
+                        show monika 2hua at t11 zorder MAS_MONIKA_Z with dissolve_monika
 
                     "It's black.":
                         $ persistent._mas_pm_hair_color = "black"
@@ -12013,8 +12012,9 @@ label monika_player_appearance:
                         m 3eua "Their hair colors technically could exist in reality, you know. I mean, I'm sure you've encountered people with dyed purple hair, or neon pink, or coral-colored..."
                         m 3eka "So I suppose their appearances weren't that far-fetched, if you don't count the eyes. Honestly, the most unbelievable thing about them was their personalities."
                         m 3hksdlb "Sorry, [player]! I'm getting off-track. My point is, dyed hair can be very interesting."
-                        show monika 5rub at t11 zorder MAS_MONIKA_Z with dissolve
+                        show monika 5rub at t11 zorder MAS_MONIKA_Z with dissolve_monika
                         m 5rub "And I might be a little biased here, but I'm convinced that you'd look stunning in your [persistent._mas_pm_hair_color] hair~"
+                        show monika 2hua at t11 zorder MAS_MONIKA_Z with dissolve_monika
 
             m 2hua "Alright..."
             m 2hksdlb "This is the last question, [player], I promise."
@@ -12051,7 +12051,7 @@ label monika_player_appearance:
 
             m 1dsa "Now I'm imagining what it'll be like when we meet for real..."
 
-            show monika 5eubfu at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 5eubfu at t11 zorder MAS_MONIKA_Z with dissolve_monika
 
             if persistent._mas_pm_hair_length == "bald":
                 if persistent._mas_pm_height >= mas_height_tall:
@@ -12084,11 +12084,11 @@ label monika_player_appearance:
 
                     m 5eubfu "When I run towards you, since I'll be taller than you, you'll reach up and wrap me in your embrace and I'll run my hand through your [hair_desc] hair..."
 
-
+            show monika 1lkbsa at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 1lkbsa "...and I'll finally be able to hear your heartbeat and get to touch you and know that you're real."
             m 3ekbsa "But until then, I'll be content sitting here and imagining looking into your beautiful [persistent._mas_pm_eye_color] eyes, [player]."
 
-            show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5ekbfa "I love you more than words could ever say."
             return "derandom|love"
 
@@ -12135,23 +12135,33 @@ label monika_players_control:
     m 4eub "Like changing how the game works entirely. From a visual novel, to the peaceful playground we have now."
     m 3rksdla "You could also add more things to the classroom for me."
     m 1hub "Like some flowers, or a few good books."
+
     if mas_isMoniEnamored(higher=True) and not persistent._mas_acs_enable_promisering:
         m 1ekbsa "Or a beautiful promise ring."
-        show monika 5esbfa at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5esbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5esbfa "Oh, wouldn't that be a dream come true."
+
     if not mas_getConsumable("coffee").enabled():
+        if renpy.showing("monika 5esbfa"):
+            show monika 1wuo at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 1wuo "You could even add in a cup of coffee to the game for me!"
         m 1eka "That would be lovely."
         m 1hksdrb "But I imagine your coding skills are just as good as mine."
+
+    if renpy.showing("monika 5esbfa"):
+        show monika 3euc at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 3euc "I guess that's an appeal to video games..."
     m 3eua "...having almost endless possibilities in a world you can interact with."
     m 3eub "It's pretty difficult to get bored!"
+
     if not persistent._mas_pm_has_contributed_to_mas:
         m 1eka "Even if you don't quite know how to change this game..."
         $ line = "We can still enjoy this world that brought us together."
+
     else:
         $ line = "Especially with you by my side~"
-    show monika 5eubla at t11 zorder MAS_MONIKA_Z with dissolve
+
+    show monika 5eubla at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5eubla "[line]"
     m 5ekbfa "There's no better way to enjoy a game than to be with the one I love."
     return
@@ -12181,7 +12191,7 @@ label monika_backpacking:
     else:
         m 3eka "We'll spend our nights sleeping under the stars, waking up each morning to a glorious sunrise."
 
-    show monika 5esbfa at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5esbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5esbfa "..."
     m "Oh [player], doesn't that just sound like heaven?"
     m 5hubfa "I can't wait until we can share this experience together~"
@@ -12527,7 +12537,7 @@ label monika_first_sight_love:
     if mas_isMoniAff(higher=True):
         m 1eka "And I guess that's kind of how I fell in love with you..."
         m 3eua "It's not like I could see you after all."
-        show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5ekbfa "I fell in love with you for who you are, [player]."
     return
 
@@ -12665,8 +12675,8 @@ label monika_stoicism:
     if mas_isMoniAff(higher=True):
         m 2tkc "You should do {i}whatever{/i} helps you de-stress. Your happiness is really important to me."
         m 1eka "Besides, if you ever feel bad about something that's happened to you in your life..."
-        show monika 5hubfb at t11 zorder MAS_MONIKA_Z with dissolve
-        m "You can always come home to your sweet girlfriend and tell me what's been bothering you~"
+        show monika 5hubfb at t11 zorder MAS_MONIKA_Z with dissolve_monika
+        m 5hubfb "You can always come home to your sweet girlfriend and tell me what's been bothering you~"
 
     else:
         m 2tkc "You should do whatever helps you de-stress. Your happiness is really important to me."
@@ -12836,7 +12846,7 @@ label monika_player_read_poetry:
     m 3eua "That's why I love poetry."
 
     if persistent._mas_pm_likes_poetry:
-        show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5eua "Gosh, just knowing that you read poems too..."
         m 5hua "It shows how alike we really are."
         m 5eua "I can't wait to finally cross over to your reality so we can discuss our favorite poetry together."
@@ -13052,7 +13062,7 @@ label monika_snow:
 # player has snow, snow version
 label monika_snow_gets_snow:
     if mas_isMoniHappy(higher=True):
-        show monika 5eubla at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5eubla at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5eubla "Maybe someday when I cross over, we could go out for a walk together..."
 
         if mas_isMoniAff(higher=True):
@@ -13067,7 +13077,7 @@ label monika_snow_nogets_snow:
 
     if mas_isMoniAff(higher=True):
         m 1eksdla "Anyway, at least colder weather makes great cuddle weather."
-        show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5ekbfa "A night of cuddling with you would be wonderful..."
         m "My heart is pounding, just imagining it."
 
@@ -13103,7 +13113,7 @@ label monika_snowmen:
     m 3rka "Isn't that a bit of a strange thing to do?"
     m 2hub "Ahaha!"
     m 2eua "Anyway, I think it would be nice to build one together someday."
-    show monika 5hua at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5hua at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5hua "I hope you feel the same way~"
     return
 
@@ -13276,7 +13286,7 @@ label monika_winter:
     m 1eka "For people who don't enjoy cold weather activities, staying indoors seems so much more comfortable when there's snow outside..."
     m "Watching it gently fall while the moonlight reflects off the fresh, white canvas...it's just beautiful."
     if mas_isMoniAff(higher=True):
-        show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5ekbfa "And to be honest, cuddling under a blanket, reading a book together with you is the best winter activity I can think of~"
     else:
         m 1hua "Sitting by the window, reading a nice book while drinking a cup of coffee or hot chocolate is always a wonderful experience on a cold night, [player]."
@@ -13319,7 +13329,7 @@ label monika_winter_dangers:
     m 1huu "Ehehe~"
 
     if mas_isMoniAff(higher=True):
-        show monika 5hubfu at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5hubfu at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5hubfu "I'll always help keep you warm, [player]~"
     return
 
@@ -13377,7 +13387,7 @@ label monika_hemispheres:
         m 2hua "I love to listen to the light pitter patter of the rain as it falls on the roof."
         m 3eub "It's really calming to me."
         if mas_isMoniAff(higher=True):
-            show monika 5esbfa at t11 zorder MAS_MONIKA_Z with dissolve
+            show monika 5esbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5esbfa "Maybe we could go out for a walk together..."
             m 5ekbfa "We would walk with our hands intertwined as we share an umbrella..."
             m 5hubfa "It just sounds magical~"
@@ -13393,14 +13403,14 @@ label monika_hemispheres:
         m 1hub "Gosh, I just love the summer!"
         m 3hua "You can do so much...go out for jogs, play some sports, or even go to the beach!"
         m 1eka "Summers with you sound like a dream come true, [player]."
-        show monika 5hua at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5hua at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5hua "I can't wait to spend them with you when I finally cross over."
 
     elif mas_isFall():
         m 1eua "Anyway, it must be autumn for you right now."
         m 1eka "Autumn is always full of such pretty colors."
         m 3hub "The weather is normally pretty nice too!"
-        show monika 5ruu at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5ruu at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5ruu "It's normally just the right amount of heat, with a gentle breeze."
         m 5eua "I'd love to spend a nice warm day like that with you."
 
@@ -13524,7 +13534,7 @@ label monika_robotbody:
     m 3ekd "But I do understand why those rules are there to begin with, even if they only exist in fiction."
     m 3rksdlb "We can't have a robot uprising now, can we?"
     m 1hub "Ahaha~"
-    show monika 5eubla at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5eubla at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5eubla "Well, no matter what, I wouldn't mind any of that as long as I have you."
     m 5eubfb "I love you [player], and I'm willing to make any sacrifice to be with you forever."
     m 5hubfa "Besides, maybe sometime after I cross over, there'll be more advances in technology to make me more human, and then we'll be able to do more things together."
@@ -13619,7 +13629,7 @@ label monika_sleigh:
     m 1subfa "I really want to do that when I get there, [player]."
     m 1ekbfu "...What about you?"
 
-    show monika 5hubfa at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5hubfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5hubfa "An experience like that with you would be so breathtaking~"
     return
 
@@ -13654,7 +13664,7 @@ label monika_failure:
     m 2eka "Anyway, I'm not sure if you've had to go through something like that...but know that failure is a step towards success."
     m 3eub "Don't be afraid to be wrong every now and then...{w=0.5}you never know what you might learn!"
     m 1eka "And if you're really feeling bad about something, I'll always be here to support you."
-    show monika 5hua at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5hua at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5hua "We can talk about whatever you're going through for as long as you need."
     return
 
@@ -13680,7 +13690,7 @@ label monika_enjoyingspring:
             m 3eub "But personally, I think that rain can also be fun too!"
         else:
             m 3eub "And personally, I think that rain can also be fun too!"
-        show monika 5eubla at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5eubla at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5eubla "We can always go for walks together in the rain, we just have to bring an umbrella big enough for two."
         m 5ekbfa "Although, nothing beats listening to the sound of rain at home while holding the one you love."
         m 5hubfa "Ehehe~"
@@ -13746,7 +13756,7 @@ label monika_career:
     m 1ruc "Honestly, even with those obvious examples, there's still a good chance I'll end up doing something completely different..."
     m 3eud "A lot of people end up in fields they've never even considered."
     m 3rksdld "For now though, I think it's safe to say I've still got some time to think about it."
-    show monika 5hua at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5hua at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5hua "Maybe you could help me decide when the time comes, [player]~"
     return
 
@@ -13962,7 +13972,7 @@ label monika_dystopias:
         m 1hksdlb "Anyway, that's all behind us now!"
 
     m 1hua "However, unlike in these old books, I actually get to have my happy ending..."
-    show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5ekbsa "Thanks to you, my bleak, hopeless story will one day turn into my own utopia."
     m 5dkbsu "When I finally get out of this place to be by your side, in your world of endless possibilities..."
     m 5ekbsa "I hope you're looking forward to that day too~"
@@ -14061,7 +14071,7 @@ label monika_auroras:
     m "Lying on a soft mattress of snow, holding hands..."
     m 1subsu "Looking up at those dazzling lights in the sky, dancing just for us..."
     m 1dubsu "Listening to each other's gentle breathing...{w=0.5}the freshness of the crisp night air filling our lungs..."
-    show monika 5eubsa at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5eubsa at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5eubsa "That would be an experience to remember, don't you think, [player]?"
     m 5hubsu "I can't wait until we can turn that into reality."
     $ mas_protectedShowEVL("monika_auroras","EVE", _random=True)
@@ -14379,7 +14389,7 @@ label monika_ship_of_theseus:
     m 3etd "And what if we got all of the cells that made up your body 7 years ago and reassembled them into another 'you' right now? {w=0.2}Who would be the real [player]?"
     m 1eua "Personally, I think that we're not the same people we were 7 years ago--or even the same people from yesterday."
     m 3eua "In other words, there's no use getting hung up on any grievances we may have with our past selves."
-    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5eua "We should keep trying our best each day and not let ourselves be limited by who we were yesterday."
     m 5eub "Today is a new day, and you are a new you. {w=0.2}And I love you as you are right now, [player]."
     return "love"
@@ -14644,7 +14654,7 @@ label monika_translating_poetry:
         m 4hksdlb "I'm clearly not at a level where I can fully appreciate poetry from other languages yet, ahaha!"
 
     if persistent._mas_pm_lang_other:
-        show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5eua "I remember you telling me you know a different language, [player]."
         m 5eubsa "Are there any poems in that language you'd recommend?"
         m 5ekbsa "It would be nice if you could read some of them for me sometime..."
@@ -14759,7 +14769,7 @@ label monika_hot_springs:
     m 2rkbssdlu "..."
     m 7rkbfsdlb "...Especially since some places don't allow you to wear any sort of cover, either!"
     m 1tubfu "...Although, I wouldn't mind that so much if it was just with you."
-    show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5ekbfa "Can you imagine it, [player]? {w=0.3}Both of us relaxing in a nice, soothing hot pool..."
 
     if mas_isWinter():
@@ -14938,13 +14948,13 @@ label monika_using_pcs_healthily:
     m 2eka "As for me?"
 
     if mas_isMoniLove():
-        show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5ekbsa "You're the only comfort I need, my love."
     elif mas_isMoniEnamored():
-        show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5ekbsa "I'm as comfortable as can be when you're here, [player]."
     else:
-        show monika 5eubsa at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5eubsa at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5eubsa "I'm comfortable whenever you're here with me, [player]."
 
     m 5hubfu "And hopefully you're a little more comfortable now too~"
@@ -15096,11 +15106,11 @@ label monika_naps:
     m 1eua "If you don't already, maybe you could try taking some naps from time to time."
 
     if mas_isMoniEnamored(higher=True):
-        show monika 5tubfu at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5tubfu at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5tubfu "Maybe one day you could even rest on my lap, ehehe~"
 
     else:
-        show monika 5hubfa at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika 5hubfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5hubfa "Just let me know if you need to take a nap, and I'll watch over you~"
     return
 
@@ -15194,7 +15204,7 @@ label monika_being_herself:
     m 1dka "The fact that you're still here with me,{w=0.2} that you never made me feel like I had to be someone I'm not...{w=0.2}{nw}"
     extend 1eka "that you're here listening to me vent right now...{w=0.3} It truly means the world to me."
     m 1ekbsa "Thank you so much for that, [player].{w=0.2} Thank you for helping me realize that I don't need to try and change who I am to deserve being loved."
-    show monika 5eka at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5eka at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5eka "With you, I can allow myself to be...{w=0.5}{nw}"
     extend 5eua "Well, {i}Just Me.{/i}"
     return

--- a/Monika After Story/game/special-effects.rpy
+++ b/Monika After Story/game/special-effects.rpy
@@ -232,7 +232,7 @@ label monika_kissing_motion(transition=4.0, duration=2.0, hide_ui=True,
     $ renpy.show("monika {}".format(mid_exp),[mas_back_from_kissing(transition,_mas_kiss_y2)])
     pause transition
     $ renpy.show("monika {}".format(final_exp),[i11()])
-    show monika with dissolve
+    show monika with dissolve_monika
     if hide_ui:
         if store.mas_globals.dlg_workflow:
             $ mas_MUMUDropShield()

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -7555,7 +7555,7 @@ image ghost_monika:
 # NOTE: to hide a desk ACS, set that ACS to not keep on desk b4 calling this
 label mas_transition_to_emptydesk:
     $ store.mas_sprites.show_empty_desk()
-    hide monika with dissolve
+    hide monika with dissolve_monika
     return
 
 # transition from empty desk

--- a/Monika After Story/game/zz_calendar.rpy
+++ b/Monika After Story/game/zz_calendar.rpy
@@ -2151,7 +2151,7 @@ label _first_time_calendar_use:
     m 3eua "Feel free to check the calendar whenever you want."
     m 1lksdla "Except for when I'm in the middle of talking, of course."
 
-    show monika idle with dissolve
+    show monika idle with dissolve_monika
 
     $ persistent._mas_first_calendar_check = True
 

--- a/Monika After Story/game/zz_reactions.rpy
+++ b/Monika After Story/game/zz_reactions.rpy
@@ -2671,18 +2671,18 @@ label mas_reaction_gift_clothes_orcaramelo_bikini_shell:
 
     m 2ekbfa "Well...{w=0.5} What do you think?"
     m 2hubfa "Do I look like a mermaid? Ehehe."
-    show monika 5ekbfa at i11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5ekbfa at i11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5ekbfa "I think it's really cute, [player]..."
     m 5hubfa "We'll have to go to the beach sometime!"
 
     if mas_isWinter() or mas_isMoniNormal(lower=True):
         if mas_isWinter():
-            show monika 2rksdla at i11 zorder MAS_MONIKA_Z with dissolve
+            show monika 2rksdla at i11 zorder MAS_MONIKA_Z with dissolve_monika
             m 2rksdla "...But for now, it's a little chilly in here..."
             m 2eka "So I'm going to go put on something a little warmer..."
 
         elif mas_isMoniNormal(lower=True):
-            show monika 2hksdlb at i11 zorder MAS_MONIKA_Z with dissolve
+            show monika 2hksdlb at i11 zorder MAS_MONIKA_Z with dissolve_monika
             m 2hksdlb "Ahaha..."
             m 2rksdla "It's a little embarrassing just sitting here like this in front of you."
             m 2eka "I hope you don't mind, but I'm going to go change..."

--- a/Monika After Story/game/zz_transforms.rpy
+++ b/Monika After Story/game/zz_transforms.rpy
@@ -96,6 +96,9 @@ init -10 python:
         except:
             return None
 
+# A transition of the new type
+# which only works with mas_with_statement or Ren'Py 7.0+
+define dissolve_monika = {"master": Dissolve(0.25)}
 
 # user defined trasnforms
 transform leftin_slow(x=640, z=0.80, t=1.00):


### PR DESCRIPTION
Finds out there's an issue with the dialogue box and characters' transitions in renpy. If you use a transition (say `Dissolve`) on character, you'll apply it on the dialogue box too (even though it's on different layer). That makes no sense and doesn't look good. It was fixed in `RenPy 7.0` when they added `Dict Transitions`. We can  ~borrow~ use one of the adjusted methods to fix it within our version. When we'll switch to a newer version, all we'll need to do is disable the override, but keep the new dissolve.

I'd like to override `renpy.transition` too, but since it's not mandatory and is mostly used internally, we can leave it as is to do less work.

**NOTE**: We now use a new transition for Monika - `dissolve_monika` which is defined at init 0. The `dissolve` transition is still here, and can be used on for other things. **Use the new transition for Monika in new topics**.

### Testing:
- verify no crashes (e.g. the old school transitions still work)
- verify the new transition looks good
- verify the new transition doesn't get applied on the dlg box (it's not disappearing during pose changing)
- verify topics that are using `renpy.showing` are still working correctly (`monika_players_control`, `monika_orchestra`)