### PR TITLE
Repr for event

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -740,7 +740,7 @@ python early:
 
         #repr override
         def __repr__(self):
-            return "<Event: {{ evl: {0} }}>".format(self.eventlabel)
+            return "<Event: (evl: {0})>".format(self.eventlabel)
 
         def monikaWantsThisFirst(self):
             """

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -740,7 +740,7 @@ python early:
 
         #repr override
         def __repr__(self):
-            return "<Event object with evl: '{0}' at {1}>".format(self.eventlabel, hex(id(self)))
+            return "<Event: {{ evl: {0} }}>".format(self.eventlabel)
 
         def monikaWantsThisFirst(self):
             """

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -738,6 +738,9 @@ python early:
             else:
                 return super(Event, self).__getattribute__(name)
 
+        #repr override
+        def __repr__(self):
+            return "<Event object with evl: '{0}' at {1}>".format(self.eventlabel, hex(id(self)))
 
         def monikaWantsThisFirst(self):
             """


### PR DESCRIPTION
Adds an override for `__repr__` for the `Event` class, makes debugging things with collections of Events much easier as their eventlabels are always displayed.