### PR TITLE
Skip over zero-sized chunks when advancing filter chunks

### DIFF
--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -1283,7 +1283,7 @@ init -10 python:
 
             return "\n".join(output)
 
-        def adv_chunk(self, sfmn, st_index, run_pp, curr_time, force_co):
+        def adv_chunk(self, sfmn, st_index, run_pp, curr_time):
             """
             Runs advance chunks alg, running progpoints but does NOT actually
             set new index. This WILL SET SLICE INDEXES.
@@ -1294,10 +1294,6 @@ init -10 python:
                 run_pp - True will run the progpoints, FAlse will not
                 curr_time - passed to the progpoint. should be current time
                     as a datetime.time object
-                force_co - True will force one chunk advancement. False will
-                    not. This is for cases where we are in the same chunk, but
-                    earlier than the current slice. Doing this allows us to
-                    reset the slice index.
 
             RETURNS: new chunk index
             """
@@ -1305,27 +1301,36 @@ init -10 python:
             c_len = len(self._chunks)
 
             # determine current chunk offsets
+            # Current Beginning OFFset, Next Beginning OFFset
             cb_off, nb_off = self._calc_off(st_index)
+            curr_chunk = self._chunks[st_index]
+            found = False
 
-            # loop unfil sfmn in range of current chunk
-            while sfmn < cb_off or nb_off <= sfmn or force_co:
-                # always set this to false after one iteration
-                force_co = False
+            # force stop iteration if something bad happened
+            iter_stop = 10
 
-                # get chunk chunk
-                curr_chunk = self._chunks[st_index]
+            # loop until we found the chunk, or if we found it, until the first
+            #   non-zero chunk
+            while iter_stop > 0 and (not found or len(curr_chunk) < 1):
 
-                # determine the next current offset and next index
+                # determine next chunk index
+                nxt_index = (st_index + 1) % c_len # next index or 0 if max len
 
-                # next offset or 0 if 86400
+                # next chunk
+                new_chunk = self._chunks[nxt_index]
+
+                # determine next chunk offsets
+                # next curent chunk offset offset or 0 if 86400
                 cb_off = nb_off % (store.mas_utils.secInDay())
-                st_index = (st_index + 1) % c_len # next index or 0 if max len
 
-                # now calc next offset
-                nb_off = cb_off + len(self._chunks[st_index])
+                # next chunk's offset
+                nb_off = cb_off + len(new_chunk)
 
-                # new chunk is
-                new_chunk = self._chunks[st_index]
+                # set found if we found the chunk
+                if not found:
+                    found = cb_off <= sfmn < nb_off
+                    # once this is set, the next loops will only happen if
+                    # current chunks are less than zero
 
                 # lastly run pp if desired
                 if run_pp:
@@ -1335,22 +1340,32 @@ init -10 python:
                         curr_time
                     )
 
-                # always run global after
-                try:
-                    store.mas_background._gbl_chunk_change(
-                        curr_chunk,
-                        new_chunk,
-                        curr_time
-                    )
-                except Exception as e:
-                    store.mas_utils.writelog(self._ERR_PP_STR_G.format(
-                        repr(e),
-                        str(curr_chunk),
-                        str(new_chunk),
-                    ))
+                    # and global 
+                    try:
+                        store.mas_background._gbl_chunk_change(
+                            curr_chunk,
+                            new_chunk,
+                            curr_time
+                        )
+                    except Exception as e:
+                        store.mas_utils.writelog(self._ERR_PP_STR_G.format(
+                            repr(e),
+                            str(curr_chunk),
+                            str(new_chunk),
+                        ))
 
-                # then finally reset slice index for this chunk
+                # then finally reset slice index for the chunk we are leaving
                 curr_chunk.reset_index()
+                
+                # and set the current chunk to next chunk
+                curr_chunk = new_chunk
+                st_index = nxt_index
+
+                iter_stop -= 1
+
+            if iter_stop < 1:
+                # this is bad
+                raise Exception("inf looped here")
 
             return st_index
 
@@ -1695,20 +1710,21 @@ init -10 python:
             pos_data = self.current_pos()
 
             # are we technically in same chunk but before in time?
-            # if so, we need to force a chunk move
-            force_co = (
-                pos_data[1] <= sfmn < pos_data[2]  # in same chunk
-                and sfmn < (pos_data[1] + pos_data[4]) # earlier than slice
-            )
+            # reset the current chunk's slice index then advance
+            if (
+                    pos_data[1] <= sfmn < pos_data[2]  # in same chunk
+                    and sfmn < (pos_data[1] + pos_data[4]) # earlier than slice
+            ):
+                self._current_chunk().reset_index()
 
-            # start by advancing chunks correctly, if needed
-            self._index = self.adv_chunk(
-                sfmn,
-                self._index,
-                True,
-                curr_time,
-                force_co
-            )
+            else:
+                # start by advancing chunks correctly, if needed
+                self._index = self.adv_chunk(
+                    sfmn,
+                    self._index,
+                    True,
+                    curr_time
+                )
 
             # now we can start advancing slices
             return self._chunks[self._index].progress(
@@ -1743,19 +1759,15 @@ init -10 python:
             self._prev_flt = self.current()
 
             # establish seconds
+            # Seconds From MidNight
             sfmn = store.mas_utils.time2sec(curr_time)
 
-            # establish chunk index
-            boff, eoff = self._calc_off(0)
-            cindex = 0
-            while cindex < len(self._chunks)-1 and (sfmn < boff or eoff <= sfmn):
-                # determine next offsets
-                cindex += 1
-                boff, eoff = self._calc_off(cindex)
+            cindex = self.adv_chunk(sfmn, 0, False, curr_time)
 
             # we should now be in the correct index probably
             self._chunks[self._index].reset_index()
             self._index = cindex
+            boff, eoff = self._calc_off(cindex)
             self._chunks[cindex].update(sfmn - boff)
 
             # mark that we used update

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -2685,6 +2685,7 @@ init 800 python:
 
         if new_background != mas_current_background:
             mas_current_background.exit(new_background, **kwargs)
+            new_background.update() # NOTE: do not put this in setBackground.
             mas_setBackground(new_background, **kwargs)
 
         store.mas_is_indoors = store.mas_background.EXP_TYPE_OUTDOOR not in new_background.ex_props


### PR DESCRIPTION
# Problem Summary
When sunrise (or both sunrise/sunset) is set to 00:00, the corresponding filter chunk ends up with 0 filter slices. This causes the progression/chunk advancement/slice advancement algorithm to fail since it assumes all chunks have slices.

Apparently this also causes the bg to disappear in custom bgs. This might be because the bg doesn't have a setting for FLT_DAY, as FLT_DAY is the default if we cant find any other filter. However I don't know if this is entirely the case for custom bgs, but the fix will handle that since we won't be crashing in the chunk adv alg anymore.

# Key Changes
* In the chunk advancement alg, skip over chunks with zero length, until the next non-zero sized chunk. This means that if sunrise is set to 00:00. the first chunk will always be the SS to SR chunk. If both sunrise/sunset are set to 00:00, the first (and only) chunk will be SR to MN.
* changed `update` to use the chunk adv alg instead of a slimmed copy of it

# Testing

### normal
1. set sunrise (or both ss/sr) to 00:00
2. force spaceroom progression by opening talk menu
3. verify correct filter is used

### custom bg
1. set sunrise (or both ss/sr) to 00:00
2. change bg
3. verify bg not gone and correct filter is used