### PR TITLE
Make startup game unlocks also use shown count

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -362,6 +362,14 @@ python early:
     #   shown_count - number of times this event has been shown to the user
     #       NOTE: this must be set by the caller, and it is asssumed that
     #           call_next_event is the only one who changes this
+    #       NOTE: IF AN EVENT HAS BEEN SEEN, IT SHOULD ALWAYS HAVE A POSITIVE
+    #           SHOWN COUNT. The only exception to this is if we crashed
+    #           halfway through a topic, in which case we will know this
+    #           since shown count will be 0 and the label would have been seen.
+    #           In that circumstance, we should immediately update the shown
+    #           count. (Event will not do this in case you need to do specific
+    #           crash handling). Call syncShownCount on the event object to 
+    #           update shown count in the crash scenario
     #       (Default: 0)
     #   diary_entry - string that will be added as a diary entry if this event
     #       has been seen. This string will respect \n and other formatting
@@ -864,6 +872,13 @@ python early:
             """
             self.start_date = None
             self.end_date = None
+
+        def syncShownCount(self):
+            """
+            Updates shown count if it is < 1 but we have seen the label
+            """
+            if self.shown_count < 1 and renpy.seen_label(self.eventlabel):
+                self.shown_count = 1
 
         def timePassedSinceLastSeen_d(self, time_passed, _now=None):
             """

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1775,8 +1775,6 @@ label ch30_reset:
 
     # check for game unlocks
     python:
