### PR TITLE
Lil fix for the new substitution

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -119,8 +119,11 @@ python early:
                         obj = getattr(obj, i)
 
                     else:
-                        if not isinstance(i, long):
+                        # convert the accessor only if obj isn't a dict
+                        # so the accessor is always a long for other iterables
+                        if not isinstance(obj, dict):
                             i = long(i)
+
                         obj = obj[i]
 
             return obj, first


### PR DESCRIPTION
In #5816 I missed one thing when tested it - if we convert all accessors into `long`s, we lose the ability to access `dict`s. There are several ways to fix it, but the most simple and straightforward is to check the type and don't do anything for `dict`s.

### Testing:
- verify that you can access **dictionaries** and **other** iterables (like lists) in substitution