### PR TITLE
Clearer isFltDay return values

### DIFF
--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -1523,9 +1523,14 @@ init -10 python:
             IN:
                 flt - filter to check
 
-            RETURNS: True if day, false if not
+            RETURNS: True if day, false if not, None if filter not associatd
+                with this filter manager
             """
-            return flt in self._day_filters
+            if flt in self._day_filters:
+                return True
+            if flt in self._night_filters:
+                return False
+            return None
 
         def _organize(self):
             """
@@ -2231,7 +2236,8 @@ init -10 python:
                 flt - filter to check
                     if None, we use the current filter
 
-            RETURNS: True if flt is a "day" filter according to this bg
+            RETURNS: True if flt is a "day" filter according to this bg,
+                False if night filter, None if not associated with this BG
             """
             if flt is None:
                 flt = store.mas_sprites.get_filter()
@@ -2247,9 +2253,13 @@ init -10 python:
                 flt - filter to check
                     if None, we use the current filter
 
-            RETURNS: True if flt is a "night" filter according to this BG
+            RETURNS: True if flt is a "night" filter according to this BG,
+                False if day filter, None if not associated with this BG.
             """
-            return not self.isFltDay(flt)
+            flt_res = self.isFltDay(flt)
+            if flt_res is not None:
+                return not flt_res
+            return None
 
         def _lookback(self, flt):
             """


### PR DESCRIPTION
# Key Changes
* changes `MASFilterableBackground.isFltDay`, `MASFilterableBackground.isFltNight`, `MASFitlerableBackgroundManager.is_flt_day` so they return `True` if the filter is day/night, `False` if the filter is the opposite, and `None` if the filter is not part of the background. This is so users of `isFltDay` and `isFltNight` know if the current background can actually determine if a filter is day/night.

# Testing
1. Open console
2. Run `mas_current_background.isFltDay` and `.isFltNight` using filters. For example:
    * `mas_current_background.isFltDay("day")` - should return True
    * `mas_current_background.isFltDay("night")` - should return False
    * `mas_current_background.isFltDay("something_that_is_not_a_filter")` - should return None