### PR TITLE
Straddle sunset filter on suntimes

### DIFF
--- a/Monika After Story/game/sprite-chart-matrix.rpy
+++ b/Monika After Story/game/sprite-chart-matrix.rpy
@@ -729,19 +729,22 @@ init -99 python in mas_sprites:
     FLT_DAY = "day"
     FLT_NIGHT = "night"
     FLT_SUNSET = "sunset"
+    FLT_SUNSET_N = "sunset_n" # same as sunset, but for night chunks
 
     # filter dict
     FILTERS = {
         FLT_DAY: store.im.matrix.identity(),
         FLT_NIGHT: store.im.matrix.tint(0.59, 0.49, 0.55),
         FLT_SUNSET: store.im.matrix.tint(0.93, 0.82, 0.78),
+        FLT_SUNSET_N: store.im.matrix.tint(0.93, 0.82, 0.78),
     }
 
     # filter fallback dict
     # key: filter
     # value: filter that should be considered "base" filter
     FLT_FB = {
-        FLT_SUNSET: FLT_DAY
+        FLT_SUNSET: FLT_DAY,
+        FLT_SUNSET_N: FLT_SUNSET,
     }
 
     # contains all base filters. These are filtesr without a fallback.

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -2736,6 +2736,12 @@ init -1 python:
                 MASBackgroundFilterSlice.cachecreate(
                     store.mas_sprites.FLT_NIGHT,
                     60
+                ),
+                MASBackgroundFilterSlice.cachecreate(
+                    store.mas_sprites.FLT_SUNSET_N,
+                    60,
+                    30*60,
+                    10
                 )
             ),
             MASBackgroundFilterChunk(
@@ -2761,6 +2767,12 @@ init -1 python:
             MASBackgroundFilterChunk(
                 False,
                 None,
+                MASBackgroundFilterSlice.cachecreate(
+                    store.mas_sprites.FLT_SUNSET_N,
+                    60,
+                    30*60,
+                    10
+                ),
                 MASBackgroundFilterSlice.cachecreate(
                     store.mas_sprites.FLT_NIGHT,
                     60


### PR DESCRIPTION
#6195 

But first, is this absolutely necessary?

Pros:
* transition times "more realistic" since the sky does get brighter *before* the sun actually rises. As well as stays brighter *after* the sun actually sets

Cons:
* the way we determine if we are in "day" or "night" is by checking the current time chunk in the background. Part of this means that filters **cannot** be used in both a "day" chunk and a "night" chunk. So, to get around this, if a filter needs to be in both the day and night chunks, it needs to have a night copy. This is intended, but I figured it would be a rare case. The biggest issue here is that if you were to vary dialogue on night/day, you might consider the sunset color to be "day", rather than "night". 

# Key Changes
* Starts sunset filter 30 minutes before sunrise and extends sunset filter 30 minutes after sunset

# Testing
* verify filters look good and start correctly