-        #TODO: Fix the game unlock/is unlocked system to account for conditions like these
-        #mas_isGameUnlocked should NOT return True if we're failing this condition because we use it elsewhere
         game_unlock_db = {
             "chess": "mas_unlock_chess",
             mas_games.HANGMAN_NAME: "mas_unlock_hangman",
@@ -1786,7 +1784,10 @@ label ch30_reset:
 
         for game_name, game_startlabel in game_unlock_db.iteritems():
             # unlock if we've seen the label
-            if mas_getEVL_shown_count(game_startlabel) > 0 or renpy.seen_label(game_startlabel):
+            if (
+                    mas_getEVL_shown_count(game_startlabel) > 0
+                    or renpy.seen_label(game_startlabel)
+            ):
                 mas_unlockGame(game_name)
 
 

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1778,14 +1778,21 @@ label ch30_reset:
         #TODO: Fix the game unlock/is unlocked system to account for conditions like these
         #mas_isGameUnlocked should NOT return True if we're failing this condition because we use it elsewhere
         game_unlock_db = {
-            "pong": "ch30_main", # pong should always be unlocked
             "chess": "mas_unlock_chess",
             mas_games.HANGMAN_NAME: "mas_unlock_hangman",
             "piano": "mas_unlock_piano",
         }
+        mas_unlockGame("pong") # always unlock pong
 
         for game_name, game_startlabel in game_unlock_db.iteritems():
-            if not mas_isGameUnlocked(game_name) and renpy.seen_label(game_startlabel):
+            # try grabbing event if possible
+            game_unlock_ev = mas_getEV(game_startlabel)
+            if game_unlock_ev:
+                if game_unlock_ev.shown_count > 0:
+                    mas_unlockGame(game_name)
+
+            elif renpy.seen_label(game_startlabel):
+                # otherwise, just use label check
                 mas_unlockGame(game_name)
 
 

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1784,10 +1784,7 @@ label ch30_reset:
 
         for game_name, game_startlabel in game_unlock_db.iteritems():
             # unlock if we've seen the label
-            if (
-                    mas_getEVL_shown_count(game_startlabel) > 0
-                    or renpy.seen_label(game_startlabel)
-            ):
+            if mas_getEVL_shown_count(game_startlabel) > 0:
                 mas_unlockGame(game_name)
 
 

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1785,14 +1785,8 @@ label ch30_reset:
         mas_unlockGame("pong") # always unlock pong
 
         for game_name, game_startlabel in game_unlock_db.iteritems():
-            # try grabbing event if possible
-            game_unlock_ev = mas_getEV(game_startlabel)
-            if game_unlock_ev:
-                if game_unlock_ev.shown_count > 0:
-                    mas_unlockGame(game_name)
-
-            elif renpy.seen_label(game_startlabel):
-                # otherwise, just use label check
+            # unlock if we've seen the label
+            if mas_getEVL_shown_count(game_startlabel) > 0 or renpy.seen_label(game_startlabel):
                 mas_unlockGame(game_name)
 
 

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -385,7 +385,10 @@ label v0_11_5(version="v0_11_5"):
 
         for game_evl, unlock_evl in game_evls:
             # 0.11.0 update script shoudl have transfered seen
-            if renpy.seen_label(unlock_evl):
+            if (
+                    renpy.seen_label(unlock_evl)
+                    or mas_getEVL_shown_count(unlock_evl) > 0
+            ):
                 mas_unlockEVL(game_evl, "GME")
 
                 # if we have seen the unlock evl, absolutely make sure it has

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -378,16 +378,19 @@ label v0_11_5(version="v0_11_5"):
     python:
         # properly unlock game topics if 0.7.1-era topics were seen
         game_evls = (
-            ("unlock_hangman", "mas_hangman", "mas_unlock_hangman"),
-            ("unlock_chess", "mas_chess", "mas_unlock_chess",),
-            ("unlock_piano", "mas_piano", "mas_unlock_piano"),
+            ("mas_hangman", "mas_unlock_hangman"),
+            ("mas_chess", "mas_unlock_chess",),
+            ("mas_piano", "mas_unlock_piano"),
         )
 
-        for old_evl, new_evl, unlock_evl in game_evls:
-            if renpy.seen_label(old_evl):
-                mas_unlockEVL(new_evl, "GME")
+        for game_evl, unlock_evl in game_evls:
+            # 0.11.0 update script shoudl have transfered seen
+            if renpy.seen_label(unlock_evl):
+                mas_unlockEVL(game_evl, "GME")
 
-                # mark unlock event as shown and cleared
+                # if we have seen the unlock evl, absolutely make sure it has
+                # a positive shown count. there is absolutely NO reason that
+                # an event that has been SEEN should have a shown count of 0.
                 unlock_ev = mas_getEV(unlock_evl)
                 if unlock_ev:
                     mas_rmEVL(unlock_evl)

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -392,6 +392,7 @@ label v0_11_5(version="v0_11_5"):
                 # mark unlock event as shown and cleared
                 unlock_ev = mas_getEV(unlock_evl)
                 if unlock_ev:
+                    mas_rmEVL(unlock_evl)
                     unlock_ev.conditional = None
                     unlock_ev.unlock_date = dt_now
                     unlock_ev.action = None

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -372,6 +372,34 @@ label v0_3_1(version=version): # 0.3.1
     return
 
 # non generic updates go here
+
+# 0.11.5
+label v0_11_5(version="v0_11_5"):
+    python:
+        dt_now = datetime.datetime.now()
+
+        # properly unlock game topics if 0.7.1-era topics were seen
+        game_evls = (
+            ("unlock_hangman", "mas_hangman", "mas_unlock_hangman"),
+            ("unlock_chess", "mas_chess", "mas_unlock_chess",),
+            ("unlock_piano", "mas_piano", "mas_unlock_piano"),
+        )
+
+        for old_evl, new_evl, unlock_evl in game_evls:
+            if renpy.seen_label(old_evl):
+                mas_unlockEVL(new_evl, "GME")
+
+                # mark unlock event as shown and cleared
+                unlock_ev = mas_getEV(unlock_evl)
+                if unlock_ev:
+                    unlock_ev.conditional = None
+                    unlock_ev.unlock_date = dt_now
+                    unlock_ev.action = None
+                    unlock_ev.unlocked = False
+                    unlock_ev.shown_count = 1
+
+    return
+
 #0.11.4
 label v0_11_4(version="v0_11_4"):
     python:

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -376,8 +376,6 @@ label v0_3_1(version=version): # 0.3.1
 # 0.11.5
 label v0_11_5(version="v0_11_5"):
     python:
-        dt_now = datetime.datetime.now()
-
         # properly unlock game topics if 0.7.1-era topics were seen
         game_evls = (
             ("unlock_hangman", "mas_hangman", "mas_unlock_hangman"),
@@ -394,7 +392,6 @@ label v0_11_5(version="v0_11_5"):
                 if unlock_ev:
                     mas_rmEVL(unlock_evl)
                     unlock_ev.conditional = None
-                    unlock_ev.unlock_date = dt_now
                     unlock_ev.action = None
                     unlock_ev.unlocked = False
                     unlock_ev.shown_count = 1

--- a/Monika After Story/game/updates_topics.rpy
+++ b/Monika After Story/game/updates_topics.rpy
@@ -65,6 +65,7 @@ label vv_updates_topics:
 
         # versions
         # use the v#_#_# notation so we can work with labels
+        vv0_11_5 = "v0_11_5"
         vv0_11_4 = "v0_11_4"
         vv0_11_3 = "v0_11_3"
         vv0_11_2 = "v0_11_2"
@@ -122,6 +123,7 @@ label vv_updates_topics:
         # some version changes skip some numbers because no major updates
         #NOTE: If a version does not have and update script, its version still must be documented and point to the next update
         #script available
+        #updates.version_updates[vv0_11_4] = vv0_11_5
         updates.version_updates[vv0_11_3] = vv0_11_4
         updates.version_updates[vv0_11_2] = vv0_11_3
         updates.version_updates[vv0_11_1] = vv0_11_3


### PR DESCRIPTION
#6150 

Two problems in the above issue:
1. Piano was locked somewhow.
2. `mas_unlock_piano` label was not found, so the game unlocks in `ch30_reset` fails

Interestingly, the game unlock Event for piano did have a shown count of 1, so it definitely was reached.

# Key Changes
* use `shown_count` first if we find the `Event` object associated with a game unlock. If we can't get the event, then check `renpy.seen_label`.
* update script to handle game unlocks for 0.7.1 and earlier persistent updating to 0.11.5
* new function `Event.syncShownCount` to set shown count to 1 if the label has been seen before. Should be used in cases of crashing midway between topics

# Testing
Either:
* pop `mas_unlock_piano` from your `_seen_ever`, lock the piano game (`mas_lockGame`), then relaunch  (**NOTE:** only if you have seen the `mas_unlock_piano` event at least once)
* OR grab the persistent from [this comment](https://github.com/Monika-After-Story/MonikaModDev/issues/6150#issuecomment-666889910) and launch with it

In both cases, piano should be unlocked.

### update script
* verify that if you have an unlock event that is seen but with a shown count of 0 (`mas_unlock_piano`, `mas_unlock_hangman`, mas_unlock_chess`) and run the v0.11.5 update script, the shown counts for the seen unlock events are set to 1.

### `syncShownCount`
* verify that if an event is seen but with a shown count of 0, calling `syncShownCount` on the event object sets the shown count to 1
