### PR TITLE
seen_label now accounts for label_overrides

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -368,7 +368,7 @@ python early:
     #           since shown count will be 0 and the label would have been seen.
     #           In that circumstance, we should immediately update the shown
     #           count. (Event will not do this in case you need to do specific
-    #           crash handling). Call syncShownCount on the event object to 
+    #           crash handling). Call syncShownCount on the event object to
     #           update shown count in the crash scenario
     #       (Default: 0)
     #   diary_entry - string that will be added as a diary entry if this event
@@ -3545,12 +3545,35 @@ init -1 python in _mas_root:
 init -999 python:
     import os
 
+    _OVERRIDE_LABEL_TO_BASE_LABEL_MAP = dict()
+
     # create the log folder if not exist
     if not os.access(os.path.normcase(renpy.config.basedir + "/log"), os.F_OK):
         try:
             os.mkdir(os.path.normcase(renpy.config.basedir + "/log"))
         except:
             pass
+
+    def mas_override_label(label_to_override, override_label):
+        """
+        Label override function
+
+        IN:
+            label_to_override - the label which will be overridden
+            override_label - the label to override with
+        """
+        global _OVERRIDE_LABEL_TO_BASE_LABEL_MAP
+
+        #Check if we're overriding an already overridden label
+        if label_to_override in config.label_overrides:
+            old_override = config.label_overrides.pop(label_to_override)
+
+            #Remove the data for the label which is no longer acting as an override
+            if old_override in _OVERRIDE_LABEL_TO_BASE_LABEL_MAP:
+                _OVERRIDE_LABEL_TO_BASE_LABEL_MAP.pop(old_override)
+
+        config.label_overrides[label_to_override] = override_label
+        _OVERRIDE_LABEL_TO_BASE_LABEL_MAP[override_label] = label_to_override
 
 init -995 python in mas_utils:
     def compareVersionLists(curr_vers, comparative_vers):

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -2003,8 +2003,4 @@ label ch30_reset:
             #Let's also push the event to get rid of the thermos too
             if not mas_inEVL("mas_consumables_remove_thermos"):
                 queueEvent("mas_consumables_remove_thermos")
-
-        #Let's loop here to update our label overrides map
-        for overridden_label, label_override in config.label_overrides.iteritems():
-            _OVERRIDE_LABEL_TO_BASE_LABEL_MAP[label_override] = overridden_label
     return

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -2004,4 +2004,7 @@ label ch30_reset:
             if not mas_inEVL("mas_consumables_remove_thermos"):
                 queueEvent("mas_consumables_remove_thermos")
 
+        #Let's loop here to update our label overrides map
+        for overridden_label, label_override in config.label_overrides.iteritems():
+            _OVERRIDE_LABEL_TO_BASE_LABEL_MAP[label_override] = overridden_label
     return

--- a/Monika After Story/game/zz_submods.rpy
+++ b/Monika After Story/game/zz_submods.rpy
@@ -567,4 +567,9 @@ init 999 python:
         #Run functions
         store.mas_submod_utils.getAndRunFunctions(name)
 
+        #Let's also check if the current label is an override label, if so, we'll then mark the base label as seen
+        base_label = _OVERRIDE_LABEL_TO_BASE_LABEL_MAP.get(name)
+        if base_label is not None:
+            persistent._seen_ever[base_label] = True
+
     config.label_callback = label_callback

--- a/Monika After Story/game/zz_submods.rpy
+++ b/Monika After Story/game/zz_submods.rpy
@@ -573,3 +573,12 @@ init 999 python:
             persistent._seen_ever[base_label] = True
 
     config.label_callback = label_callback
+
+    @store.mas_submod_utils.functionplugin("ch30_reset", priority=-999)
+    def __build_override_label_to_base_label_map():
+        """
+        Populates a lookup dict for all label overrides which are in effect
+        """
+        #Let's loop here to update our label overrides map
+        for overridden_label, label_override in config.label_overrides.iteritems():
+            _OVERRIDE_LABEL_TO_BASE_LABEL_MAP[label_override] = overridden_label


### PR DESCRIPTION
Adds a part to the label_callback function we defined to mark overridden labels as seen if their respective override is seen.

Also added a new function, `mas_override_label`, which will add the labels to `config.label_overrides` and to a new map, `_OVERRIDE_LABEL_TO_BASE_LABEL_MAP` for easy lookup in the label_callback.

`OVERRIDE_LABEL_TO_BASE_LABEL_MAP` is populated using a `functionplugin` plugged into the `ch30_reset` label, since function plugins account for labels being overridden, if `ch30_reset` is for whatever reason overridden, this change is still applied regardless.

## Testing:
- Verify that when seeing an overridden label, be it by `call`, `jump`, or `fall through`, they are marked as seen, along with their base label (overridden label)
- Verify that overriding via direct access to the `config.label_overrides` dict has the override info added to the new map