### PR TITLE
add repr to BG filter classes and exception logging for progress()

### DIFF
--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -22,7 +22,6 @@ init -5 python in mas_background:
     #value: ignored
     EXP_SKIP_OUTRO = "skip_outro"
 
-
 #START: Class definition
 init -10 python:
 
@@ -2584,9 +2583,9 @@ init -20 python in mas_background:
             bg_obj.background_id
         ))
         bg_log.write("Filter System:\n\n")
-        bg_log.write(str(bg_obj))
+        bg_log.write(str(bg_obj._flt_man))
         bg_log.write("\n\nRaw Filter Manager Data:\n")
-        bg_log.write(repr(bg_obj))
+        bg_log.write(repr(bg_obj._flt_man))
 
         if tbout:
             import traceback

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -2362,8 +2362,8 @@ init -10 python:
                 # in this case, we don't know what happened, but we got
                 # screwed. log out state of the flt man as well as the
                 # traceback
-                exc_type, exc_value, exc_tb = store.mas_utils.sys.exc_info()
-                store.mas_background.log_bg(self, exc_tb)
+                exc_info = store.mas_utils.sys.exc_info()
+                store.mas_background.log_bg(self, exc_info)
                 
                 # reset the manager to defualt indexes. Next time progress
                 # is called will hopefully update without error
@@ -2580,13 +2580,16 @@ init -20 python in mas_background:
         return False
 
 
-    def log_bg(bg_obj, tbout=None):
+    def log_bg(bg_obj, exc_info=None):
         """
         Logs the given BG object to standard bg log
 
         IN:
             bg_obj - bg object to log
-            tbout - traceback object to print out, if provided
+            exc_info - exception info. Should be tuple:
+                [0] - exception type
+                [1] - exception value
+                [2] - traceback
                 (Default: None)
         """
         if bg_obj is None:
@@ -2609,11 +2612,11 @@ init -20 python in mas_background:
         bg_log.write("\n\nRaw Filter Manager Data:\n")
         bg_log.write(repr(bg_obj._flt_man))
 
-        if tbout:
+        if exc_info:
             import traceback
 
             bg_log.write("\n\n")
-            for tb_line in traceback.format_tb(tbout):
+            for tb_line in traceback.format_exception(*exc_info):
                 bg_log.write(tb_line)
 
 

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -1080,6 +1080,7 @@ init -10 python:
             """
             # advance slices
             self._index = self.adv_slice(sfco, self._index, True, curr_time)
+
             return self.current()
 
         def update(self, ct_off):

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -345,7 +345,7 @@ init -10 python:
                 self.order,
                 self.offset,
                 self.length,
-                self.flt_slice
+                repr(self.flt_slice)
             )
 
         def __str__(self):

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -2362,8 +2362,10 @@ init -10 python:
                 # in this case, we don't know what happened, but we got
                 # screwed. log out state of the flt man as well as the
                 # traceback
-                exc_info = store.mas_utils.sys.exc_info()
-                store.mas_background.log_bg(self, exc_info)
+                store.mas_background.log_bg(
+                    self,
+                    store.mas_utils.sys.exc_info()
+                )
                 
                 # reset the manager to defualt indexes. Next time progress
                 # is called will hopefully update without error


### PR DESCRIPTION
#6330 and related

# Key Changes
* adds `__repr__` definitions for the bg filter manager and related classes
* adds exception logging to `progress` function, where the custom room pack errors are happening
* fixes try excepts that used `Error` instead of `Exception`

# Testing
* `mas_current_background._flt_man` is where the filter manager is. all filter chunk/slice data will appear but it won't be easily readable for obvious reasons. 
* as far as the exception testing, you can run `mas_current_background._flt_man._current_chunk()._index = 29` or similar, then open and close talk menu. It should trigger a progress call, which will fail, and the transition will default to midnight. There should be a file `bg_flt.txt` in the root ddlc dir, whch contains bg info and both the `__str__` and `__repr__` of the bg object as well as traceback info