### PR TITLE
Validate suntime data in more locations

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -393,6 +393,19 @@ init python:
             renpy.with_statement(Dissolve(1.0))
 
 
+    def mas_validate_suntimes():
+        """
+        Validates both persistent and store suntimes are in a valid state.
+        Sunrise is always used as the lead if a reset is needed.
+        """
+        if (
+            mas_suntime.sunrise > mas_suntime.sunset
+            or persistent._mas_sunrise > persistent._mas_sunset
+        ):
+            mas_suntime.sunset = mas_suntime.sunrise
+            persistent._mas_sunset = persistent._mas_sunrise
+
+
     def show_calendar():
         """RUNTIME ONLY
         Opens the calendar if we can
@@ -1963,6 +1976,10 @@ label ch30_reset:
 
     #Check BGSel topic unlocked state
     $ mas_checkBackgroundChangeDelegate()
+
+    # verify suntimes are correct
+    # NOTE: must be before background build update
+    $ store.mas_validate_suntimes()
 
     # build background filter data and update the current filter progression
     $ store.mas_background.buildupdate()

--- a/Monika After Story/game/zz_hotkeys.rpy
+++ b/Monika After Story/game/zz_hotkeys.rpy
@@ -219,9 +219,15 @@ init python:
             scope - temp space used in `_mas_game_menu_start`
         """
         # call backs for the game menu
+
+        # if we are changing animation state, re-draw spaceroom masks
         if scope.get("disb_ani") != persistent._mas_disable_animations:
             mas_drawSpaceroomMasks(dissolve_masks=False)
 
+        # always clean current suntimes so they are not invalid
+        store.mas_validate_suntimes()
+
+        # rebuild backgrounds if the suntime has changed
         if (
                 scope.get("sr_time") != store.mas_suntime.sunrise
                 or scope.get("ss_time") != store.mas_suntime.sunset


### PR DESCRIPTION
Any issues with `buildupdate()` is likely a problem with the internal suntime values. `buildupdate` and its children assume the suntime values are valid and do not have any handling for bad suntimes. There is no plan to add additional handling since building bg slices can be performance intensive (O(n^2))

# Key changes
* adds extra suntime validation to prevent invalid suntimes before `buildupdate()` is called

# testing
* verify sliding/clicking suntimes in settings menu works
* verify no crash when attempting to break suntimes by clicking on the sunrise/sunset slider in a way that could result in an invalid state
* could also set `persistent._mas_sunrise` / `persistent._mas_sunset` to an invalid value and restarting the game. Startup should validate suntimes before `buildupdate` is called.

