### PR TITLE
Improve notify-send command

### DIFF
--- a/Monika After Story/game/zz_windowreacts.rpy
+++ b/Monika After Story/game/zz_windowreacts.rpy
@@ -338,7 +338,7 @@ init python:
         # we have to close the quotation, insert a literal single quote and reopen the quotation.
         body  = body.replace("'", "'\\''")
         title = title.replace("'", "'\\''") # better safe than sorry
-        os.system("notify-send '{0}' '{1}' -a 'Monika After Story' -u low".format(title,body))
+        os.system("notify-send '{0}' '{1}' -a 'Monika' -u low".format(title,body))
 
     def display_notif(title, body, group=None, skip_checks=False):
         """

--- a/Monika After Story/game/zz_windowreacts.rpy
+++ b/Monika After Story/game/zz_windowreacts.rpy
@@ -338,7 +338,7 @@ init python:
         # we have to close the quotation, insert a literal single quote and reopen the quotation.
         body  = body.replace("'", "'\\''")
         title = title.replace("'", "'\\''") # better safe than sorry
-        os.system("notify-send '{0}' '{1}' -u low".format(title,body))
+        os.system("notify-send '{0}' '{1}' -a 'Monika After Story' -u low".format(title,body))
 
     def display_notif(title, body, group=None, skip_checks=False):
         """


### PR DESCRIPTION
There was an unrelated change in #6265 which affected command line arguments passed to `notify-send` shell command.

This PR introduces this change and commit a5cd654 reverts it on its original branch.

Edit: **Note**: `-a` option, as well as `--app-name`, **is not mentioned in man pages**, however, [it is present in libnotify](https://github.com/GNOME/libnotify/blob/98a4bf483a69c6436311bcb9834d9d93235c96b7/tools/notify-send.c#L151) and in `notify-send --help` output.

Edit 2: Merged posts.

Also, I'm not sure whether we should supply 'Monika After Story' or just 'Monika' as the application name.

The first option is more conventional since it pushes notification with the corresponding application name set, but the second option seems to correspond to her telling the player that *she* pushes them personally, and it keeps the fourth wall broken.

Edit 3: `notify-send` accepts `-i` or `--icon` option for setting notification icon. I don't know if that's something we need, but I thought I'd better mention it as well so you'll be aware of this capability if you aren't already.