### PR TITLE
Adding a context manager for Event

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -1943,7 +1943,6 @@ python early:
 
             #NOTE: we don't add the rest since there's no reason to undo those.
 
-
 # init -1 python:
     # this should be in the EARLY block
     class MASButtonDisplayable(renpy.Displayable):

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -31,7 +31,7 @@ python early:
         """
 
         def __call__(self, *args, **kwargs):
-            return None
+            return MASDummyClass()
 
         def __len__(self):
             return 0

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -23,6 +23,47 @@ python early:
         """
         return
 
+    class MASDummyClass(object):
+        """
+        Dummy class that does nothing.
+
+        If compared to, it will always return False.
+        """
+
+        def __call__(self, *args, **kwargs):
+            return None
+
+        def __len__(self):
+            return 0
+
+        def __getattr__(self, name):
+            return MASDummyClass()
+
+        def __setattr__(self, name, value):
+            return
+
+        def __lt__(self, other):
+            return False
+
+        def __le__(self, other):
+            return False
+
+        def __eq__(self, other):
+            return False
+
+        def __ne__(self, other):
+            return False
+
+        def __gt__(self, other):
+            return False
+
+        def __ge__(self, other):
+            return False
+
+        def __nonzero__(self):
+            return False
+
+
     # clear this so no more traceback. We expect node loops anyway
     renpy.execution.check_infinite_loop = dummy
 
@@ -1901,6 +1942,7 @@ python early:
                     mas_rmallEVL(ev.eventlabel)
 
             #NOTE: we don't add the rest since there's no reason to undo those.
+
 
 # init -1 python:
     # this should be in the EARLY block

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -410,6 +410,32 @@ init 6 python:
             - functions calls do nothing
             - all comparisons return False.
         """
+        _default_values = {
+            "eventlabel": "",
+            "prompt": None,
+            "label": None,
+            "category": None,
+            "unlocked": False,
+            "random": False,
+            "pool": False,
+            "conditional": None,
+            "action": None,
+            "start_date": None,
+            "end_date": None,
+            "unlock_date": None,
+            "shown_count": 0,
+            "last_seen": None,
+            "years": None,
+            "sensitive": False,
+            "aff_range": None,
+            "show_in_idle": False,
+            "flags": 0,
+        }
+
+        _null_dicts = {
+            "per_eventdb": 0,
+            "rules": 0,
+        }
 
         def __init__(self, evl):
             """
@@ -431,7 +457,21 @@ init 6 python:
 
         def __getattr__(self, name):
             if self._ev is None:
-                return MASDummyClass()
+                
+                # event props
+                if name in MAS_EVL._default_values:
+                    return MAS_EVL._default_values.get(name)
+
+                # event props where we dont want static vars to collide
+                if name in MAS_EVL._null_dicts:
+                    return {}
+
+                if callable(Event.__dict__.get(name)):
+                    # functions (on object, not class)
+                    return MASDummyClass()
+
+                # everything else gets whatever we have in event
+                return getattr(Event, name)
 
             return getattr(self._ev, name)
 

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -405,10 +405,10 @@ init 6 python:
         other event objects like normal.
 
         In cases where the Event does not exist, the following occurs:
-            - all properties return None
+            - Event properties return their defaults (see below)
             - property set operations do nothing
             - functions calls do nothing
-            - all comparisons return False.
+            - The Event class is used as fallback
         """
         _default_values = {
             "eventlabel": "",


### PR DESCRIPTION
dev QOL addition

# Key Changes
* adds a dummy class that does nothing but can be hurt in a variety of ways (`MASDummyClass`)
* adds a context manager wrapper around `Event` that can be used to do things to/with an event object without having to None check - `MAS_EVL`

example:
```python
normal_ev = mas_getEV("a_label")
get_value = None
with MAS_EVL("some_label") as ev:
    ev.unlocked = True
    ev.checkAffection(value)
    cmp_value = normal_ev == ev
    get_value = ev.shown_count
    # etc...
```

The above will not crash even if a bad label (or no event object found) occurs, **unless** you write code that would have crashed normally anyway (like calling `ev.checkAffection` with no arguments, etc...). 

In a bad scenario, the behavior of different actions on the `ev` var vary:
* all Event-based properties return default values
* setting properties does nothing
* function calls do nothing 
* the `Event` class is used as a fallback for everything else. 

Two caveats:
1. None checking ev doesnt work (well obviously).
2. when calling a function on a bad `ev`, the object actually being called on is the `MASDummyClass`. if pre-determined default behavior is more desirable, then `_default_values` can be expanded.

### Important things to remember

The normal way (None checking `mas_getEV`) allows us to include backup scenarios if something is off or data is missing. This `with` version of `Event` should only be used when we don't care about a bad case.

# Testing
* try stuff in console. In general, all things normally done with an `Event` object can be done with an instance of `MAS_EVL` regardless of the eventlabel's validity. If the eventlable is real, then the `Event` object will be modified. Otherwise nothing should happen. And as a reminder, anything that doesn't work with a real `Event` object will **not** work with the context manager version.