### PR TITLE
New minigame - Staring contest

### DIFF
--- a/Monika After Story/game/staring_minigame.rpy
+++ b/Monika After Story/game/staring_minigame.rpy
@@ -1,0 +1,80 @@
+"""
+TODOs in no particular order:
+    put this in the game menu
+    unlock condition - the staring topic
+    stalemate - when the screen is clicked short time (eg 0.2s) before moni loses
+    glitch path - monika gets frustrated after losing a few times and tries to spook the player
+    fix monika's position in staring_loop
+    add dialogue
+        how to lose
+        randomized quips on win/loss
+"""
+
+screen staring_loop(sprcode,dur):
+    """
+    Shows Monika with a non-blinking expression for a given period.
+    Interrupted by clicking.
+    
+    IN:
+        sprcode - expression sprite code
+        dur - duration for which the expression is shown
+
+    OUT:
+        string
+            "keep_going" if time runs out
+            "player_loss" if screen is clicked before timeout
+    """
+    timer dur action Return("keep_going")
+    imagemap:
+        # moni keeps getting shoved into the corner and idk how to fix that
+        ground "monika "+ sprcode +"_static"
+        hotspot (640,360,1280,720) action Return("player_loss") # should cover the whole screen - check this
+
+label game_staring:
+
+    m "You'd like to have a staring contest with me?"
+    m "Alright, but you better be prepared to lose, ahaha~"
+
+    # prevent interactions
+    $ mas_RaiseShield_core()
+    $ mas_OVLHide()
+    $ disable_esc()
+
+    $ staring_keep_going = True
+    $ staring_step = 0          # monika's strain level
+    $ exp_list = ["2tua","2eua","2esa","2euc","2efa","2efsdlc","2ffsdlc"]     # increasingly strained expressions
+    hide monika with dissolve_monika
+
+    while staring_keep_going:
+        # main loop - goes through the 7 expressions in random length timesteps
+        # total duration between 21 and 63 seconds
+        call screen staring_loop(exp_list[staring_step],random.randint(3,9))
+
+        if (_return == "keep_going"):
+            if staring_step < 6:
+                # go to next step
+                $ staring_step += 1
+            else:
+                # monika's loss
+                $ staring_keep_going = False
+                $ monika_win = False
+
+        else:
+            # player's loss
+            $ staring_keep_going = False
+            $ monika_win = True
+
+    # drop shields
+    $ mas_DropShield_core()
+    $ mas_OVLShow()
+    $ enable_esc()
+
+    if monika_win:
+        show monika 2tub at i11 zorder MAS_MONIKA_Z
+        m "Told you so.{w=0.3}{nw}"
+        extend 2hua" Ahaha~"
+    else:
+        show monika 2hfsdld at i11 zorder MAS_MONIKA_Z
+        m "Bleh."
+
+return

--- a/Monika After Story/game/staring_minigame.rpy
+++ b/Monika After Story/game/staring_minigame.rpy
@@ -1,23 +1,12 @@
-"""
-TODOs in no particular order:
-    put this in the game menu
-    unlock condition - the staring topic
-    stalemate - when the screen is clicked short time (eg 0.2s) before moni loses
-    glitch path - monika gets frustrated after losing a few times and tries to spook the player
-    fix monika's position in staring_loop
-    add dialogue
-        how to lose
-        randomized quips on win/loss
-"""
 
 screen staring_loop(sprcode,dur):
     """
     Shows Monika with a non-blinking expression for a given period.
     Interrupted by clicking.
-    
+
     IN:
         sprcode - expression sprite code
-        dur - duration for which the expression is shown
+        dur - duration in seconds for which the expression is shown
 
     OUT:
         string
@@ -30,6 +19,7 @@ screen staring_loop(sprcode,dur):
         ground "monika "+ sprcode +"_static"
         hotspot (640,360,1280,720) action Return("player_loss") # should cover the whole screen - check this
 
+# entry point
 label game_staring:
 
     m "You'd like to have a staring contest with me?"

--- a/Monika After Story/game/zz_games.rpy
+++ b/Monika After Story/game/zz_games.rpy
@@ -172,6 +172,21 @@ label mas_piano:
     call mas_piano_start
     return
 
+init 5 python:
+    addEvent(
+        Event(
+            persistent._mas_game_database,
+            eventlabel="mas_staring",
+            prompt="Staring contest"
+        ),
+        code="GME",
+        restartBlacklist=True
+    )
+
+label mas_staring:
+    call game_staring
+    return
+
 label mas_pick_a_game:
     # we can assume that getting here means we didnt cut off monika
     $ mas_RaiseShield_dlg()


### PR DESCRIPTION
Look at Monika harder than ever before.

Monika will stare at you for a randomized period of time (should average out around 40 seconds as of right now) while cycling through increasingly strained expressions. 
Once she goes through them all, the player wins. 
Player can signal their loss by clicking the screen at any time during the main loop.

Some of the code was taken from the islands script and might be sub-optimal for this use.

Stuff to do:

- [ ] Make this unlockable - via #6123
- [ ] Add stalemate option - procs if the player loses short time (eg 0.2s) before Monika does
- [ ] Glitch path - Monika gets frustrated after losing a few times in a row and tries to spook the player
- [ ] Add dialogue
