### PR TITLE
Backgrounds have ex_props

### DIFF
--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1093,7 +1093,7 @@ init 5 python:
             or mas_isplayer_bday()
             or mas_isF14()
         )
-        and persistent._mas_current_background == "spaceroom"
+        and store.mas_background.EXP_TYPE_OUTDOOR not in mas_getBackground(persistent._mas_current_background, mas_background_def).ex_props
     ):
 
         ev_rules = dict()

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -5,6 +5,11 @@ default persistent._mas_background_MBGdata = {}
 #Defaults to def (spaceroom)
 default persistent._mas_current_background = "spaceroom"
 
+init -5 python in mas_background:
+    #marks this background as an outdoor type (disables opendoor for it)
+    #value: ignored
+    EXP_TYPE_OUTDOOR = "outdoor"
+
 #START: Class definition
 init -10 python:
 
@@ -1848,6 +1853,7 @@ init -10 python:
             unlocked=False,
             entry_pp=None,
             exit_pp=None,
+            ex_props=None
         ):
             """
             Constructor for background objects
@@ -1892,6 +1898,10 @@ init -10 python:
 
                 exit_pp:
                     Exit programming point for this background
+                    (Default: None)
+
+                ex_props:
+                    Extra properties for backgrounds. If None, an empty dict is assigned
                     (Default: None)
             """
             # sanity checks
@@ -1942,6 +1952,12 @@ init -10 python:
             self.unlocked = unlocked
             self.entry_pp = entry_pp
             self.exit_pp = exit_pp
+
+            #Add ex_props
+            if ex_props is None:
+                ex_props = dict()
+
+            self.ex_props = ex_props
 
             # add to background map
             self.mas_background.BACKGROUND_MAP[background_id] = self
@@ -2532,6 +2548,19 @@ init 800 python:
     #Just set us to the normal room here
     mas_setBackground(mas_background_def)
 
+init python:
+    def mas_getBackground(background_id, default=None):
+        """
+        Gets a MASFilterableBackground by id
+
+        IN:
+            background_id - id of the background to get
+            default - default to return if not found
+
+        OUT:
+            MASFilterableBackground if found, None otherwise
+        """
+        return store.mas_background.BACKGROUND_MAP.get(background_id, default)
 
 #START: Programming points
 init -2 python in mas_background:

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -2548,6 +2548,7 @@ init 800 python:
     #Just set us to the normal room here
     mas_setBackground(mas_background_def)
 
+#NOTE: This is at init 0 so it can be used for conditionals in events/etc
 init python:
     def mas_getBackground(background_id, default=None):
         """


### PR DESCRIPTION
Adds ex_props to backgrounds for easier control over things like greetings.

This also allows the opendoor greeting to be excluded via the `EXP_TYPE_OUTDOOR` exprop. That way, if people opt to not use the spaceroom, but their own custom backgrounds, opendoor isn't just completely lost. (Opendoor only really makes sense for indoor locations so that's what we're using it with)

Also adds a `mas_getBackground()` function, which allows us to get backgrounds by id (and return a default) (Needed because backgrounds are set in ch30_reset)

## Testing:
- Verify opendoor greetings do not happen if a background is flagged with the `EX_TYPE_OUTDOOR` exprop
- Verify opendoor greetings work properly otherwise
- Verify no crashes