### PR TITLE
New prop for submods with multiple authors + fixes

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -3554,11 +3554,14 @@ init -995 python in mas_utils:
                 - 0 if the current version is the same as the comparitive version
                 - 1 if the current version is greater than the comparitive version
         """
-
         #Define a local function to use to fix up the version lists if need be
         def fixVersionListLen(smaller_vers_list, larger_vers_list):
             """
             Adjusts the smaller version list to be the same length as the larger version list for easy comparison
+
+            IN:
+                smaller_vers_list - the smol list to adjust
+                larger_vers_list - the list we will adjust the smol list to
 
             OUT:
                 adjusted version list
@@ -3569,19 +3572,16 @@ init -995 python in mas_utils:
                 smaller_vers_list.append(0)
             return smaller_vers_list
 
-
-        #Now, let's do some work.
-        #First, we check if the lists are the same. If so, we're the same version and can return 0
-        if comparative_vers == curr_vers:
-            return 0
-
-        #The lists are not the same, which means we need to do a bit of work.
-        #Before we do that, let's verify that the lists are the same length
-        if len(comparative_vers) > len(curr_vers):
+        #Let's verify that the lists are the same length
+        if len(curr_vers) < len(comparative_vers):
             curr_vers = fixVersionListLen(curr_vers, comparative_vers)
 
         elif len(curr_vers) > len(comparative_vers):
             comparative_vers = fixVersionListLen(comparative_vers, curr_vers)
+
+        #Check if the lists are the same. If so, we're the same version and can return 0
+        if comparative_vers == curr_vers:
+            return 0
 
         #Now we iterate and check the version numbers sequentially from left to right
         for index in range(len(curr_vers)):
@@ -3592,7 +3592,6 @@ init -995 python in mas_utils:
             elif curr_vers[index] < comparative_vers[index]:
                 #Comparative version is greater, the rest of this is irrelevant
                 return -1
-
 
 init -991 python in mas_utils:
     import store

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -3538,6 +3538,33 @@ init -999 python:
             pass
 
 init -995 python in mas_utils:
+    import store
+    import os
+    import stat
+    import shutil
+    import datetime
+    import codecs
+    import platform
+    import time
+    import traceback
+    import sys
+    #import tempfile
+    from os.path import expanduser
+    from renpy.log import LogFile
+    from bisect import bisect
+    from contextlib import contextmanager
+
+    # LOG messges
+    _mas__failrm = "[ERROR] Failed remove: '{0}' | {1}\n"
+    _mas__failcp = "[ERROR] Failed copy: '{0}' -> '{1}' | {2}\n"
+    _mas__faildir = "[ERROR] Failed to check if dir: {0} | {1}\n"
+
+    # bad text dict
+    BAD_TEXT = {
+        "{": "{{",
+        "[": "[["
+    }
+
     def compareVersionLists(curr_vers, comparative_vers):
         """
         Generic version number checker
@@ -3593,34 +3620,6 @@ init -995 python in mas_utils:
                 #Comparative version is greater, the rest of this is irrelevant
                 return -1
 
-init -991 python in mas_utils:
-    import store
-    import os
-    import stat
-    import shutil
-    import datetime
-    import codecs
-    import platform
-    import time
-    import traceback
-    import sys
-    #import tempfile
-    from os.path import expanduser
-    from renpy.log import LogFile
-    from bisect import bisect
-    from contextlib import contextmanager
-
-    # LOG messges
-    _mas__failrm = "[ERROR] Failed remove: '{0}' | {1}\n"
-    _mas__failcp = "[ERROR] Failed copy: '{0}' -> '{1}' | {2}\n"
-    _mas__faildir = "[ERROR] Failed to check if dir: {0} | {1}\n"
-
-    # bad text dict
-    BAD_TEXT = {
-        "{": "{{",
-        "[": "[["
-    }
-
     def all_none(data=None, lata=None):
         """
         Checks if a dict and/or list is all None
@@ -3647,7 +3646,6 @@ init -991 python in mas_utils:
 
         return True
 
-
     def clean_gui_text(text):
         """
         Cleans the given text so its suitable for GUI usage
@@ -3662,7 +3660,6 @@ init -991 python in mas_utils:
             text = text.replace(bad, BAD_TEXT[bad])
 
         return text
-
 
     def eqfloat(left, right, places=6):
         """
@@ -3682,7 +3679,6 @@ init -991 python in mas_utils:
 
         return abs(left-right) < acc
 
-
     def floatsplit(value):
         """
         Splits a float into int and float parts (unlike _splitfloat which
@@ -3697,7 +3693,6 @@ init -991 python in mas_utils:
         """
         int_part = int(value)
         return int_part, value - int_part
-
 
     def pdget(key, table, validator=None, defval=None):
         """
@@ -3725,7 +3720,6 @@ init -991 python in mas_utils:
 
         return defval
 
-
     def td2hr(duration):
         """
         Converts a timedetla to hours (fractional)
