### PR TITLE
History reset fix for pre-0.10.0 persists

### DIFF
--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -1526,15 +1526,7 @@ label v0_10_0(version="v0_10_0"):
                 and mhs_922.trigger.day == 30
         ):
             # NOTE: START UPDATE SCRIPT MODIFICATION FROM 0.11.5
-            if not mhs_922.isFuture(dt_now):
-                # the mhs was JUSt triggered, and is either currently active
-                # or happened in the past.
-                # in this case, we should always set to next year
-                trigger_year = dt_now.year + 1
-            else:
-                trigger_year = dt_now.year
-
-            mhs_922.setTrigger(datetime.datetime(trigger_year, 1, 6))
+            mhs_922.setTrigger(datetime.datetime(dt_now.year + 1, 1, 6))
             # NOTE: END UPDATE SCRIPT MODIFICATION FROM 0.11.5
 
             mhs_922.use_year_before = True
@@ -1566,15 +1558,7 @@ label v0_10_0(version="v0_10_0"):
                 and mhs_o31.trigger.day == 2
         ):
             # NOTE: START UPDATE SCRIPT MODIFICATION FROM 0.11.5
-            if not mhs_o31.isFuture(dt_now):
-                # the mhs was JUSt triggered, and is either currently active
-                # or happened in the past.
-                # in this case, we should always set to next year
-                trigger_year = dt_now.year + 1
-            else:
-                trigger_year = dt_now.year
-
-            mhs_o31.setTrigger(datetime.datetime(trigger_year, 1, 6))
+            mhs_o31.setTrigger(datetime.datetime(dt_now.year + 1, 1, 6))
             # NOTE: END UPDATE SCRIPT MODIFICATION FROM 0.11.5
 
             mhs_o31.use_year_before = True

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -1514,6 +1514,10 @@ label v0_10_0(version="v0_10_0"):
             )
             concert_ev.action = EV_ACT_RANDOM
 
+        # NOTE: START UPDATE SCRIPT MODIFICATION FROM 0.11.5
+        dt_now = datetime.datetime.now()
+        # NOTE: END UPDATE SCRIPT MODIFICATION FROM 0.11.5
+
         # MHS checking
         mhs_922 = store.mas_history.getMHS("922")
         if (
@@ -1521,7 +1525,18 @@ label v0_10_0(version="v0_10_0"):
                 and mhs_922.trigger.month == 9
                 and mhs_922.trigger.day == 30
         ):
-            mhs_922.setTrigger(datetime.datetime(2020, 1, 6))
+            # NOTE: START UPDATE SCRIPT MODIFICATION FROM 0.11.5
+            if mhs_922.was_triggered() and not mhs_922.isFuture(dt_now):
+                # the mhs was JUSt triggered, and is either currently active
+                # or happened in the past.
+                # in this case, we should always set to next year
+                trigger_year = dt_now.year + 1
+            else:
+                trigger_year = dt_now.year
+
+            mhs_922.setTrigger(datetime.datetime(trigger_year, 1, 6))
+            # NOTE: END UPDATE SCRIPT MODIFICATION FROM 0.11.5
+
             mhs_922.use_year_before = True
 
         mhs_pbday = store.mas_history.getMHS("player_bday")
@@ -1550,7 +1565,18 @@ label v0_10_0(version="v0_10_0"):
                 and mhs_o31.trigger.month == 11
                 and mhs_o31.trigger.day == 2
         ):
-            mhs_o31.setTrigger(datetime.datetime(2020, 1, 6))
+            # NOTE: START UPDATE SCRIPT MODIFICATION FROM 0.11.5
+            if mhs_o31.was_triggered() and not mhs_o31.isFuture(dt_now):
+                # the mhs was JUSt triggered, and is either currently active
+                # or happened in the past.
+                # in this case, we should always set to next year
+                trigger_year = dt_now.year + 1
+            else:
+                trigger_year = dt_now.year
+
+            mhs_o31.setTrigger(datetime.datetime(trigger_year, 1, 6))
+            # NOTE: END UPDATE SCRIPT MODIFICATION FROM 0.11.5
+
             mhs_o31.use_year_before = True
 
         # always save mhs

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -1526,7 +1526,7 @@ label v0_10_0(version="v0_10_0"):
                 and mhs_922.trigger.day == 30
         ):
             # NOTE: START UPDATE SCRIPT MODIFICATION FROM 0.11.5
-            if mhs_922.was_triggered() and not mhs_922.isFuture(dt_now):
+            if not mhs_922.isFuture(dt_now):
                 # the mhs was JUSt triggered, and is either currently active
                 # or happened in the past.
                 # in this case, we should always set to next year
@@ -1566,7 +1566,7 @@ label v0_10_0(version="v0_10_0"):
                 and mhs_o31.trigger.day == 2
         ):
             # NOTE: START UPDATE SCRIPT MODIFICATION FROM 0.11.5
-            if mhs_o31.was_triggered() and not mhs_o31.isFuture(dt_now):
+            if not mhs_o31.isFuture(dt_now):
                 # the mhs was JUSt triggered, and is either currently active
                 # or happened in the past.
                 # in this case, we should always set to next year

--- a/Monika After Story/game/zz_history.rpy
+++ b/Monika After Story/game/zz_history.rpy
@@ -547,7 +547,7 @@ init -850 python:
             self.entry_pp = entry_pp
             self.exit_pp = exit_pp
             self.trigger_pp = trigger_pp
-
+            self._was_triggered = False
 
         @staticmethod
         def getSortKey(_mhs):
@@ -560,7 +560,6 @@ init -850 python:
             RETURNS the sort key, which is trigger datetime
             """
             return _mhs.trigger
-
 
         @staticmethod
         def correctTriggerYear(_trigger):
@@ -800,6 +799,8 @@ init -850 python:
             if self.exit_pp is not None:
                 self.exit_pp(self)
 
+            # mark that we ran
+            self._was_triggered = True
 
         def toTuple(self):
             """
@@ -811,6 +812,12 @@ init -850 python:
                     NOTE: needed for ease of migrations
             """
             return (self.trigger, self.use_year_before)
+
+        def was_triggered(self):
+            """
+            RETURNS: True if this MHS was triggered during this session
+            """
+            return self._was_triggered
 
 
 init -800 python in mas_history:


### PR DESCRIPTION
#6148 

# Key Changes
* `MASHistorySaver.was_triggered` - returns True if the mhs was just triggered
* **update script modification** - 0.10.0's update script has been modified to set trigger years for 922 and o31 to year + 1

**NOTE:** FYI update script modifications should be rare - only for fixing a potential data integrity issue or crashes. Unchanging update scripts helps keep the mod predictable.

# Testing
1. Launch the game with a pre-0.10.0 persistent on 922 or o31.
2. Verify no data reset or repeated intros. 