### PR TITLE
Fix transitions for the dialogue box

### DIFF
--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -2437,7 +2437,7 @@ label call_next_event:
 
     # return to normal pose
     if not renpy.showing("monika idle"):
-        show monika idle at t11 zorder MAS_MONIKA_Z with dissolve
+        show monika idle at t11 zorder MAS_MONIKA_Z with dissolve_monika
 
     return False
 

--- a/Monika After Story/game/options.rpy
+++ b/Monika After Story/game/options.rpy
@@ -98,8 +98,8 @@ define config.window = "auto"
 
 ## Transitions used to show and hide the dialogue window
 
-define config.window_show_transition = Dissolve(.2)
-define config.window_hide_transition = Dissolve(.2)
+define config.window_show_transition = dissolve_textbox
+define config.window_hide_transition = dissolve_textbox
 
 
 ## Preference defaults #########################################################

--- a/Monika After Story/game/script-songs.rpy
+++ b/Monika After Story/game/script-songs.rpy
@@ -1286,7 +1286,7 @@ label mas_song_god_knows:
     m 1eubsa "{i}~As if we were God blessed~{/i}"
     m 1dubsu "..."
     m 3rud "You know, I'm still skeptical about whether some sort of a god exists or not..."
-    show monika 5hubsu at t11 zorder MAS_MONIKA_Z with dissolve
+    show monika 5hubsu at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5hubsu "But having you here really does feel like a blessing from the heavens."
     return
 

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -2526,7 +2526,9 @@ label monika_holdme_reactions:
     return
 
 label monika_holdme_long:
+    window show
     m "..."
+    window auto
     menu:
         "{i}Wake Monika up.{/i}":
             $ play_song(None, fadeout=5.0)

--- a/Monika After Story/game/zz_transforms.rpy
+++ b/Monika After Story/game/zz_transforms.rpy
@@ -98,7 +98,9 @@ init -10 python:
 
 # A transition of the new type
 # which only works with mas_with_statement or Ren'Py 7.0+
-define dissolve_monika = {"master": Dissolve(0.25)}
+init -5 python:
+    dissolve_monika = {"master": Dissolve(0.25, alpha=True)}
+    dissolve_textbox = {"screens": Dissolve(0.2, alpha=True)}
 
 # user defined trasnforms
 transform leftin_slow(x=640, z=0.80, t=1.00):


### PR DESCRIPTION
Hiding/showing the dlg box conflicts with showing/hiding Monika. While doing it to Monika affects only the `master` layer, doing it to the dlg box affects the entire scene. Which means we dissolve Monika twice. This leads to some graphical bugs.

This also adds the `alpha` param to Monika's transition. Because that's how it should've been from the beginning.

### Testing:
- verify Monika's sprites behave as expected on the `window show`, `window hide`, and similar statements
- verify the dlg box **and** Monika's transitions look good