### PR TITLE
Add wayland check

### DIFF
--- a/Monika After Story/game/zz_windowreacts.rpy
+++ b/Monika After Story/game/zz_windowreacts.rpy
@@ -75,25 +75,40 @@ init python:
             tip.hwnd = None
 
     elif renpy.linux:
-        import subprocess
-        try:
-            subprocess.call(['notify-send', '--version'])
-
-        except OSError as e:
-            #Command wasn't found
-            store.mas_windowreacts.can_show_notifs = False
-            store.mas_utils.writelog(
-                "[WARNING]: notify-send not found, disabling notifications.\n"
-            )
-
-        try:
-            subprocess.call(["xdotool", "--version"])
-
-        except OSError:
-            #Command not found
+        # wayland check
+        if "WAYLAND_DISPLAY" in os.environ:
             persistent._mas_windowreacts_windowreacts_enabled = False
             store.mas_windowreacts.can_do_windowreacts = False
-            store.mas_utils.writelog("[WARNING]: xdotool not found, disabling windowreacts.\n")
+            store.mas_utils.writelog(
+                "[WARNING]: Window reacts do not work on Wayland\n"
+            )
+
+            # NOTE: it is possible for WAYLAND_DISPLAY to be unset on a wayland
+            # desktop. This is not ideal but is handled with try catch block
+
+        else:
+            import subprocess
+
+            # notify send check
+            try:
+                subprocess.call(['notify-send', '--version'])
+
+            except OSError as e:
+                #Command wasn't found
+                store.mas_windowreacts.can_show_notifs = False
+                store.mas_utils.writelog(
+                    "[WARNING]: notify-send not found, disabling notifications.\n"
+                )
+
+            # xdotool check
+            try:
+                subprocess.call(["xdotool", "--version"])
+
+            except OSError:
+                #Command not found
+                persistent._mas_windowreacts_windowreacts_enabled = False
+                store.mas_windowreacts.can_do_windowreacts = False
+                store.mas_utils.writelog("[WARNING]: xdotool not found, disabling windowreacts.\n")
 
     else:
         store.mas_windowreacts.can_do_windowreacts = False


### PR DESCRIPTION
#6042 

**dont merge until i test this on my own linux**

# Key Changes
* adds a check for `WAYLAND_DISPLAY` env var and disables window reacts if its found

# Testing
* Verify window reacts still work on Linux with X11
* Verify window reacts do not work on Linux with Wayland - might need to virtual machine to try this