### PR TITLE
Fixes

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -1,9 +1,8 @@
 define persistent.demo = False
-define persistent.steam = False
 define config.developer = False #This is the flag for Developer tools
 
-init 1 python:
-    persistent.steam = "steamapps" in config.basedir.lower()
+define is_steam = "steamapps" in config.basedir.lower()
+# define persistent.steam = "steamapps" in config.basedir.lower()
 
 python early:
     import singleton
@@ -7273,16 +7272,7 @@ default persistent._mas_sensitive_mode = False
 #Amount of times player has reloaded in ddlc
 default persistent._mas_ddlc_reload_count = 0
 
-init python:
-    startup_check = False
-    try:
-        persistent.ever_won['hangman']
-    except:
-        persistent.ever_won['hangman']=False
-    try:
-        persistent.ever_won['piano']
-    except:
-        persistent.ever_won['piano']=False
+define startup_check = False
 
 default his = "his"
 default he = "he"
@@ -7295,6 +7285,10 @@ default guy = "guy"
 default him = "him"
 default himself = "himself"
 
+# Input characters filters
+define lower_letters_only = " abcdefghijklmnopqrstuvwxyz"
+define letters_only = " abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+define name_characters_only = " abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_'"
 
 #Default is NORMAL
 default persistent._mas_randchat_freq = mas_randchat.NORMAL

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -2003,7 +2003,7 @@ label monika_affection_nickname:
                 python:
                     inputname = mas_input(
                         _("So what do you want to call me?"),
-                        allow=" abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_",
+                        allow=name_characters_only,
                         length=10,
                         screen_kwargs={"use_return_button": True}
                     ).strip(' \t\n\r')

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -2060,7 +2060,7 @@ label greeting_amnesia:
     $ m_name = "Monika"
     m 1eua "Oh, hello!"
     m 1eub "My name is Monika."
-    $ fakename = renpy.input('What is your name?',length=15).strip(' \t\n\r')
+    $ fakename = renpy.input("What is your name?", allow=general_symbols_only, length=20).strip(' \t\n\r')
     m 1hua "Well, it's nice to meet you, [fakename]!"
     m 3eud "Say, [fakename], do you happen to know where everyone else is?"
     m 1ekc "You're the first person I've seen and I can't seem to leave this classroom."

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -2060,7 +2060,7 @@ label greeting_amnesia:
     $ m_name = "Monika"
     m 1eua "Oh, hello!"
     m 1eub "My name is Monika."
-    $ fakename = renpy.input("What is your name?", allow=general_symbols_only, length=20).strip(' \t\n\r')
+    $ fakename = renpy.input("What is your name?", allow=name_characters_only, length=20).strip(' \t\n\r')
     m 1hua "Well, it's nice to meet you, [fakename]!"
     m 3eud "Say, [fakename], do you happen to know where everyone else is?"
     m 1ekc "You're the first person I've seen and I can't seem to leave this classroom."

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -506,6 +506,7 @@ label mas_player_name_enter_name_loop(input_prompt):
     while not done:
         $ tempname = mas_input(
             "[input_prompt]",
+            allow=name_characters_only,
             length=20,
             screen_kwargs={"use_return_button": True}
         ).strip(' \t\n\r')
@@ -1726,7 +1727,7 @@ init 5 python:
             persistent.event_database,
             eventlabel="mas_steam_install_detected",
             conditional=(
-                "persistent.steam"
+                "store.is_steam"
             ),
             action=EV_ACT_QUEUE
         )

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -8,9 +8,6 @@ define mas_rev_unseen = []
 define mas_rev_seen = []
 define mas_rev_mostseen = []
 define testitem = 0
-define numbers_only = "0123456789"
-define lower_letters_only = "qwertyuiopasdfghjklzxcvbnm "
-define letters_only = "abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 define mas_did_monika_battery = False
 define mas_sensitive_limit = 3
 
@@ -7380,6 +7377,7 @@ label monika_orchestra:
             while not instrumentname:
                 $ instrumentname = mas_input(
                     "What instrument do you play?",
+                    allow=" abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_",
                     length=15,
                     screen_kwargs={"use_return_button": True}
                 ).strip(' \t\n\r')

--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -850,7 +850,7 @@ label forced_update_now:
     $ mas_updater.force = True
 
     # steam check
-    if persistent.steam and not persistent._mas_unstable_mode:
+    if is_steam and not persistent._mas_unstable_mode:
 
         $ mas_RaiseShield_core()
 
@@ -886,10 +886,10 @@ label forced_update_now:
 
 #This file goes through the actions for updating Monika After story
 label update_now:
-    $import time #this instance of time can stay
+    $ import time #this instance of time can stay
 
     # steam check
-    if persistent.steam and not persistent._mas_unstable_mode:
+    if is_steam and not persistent._mas_unstable_mode:
         return
 
     # screen check

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -410,6 +410,20 @@ label v0_11_4(version="v0_11_4"):
 
         #Unlock this fare
         mas_unlockEVL("bye_illseeyou", "BYE")
+
+        # In case someone updates from a really oudated version
+        for _key in ("hangman", "piano"):
+            if _key not in persistent.ever_won:
+                persistent.ever_won[_key] = False
+
+        # Adjust the conditional if needed
+        steam_install_detected_ev = mas_getEV("mas_steam_install_detected")
+        if (
+            steam_install_detected_ev is not None
+            and steam_install_detected_ev.conditional is not None
+        ):
+            steam_install_detected_ev.conditional = "store.is_steam"
+
     return
 
 #0.11.3


### PR DESCRIPTION
Main changes:
- Moved input filters to `definitions`.
- Adjusted allowed characters for name input.
- Added filter for name input.
- Added filter for instrument input.

Sub changes:
- No idea why Dan's used a persistent var for steam detection (`persistent.steam`) since it resets on every startup anyway. Now we use `is_steam` instead. Although, I've not deleted the var because it was used in DDLC, added an update script for `mas_steam_install_detected`.
- Removed that weird spaghetti of `try/except` in `definitions`, added an update scrips to handle that just once instead.