### PR TITLE
Fix for music hotkeys

### DIFF
--- a/Monika After Story/game/import_ddlc.rpy
+++ b/Monika After Story/game/import_ddlc.rpy
@@ -28,7 +28,7 @@ label import_ddlc_persistent_in_settings:
         # current in dialogue workflow, we should only enable the escape
         # and music stuff
         $ enable_esc()
-        $ mas_MUMUDropShield()
+        $ mas_MUINDropShield()
 
     else:
         # otherwise, reenable core interactions

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1881,7 +1881,7 @@ label monikaroom_greeting_cleanup:
         mas_disable_quit()
 
         # 2 - music is renabled
-        mas_MUMUDropShield()
+        mas_MUINDropShield()
 
         # 3 - keymaps should be set
         set_keymaps()
@@ -2634,8 +2634,8 @@ label greeting_hairdown:
     $ mas_lockEVL("greeting_hairdown", "GRE")
 
     # cleanup
-    # enable music menu
-    $ mas_MUMUDropShield()
+    # enable music menu and music hotkeys
+    $ mas_MUINDropShield()
 
     # 3 - set the keymaps
     $ set_keymaps()

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -2574,7 +2574,7 @@ label mas_d25_spent_time_monika:
 
                 #Re-enable buttons
                 $ enable_esc()
-                $ mas_MUMUDropShield()
+                $ mas_MUINDropShield()
                 $ HKBShowButtons()
         return
 
@@ -5659,7 +5659,7 @@ label mas_f14_first_kiss:
                 m 6ekbsu "...the moment of our first kiss."
                 m "Happy Valentine's Day, [player]~"
                 $ enable_esc()
-                $ mas_MUMUDropShield()
+                $ mas_MUINDropShield()
                 $ HKBShowButtons()
                 return
 

--- a/Monika After Story/game/special-effects.rpy
+++ b/Monika After Story/game/special-effects.rpy
@@ -235,7 +235,7 @@ label monika_kissing_motion(transition=4.0, duration=2.0, hide_ui=True,
     show monika with dissolve_monika
     if hide_ui:
         if store.mas_globals.dlg_workflow:
-            $ mas_MUMUDropShield()
+            $ mas_MUINDropShield()
             $ enable_esc()
         else:
             $ mas_DropShield_core()

--- a/Monika After Story/game/updater.rpy
+++ b/Monika After Story/game/updater.rpy
@@ -860,7 +860,7 @@ label forced_update_now:
             # current in dialogue workflow, we should only enable the escape
             # and music stuff
             $ enable_esc()
-            $ mas_MUMUDropShield()
+            $ mas_MUINDropShield()
 
         else:
             # otherwise, reenable core interactions
@@ -877,7 +877,7 @@ label forced_update_now:
             # current in dialogue workflow, we should only enable the escape
             # and music stuff
             $ enable_esc()
-            $ mas_MUMUDropShield()
+            $ mas_MUINDropShield()
 
         else:
             # otherwise, reenable core interactions

--- a/Monika After Story/game/zz_hangman.rpy
+++ b/Monika After Story/game/zz_hangman.rpy
@@ -587,7 +587,7 @@ label mas_hangman_game_loop:
                 $ is_window_sayori_visible = False
 
                 # enable disabled songs and esc
-                $ mas_MUMUDropShield()
+                $ mas_MUINDropShield()
                 $ enable_esc()
 
             # otherwise, window sayori

--- a/Monika After Story/game/zz_music_selector.rpy
+++ b/Monika After Story/game/zz_music_selector.rpy
@@ -1150,7 +1150,7 @@ init python:
             if store.mas_globals.dlg_workflow:
                 # the dialogue workflow means we should only enable
                 # music menu interactions
-                mas_MUMUDropShield()
+                mas_MUINDropShield()
 
             elif store.mas_globals.in_idle_mode:
                 # to idle


### PR DESCRIPTION
In some flows we disable music hotkeys (`-` and `+`), but never enable them afterwards. To solve this I replaced `mas_MUMUDropShield` with `mas_MUINDropShield`.

### Testing:
- verify you're able to adjust the volume via the hotkeys (run the changed labels/topics)
- verify we enable the hotkeys in all places we need to
- verify this doesn't break the flow (the hotkeys are enabled only when we need them enabled)