@@ -3736,7 +3730,6 @@ init -991 python in mas_utils:
         RETURNS: hours as float
         """
         return (duration.days * 24) + (duration.seconds / 3600.0)
-
 
     def tryparseint(value, default=0):
         """
@@ -3755,7 +3748,6 @@ init -991 python in mas_utils:
             return int(value)
         except:
             return default
-
 
     def copyfile(oldpath, newpath):
         """
@@ -3779,7 +3771,6 @@ init -991 python in mas_utils:
             writelog(_mas__failcp.format(oldpath, newpath, str(e)))
         return False
 
-
     @contextmanager
     def stdout_as(outstream):
         """
@@ -3796,7 +3787,6 @@ init -991 python in mas_utils:
         finally:
             sys.stdout = oldout
 
-
     def writelog(msg):
         """
         Writes to the mas log if it is open
@@ -3807,13 +3797,21 @@ init -991 python in mas_utils:
         if mas_log_open:
             mas_log.write(msg)
 
+    def wtf(msg):
+        """
+        Wow That Failed
+        For logging stuff that should never happen
+
+        IN:
+            msg - message to log
+        """
+        writelog(msg)
 
     def writestack():
         """
         Prints current stack to log
         """
         writelog("".join(traceback.format_stack()))
-
 
     def trydel(f_path, log=False):
         """
@@ -3826,7 +3824,6 @@ init -991 python in mas_utils:
         except Exception as e:
             if log:
                 writelog("[exp] {0}\n".format(repr(e)))
-
 
     def trywrite(f_path, msg, log=False, mode="w"):
         """
@@ -3852,7 +3849,6 @@ init -991 python in mas_utils:
         finally:
             if outfile is not None:
                 outfile.close()
-
 
     def logcreate(filepath, append=False, flush=False, addversion=False):
         """
@@ -3880,7 +3876,6 @@ init -991 python in mas_utils:
                 store.persistent.version_number
             ))
         return new_log
-
 
     def logrotate(logpath, filename):
         """
@@ -3940,7 +3935,6 @@ init -991 python in mas_utils:
 
         # and delete the current file
         trydel(old_path)
-
 
     def tryparsedt(_datetime, default=None, sep=" "):
         """
@@ -4070,7 +4064,6 @@ init -991 python in mas_utils:
             except:
                 self.file = False
                 return False
-
 
     # A map from the log name to a log object.
     mas_mac_log_cache = { }

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -3586,11 +3586,13 @@ init -995 python in mas_utils:
         #Now we iterate and check the version numbers sequentially from left to right
         for index in range(len(curr_vers)):
             if curr_vers[index] > comparative_vers[index]:
-                #We've found a number which was greater, let's return 1 as we know this version is greater
+                #The current version is greater here, let's return 1 as the rest of the version is irrelevant
                 return 1
 
-        #If we're here, we never found something greater. Let's return -1
-        return -1
+            elif curr_vers[index] < comparative_vers[index]:
+                #Comparative version is greater, the rest of this is irrelevant
+                return -1
+
 
 init -991 python in mas_utils:
     import store

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -3003,17 +3003,26 @@ screen submods():
                         xfill True
                         xmaximum 1000
 
-                        label submod.name yanchor 0 xalign 0
+                        label submod.name:
+                            yanchor 0
+                            xalign 0
+                            text_text_align 0.0
 
-                        hbox:
-                            spacing 20
-                            xmaximum 1000
+                        if submod.coauthors:
+                            $ authors = "v{0}{{space=20}}by {1}, {2}".format(submod.version, submod.author, ", ".join(submod.coauthors))
 
-                            text "v{}".format(submod.version) yanchor 0 xalign 0 style "main_menu_version"
-                            text "by {}".format(submod.author) yanchor 0 xalign 0 style "main_menu_version"
+                        else:
+                            $ authors = "v{0}{{space=20}}by {1}".format(submod.version, submod.author)
+
+                        text "[authors]":
+                            yanchor 0
+                            xalign 0
+                            text_align 0.0
+                            layout "greedy"
+                            style "main_menu_version"
 
                         if submod.description:
-                            text submod.description
+                            text submod.description text_align 0.0
 
                     if submod.settings_pane:
                         $ renpy.display.screen.use_screen(submod.settings_pane, _name="{0}_{1}".format(submod.author, submod.name))

--- a/Monika After Story/game/zz_submods.rpy
+++ b/Monika After Story/game/zz_submods.rpy
@@ -128,7 +128,7 @@ init -991 python in mas_submod_utils:
             """
             Representation of this object
             """
