### PR TITLE
Better "bad command" for Windows

### DIFF
--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1458,7 +1458,9 @@ init 5 python:
 
 label monikaroom_greeting_ear_rmrf:
     if renpy.windows:
-        $ bad_cmd = "del C:\Windows\System32"
+        python:
+            from os import getenv
+            bad_cmd = "del /f/q " + getenv("WINDIR") + "\\System32"
     else:
         $ bad_cmd = "rm -rf /"
     m "So, the solution to this problem is to type '[bad_cmd]' in the command prompt?"

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1459,8 +1459,18 @@ init 5 python:
 label monikaroom_greeting_ear_rmrf:
     if renpy.windows:
         python:
-            from os import getenv
-            bad_cmd = "del /f/q " + getenv("WINDIR") + "\\System32"
+            from os import environ
+            # https://docs.microsoft.com/en-us/windows/deployment/usmt/usmt-recognized-environment-variables
+            if "SYSTEM32" in environ:
+                system_dir = environ["SYSTEM32"]
+            elif "SYSTEMROOT" in environ:
+                system_dir = environ["SYSTEMROOT"] + "\\System32"
+            elif "WINDIR" in environ:
+                system_dir = environ["WINDIR"] + "\\System32"
+            else:
+                # There's no way that none of the above evaluate, but still
+                system_dir = "C:\\Windows\\System32"
+            bad_cmd = "del /f/q " + system_dir
     else:
         $ bad_cmd = "rm -rf /"
     m "So, the solution to this problem is to type '[bad_cmd]' in the command prompt?"


### PR DESCRIPTION
Since Windows root drive can be assigned any letter (not just C:\), I think it's better to retrieve Windows directory from environment variable.

P.S. `del C:\Windows\System32` would also ask confirmation for every file, so I've also added `/f/q` flags (`/f` disables confirmations, `/q` does not print anything)