### PR TITLE
Minor enhancements

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -3465,10 +3465,12 @@ init -991 python in mas_utils:
     import platform
     import time
     import traceback
+    import sys
     #import tempfile
     from os.path import expanduser
     from renpy.log import LogFile
     from bisect import bisect
+    from contextlib import contextmanager
 
     # LOG messges
     _mas__failrm = "[ERROR] Failed remove: '{0}' | {1}\n"
@@ -3638,6 +3640,23 @@ init -991 python in mas_utils:
         except Exception as e:
             writelog(_mas__failcp.format(oldpath, newpath, str(e)))
         return False
+
+
+    @contextmanager
+    def stdout_as(outstream):
+        """
+        Context manager that can replace stdout temporarily. Use with the
+        with statement (python).
+
+        IN:
+            outstream - the stream to temporarily replace sys.stdout with
+        """
+        oldout = sys.stdout
+        sys.stdout = outstream
+        try:
+            yield
+        finally:
+            sys.stdout = oldout
 
 
     def writelog(msg):

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -2193,8 +2193,10 @@ label call_next_event:
             else:
                 $ display_notif(m_name, mas_other_notif_quips, "Topic Alerts")
 
+        $ mas_globals.this_ev = ev
         call expression event_label from _call_expression
-        $ persistent.current_monikatopic=0
+        $ persistent.current_monikatopic = 0
+        $ mas_globals.this_ev = None
 
         #if this is a random topic, make sure it's unlocked for prompts
         $ ev = evhand.event_database.get(event_label, None)

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -77,6 +77,9 @@ init -1 python in mas_globals:
     returned_home_this_sesh = bool(store.persistent._mas_moni_chksum)
     #Whether or not this sesh was started by a returned home greet
 
+    this_ev = None
+    # the current topic, but as event object. may be None.
+
 init 970 python:
     import store.mas_filereacts as mas_filereacts
 


### PR DESCRIPTION
# Key changes
* added `mas_utils.stdout_as` - useful when using python functions that only print to stdout, like `dis.dis`. 
* added `mas_globals.this_ev` - this is set to the current Event object in `call_next_event`. Like how `persistent.current_monikatopic` is set to the label, but the EV is not persistent. **NOTE:** Since this is only set in `call_next_event`, its not accurate when using delegate topics. If a delegated topic wants to use this, the delegate topic should set the variable accordingly. 

# Testing
* Verify that the `mas_globals.this_ev` is set to the correct event object when viewing regular, non-delegate topics (or greetings/farewells, and anything else that uses `call_next_event`). Also verify the var is set to None in all other cases. 

Don't really have any in-game testing instructions for the util function. You could paste this in the console if you want to try it out:
```python
import dis
with open("testfile.out", "w") as outfile:
    with mas_utils.stdout_as(outfile):
        dis.dis(<insert a mas function you want to look at>)
```
then open the text file and see bytecode. (If you are launching with renpy SDK, this code will write the file in the root of the SDK's folder)