-            return "<Submod {0} v{1} by {2}>".format(self.name, self.version, self.author)
+            return "<Submod: ({0} v{1} by {2})>".format(self.name, self.version, self.author)
 
         def getVersionNumberList(self):
             """

--- a/Monika After Story/game/zz_submods.rpy
+++ b/Monika After Story/game/zz_submods.rpy
@@ -6,16 +6,38 @@ init 10 python:
     store.mas_submod_utils.Submod._checkUpdates()
 
 init -989 python:
+    #Log initialized submods
+    if store.mas_submod_utils.submod_map:
+        store.mas_submod_utils.writeLog(
+            "INSTALLED SUBMODS: {0}\n".format(
+                ", ".join(
+                    ["'{0}' v{1}".format(submod.name, submod.version) for submod in store.mas_submod_utils.submod_map.itervalues()]
+                )
+            )
+        )
+
     #Run dependency checks
     store.mas_submod_utils.Submod._checkDependencies()
 
 init -991 python in mas_submod_utils:
     import re
     import store
-    import sys
-    import traceback
+    # import sys
+    # import traceback
 
     persistent = store.persistent
+
+    log = store.mas_utils.getMASLog("log/submod_log", append=True, flush=True)
+    log.write("VERSION: {0}".format(persistent.version_number))
+
+    def writeLog(msg):
+        """
+        Writes to the submod log if it is open
+
+        IN:
+            msg - message to write to log
+        """
+        log.write(msg)
 
     submod_map = dict()
 

--- a/Monika After Story/game/zz_submods.rpy
+++ b/Monika After Story/game/zz_submods.rpy
@@ -9,9 +9,9 @@ init -989 python:
     #Log initialized submods
     if store.mas_submod_utils.submod_map:
         store.mas_submod_utils.writeLog(
-            "INSTALLED SUBMODS: {0}\n".format(
-                ", ".join(
-                    ["    '{0}' v{1}\n".format(submod.name, submod.version) for submod in store.mas_submod_utils.submod_map.itervalues()]
+            "\nINSTALLED SUBMODS:\n{0}".format(
+                ",\n".join(
+                    ["    '{0}' v{1}".format(submod.name, submod.version) for submod in store.mas_submod_utils.submod_map.itervalues()]
                 )
             )
         )

--- a/Monika After Story/game/zz_submods.rpy
+++ b/Monika After Story/game/zz_submods.rpy
@@ -11,7 +11,7 @@ init -989 python:
         store.mas_submod_utils.writeLog(
             "INSTALLED SUBMODS: {0}\n".format(
                 ", ".join(
-                    ["'{0}' v{1}".format(submod.name, submod.version) for submod in store.mas_submod_utils.submod_map.itervalues()]
+                    ["    '{0}' v{1}\n".format(submod.name, submod.version) for submod in store.mas_submod_utils.submod_map.itervalues()]
                 )
             )
         )

--- a/Monika After Story/game/zz_submods.rpy
+++ b/Monika After Story/game/zz_submods.rpy
@@ -52,7 +52,8 @@ init -991 python in mas_submod_utils:
             description=None,
             dependencies={},
             settings_pane=None,
-            version_updates={}
+            version_updates={},
+            coauthors=[]
         ):
             """
             Submod object constructor
@@ -86,6 +87,9 @@ init -991 python in mas_submod_utils:
 
                     becomes:
                         label monikaafterstory_example_submod_v1_2_3(version="v1_2_3")
+
+                coauthors - list/tuple of co-authors of this submod
+                    (Default: empty list)
             """
             #First make sure this name us unique
             if name in submod_map:
@@ -111,6 +115,7 @@ init -991 python in mas_submod_utils:
             self.dependencies = dependencies
             self.settings_pane = settings_pane
             self.version_updates = version_updates
+            self.coauthors = tuple(coauthors)
 
             #Now we add these to our maps
             submod_map[name] = self
@@ -118,6 +123,12 @@ init -991 python in mas_submod_utils:
             #NOTE: We check for things having updated later so all update scripts get called together
             if name not in persistent._mas_submod_version_data:
                 persistent._mas_submod_version_data[name] = version
+
+        def __repr__(self):
+            """
+            Representation of this object
+            """
+            return "<Submod {0} v{1} by {2}>".format(self.name, self.version, self.author)
 
         def getVersionNumberList(self):
             """


### PR DESCRIPTION
Some submods have more than one person working on it. I saw a workaround, and I don't like it. This adds a new prop for `Submod` objects - `coauthors`. Assuming it's a `list`/`tuple` of `string`s. We show those on the `submods` screen near authors.

- I also added `__repr__` to the `Submod` class.
- This also fixes `compareVersionLists` to work for any cases.
- Added a new log (and a new method) for submods - `submod_log.txt`. For that I have to move some things in `definitions` (such as `writelog`) to `init -995`. This won't affect the places where we're already using those. It also makes sense to have logging stuff defined earlier.
- We now have a new function `wtf`, which is an alias to `writelog`. Because why not I guess.

### Testing:
- verify that co-authors are shown on the screen, and the screen still looks good
- verify nothing breaks if no co-authors were provided
- verify that `__repr__` for submods has all we need
- verify that `compareVersionLists` works properly for any version lists
- verify the new submod log works fine