### PR TITLE
Wiki brackets drop

### DIFF
--- a/Monika After Story/game/zz_windowreacts.rpy
+++ b/Monika After Story/game/zz_windowreacts.rpy
@@ -488,7 +488,7 @@ label mas_wrs_wikipedia:
 
             # May contain clarification in trailing parentheses
             wiki_article = re.sub("\\s*\\(.+\\)$", "", wiki_article)
-            wikipedia_reacts.append("'" + wiki_article + "'...\nSeems interesting, " + player + ".")
+            wikipedia_reacts.append(renpy.substitute("'[wiki_article]'...\nSeems interesting, [player]."))
 
         except ValueError:
             pass

--- a/Monika After Story/game/zz_windowreacts.rpy
+++ b/Monika After Story/game/zz_windowreacts.rpy
@@ -477,13 +477,12 @@ label mas_wrs_wikipedia:
 
     #Items in here will get the wiki article you're looking at for reacts.
     python:
-        import re
         wind_name = mas_getActiveWindow(friendly=True)
         try:
             cutoff_index = wind_name.index(" - Wikipedia")
 
             #If we're still here, we didn't value error
-            #Now we get the article            
+            #Now we get the article
             wiki_article = wind_name[:cutoff_index]
 
             # May contain clarification in trailing parentheses

--- a/Monika After Story/game/zz_windowreacts.rpy
+++ b/Monika After Story/game/zz_windowreacts.rpy
@@ -477,14 +477,17 @@ label mas_wrs_wikipedia:
 
     #Items in here will get the wiki article you're looking at for reacts.
     python:
+        import re
         wind_name = mas_getActiveWindow(friendly=True)
         try:
             cutoff_index = wind_name.index(" - Wikipedia")
 
             #If we're still here, we didn't value error
-            #Now we get the article
-
+            #Now we get the article            
             wiki_article = wind_name[:cutoff_index]
+
+            # May contain clarification in trailing parentheses
+            wiki_article = re.sub("\\s*\\(.+\\)$", "", wiki_article)
             wikipedia_reacts.append(renpy.substitute("'[wiki_article]'...\nSeems interesting, [player]."))
 
         except ValueError:

--- a/Monika After Story/game/zz_windowreacts.rpy
+++ b/Monika After Story/game/zz_windowreacts.rpy
@@ -488,7 +488,7 @@ label mas_wrs_wikipedia:
 
             # May contain clarification in trailing parentheses
             wiki_article = re.sub("\\s*\\(.+\\)$", "", wiki_article)
-            wikipedia_reacts.append("'" + wiki_article + "'...\nSeems interesting, " + player + "."))
+            wikipedia_reacts.append("'" + wiki_article + "'...\nSeems interesting, " + player + ".")
 
         except ValueError:
             pass

--- a/Monika After Story/game/zz_windowreacts.rpy
+++ b/Monika After Story/game/zz_windowreacts.rpy
@@ -488,7 +488,7 @@ label mas_wrs_wikipedia:
 
             # May contain clarification in trailing parentheses
             wiki_article = re.sub("\\s*\\(.+\\)$", "", wiki_article)
-            wikipedia_reacts.append(renpy.substitute("'[wiki_article]'...\nSeems interesting, [player]."))
+            wikipedia_reacts.append("'" + wiki_article + "'...\nSeems interesting, " + player + "."))
 
         except ValueError:
             pass

--- a/Monika After Story/game/zz_windowreacts.rpy
+++ b/Monika After Story/game/zz_windowreacts.rpy
@@ -483,10 +483,11 @@ label mas_wrs_wikipedia:
 
             #If we're still here, we didn't value error
             #Now we get the article
+
             wiki_article = wind_name[:cutoff_index]
             wikipedia_reacts.append(renpy.substitute("'[wiki_article]'...\nSeems interesting, [player]."))
 
-        except:
+        except ValueError:
             pass
 
     $ wrs_success = display_notif(


### PR DESCRIPTION
According to [the Wikipedia article naming conventions](https://en.wikipedia.org/wiki/Wikipedia:Article_titles), round brackets (parentheses) are only supposed to clarify or disambiguate articles.

Changes made in the branch involved in this PR remove trailing parentheses from the article name in window reaction.