### PR TITLE
cleans travis output of dynamic sprite errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,5 @@ env:
 # command to check syntax
 script: 
     - python MonikaModDev/tools/travis.py
-    - cd renpy && ./renpy.sh "../mas0105/" lint > renpy_output 
+    - cd renpy && ./renpy.sh "../mas0105/" lint > renpy_output && python ../MonikaModDev/tools/renpy_lint_parser.py && cat renpy_output_clean
     - ./renpy.sh launcher distribute "../mas0105/"
-    - python ../MonikaModDev/tools/renpy_lint_parser.py
-    - cat renpy_output_clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,4 @@ script:
     - cd renpy && ./renpy.sh "../mas0105/" lint > renpy_output 
     - ./renpy.sh launcher distribute "../mas0105/"
     - python ../MonikaModDev/tools/renpy_lint_parser.py
+    - cat renpy_output_clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,6 @@ env:
 # command to check syntax
 script: 
     - python MonikaModDev/tools/travis.py
-    - cd renpy && ./renpy.sh "../mas0105/" lint && ./renpy.sh launcher distribute "../mas0105/"
+    - cd renpy && ./renpy.sh "../mas0105/" lint > renpy_output 
+    - ./renpy.sh launcher distribute "../mas0105/"
+    - python ../MonikaModDev/tools/renpy_lint_parser.py

--- a/tools/renpy_lint_parser.py
+++ b/tools/renpy_lint_parser.py
@@ -8,7 +8,7 @@ import os
 # regex parsing
 
 IMG_NOT_FOUND = re.compile(
-    "\w+/(\w+/)*.+\.rpy:\d+ (Could not find image \(monika |The image named 'monika )\d\w\w\w+"
+    "\w+/(\w+/)*.+\.rpy:\d+ (Could not find image \(monika |The image named 'monika )\d\w+"
 )
 
 # file load

--- a/tools/renpy_lint_parser.py
+++ b/tools/renpy_lint_parser.py
@@ -8,7 +8,7 @@ import os
 # regex parsing
 
 IMG_NOT_FOUND = re.compile(
-    "\w+/(\w+/)*.+\.rpy:\d+ (Could not find image \(monika |The image named 'monika )(\d\w\w\w+|\d\w|1|5|g1|g2)"
+    "\w+/(\w+/)*.+\.rpy:\d+ (Could not find image \(monika |The image named 'monika )(\d\w\w\w+|\d\w|1|5|4|g1|g2)"
 )
 
 # file load

--- a/tools/renpy_lint_parser.py
+++ b/tools/renpy_lint_parser.py
@@ -8,7 +8,7 @@ import os
 # regex parsing
 
 IMG_NOT_FOUND = re.compile(
-    "\w+/(\w+/)*\w+\.rpy:\d+ (Could not find image \(monika |The image named 'monika )\d\w\w\w+"
+    "\w+/(\w+/)*.+\.rpy:\d+ (Could not find image \(monika |The image named 'monika )\d\w\w\w+"
 )
 
 # file load

--- a/tools/renpy_lint_parser.py
+++ b/tools/renpy_lint_parser.py
@@ -1,0 +1,32 @@
+# parses renpy_output and removes missing dynamic image lines. 
+# (and other known things)
+
+import re
+import os
+
+
+# regex parsing
+
+IMG_NOT_FOUND = re.compile(
+    "\w+/\w+\.rpy:\d+ (Could not find image \(monika |The image named 'monika )\d\w\w\w+"
+)
+
+# file load
+
+IN_FILENAME = "renpy_output"
+OUT_FILENAME = "renpy_output_clean"
+
+# load files
+INFILE = open(IN_FILENAME, "r")
+OUTFILE = open(OUT_FILENAME, "w")
+
+if not INFILE or not OUTFILE:
+    print("file load failed")
+    exit(1)
+
+# loop and clean
+for line in INFILE:
+    if not IMG_NOT_FOUND.match(line):
+        OUTFILE.write(line)
+
+exit(0)

--- a/tools/renpy_lint_parser.py
+++ b/tools/renpy_lint_parser.py
@@ -27,7 +27,7 @@ if not INFILE or not OUTFILE:
 # loop and clean
 for line in INFILE:
     if (
-            len(line.strip) > 0
+            len(line.strip()) > 0
             and not IMG_NOT_FOUND.match(line)
     ):
         OUTFILE.write(line)

--- a/tools/renpy_lint_parser.py
+++ b/tools/renpy_lint_parser.py
@@ -8,7 +8,7 @@ import os
 # regex parsing
 
 IMG_NOT_FOUND = re.compile(
-    "\w+/(\w+/)*.+\.rpy:\d+ (Could not find image \(monika |The image named 'monika )\d\w+"
+    "\w+/(\w+/)*.+\.rpy:\d+ (Could not find image \(monika |The image named 'monika )(\d\w\w\w+|\d\w|1|5|g1|g2)"
 )
 
 # file load

--- a/tools/renpy_lint_parser.py
+++ b/tools/renpy_lint_parser.py
@@ -32,4 +32,6 @@ for line in INFILE:
     ):
         OUTFILE.write(line)
 
+INFILE.close()
+OUTFILE.close()
 exit(0)

--- a/tools/renpy_lint_parser.py
+++ b/tools/renpy_lint_parser.py
@@ -8,7 +8,7 @@ import os
 # regex parsing
 
 IMG_NOT_FOUND = re.compile(
-    "\w+/\w+\.rpy:\d+ (Could not find image \(monika |The image named 'monika )\d\w\w\w+"
+    "\w+/(\w+/)*\w+\.rpy:\d+ (Could not find image \(monika |The image named 'monika )\d\w\w\w+"
 )
 
 # file load
@@ -26,7 +26,10 @@ if not INFILE or not OUTFILE:
 
 # loop and clean
 for line in INFILE:
-    if not IMG_NOT_FOUND.match(line):
+    if (
+            len(line.strip) > 0
+            and not IMG_NOT_FOUND.match(line)
+    ):
         OUTFILE.write(line)
 
 exit(0)


### PR DESCRIPTION
# Key Changes
* Basically any line that says a monika image could not be found is removed from the lint output.

# Testing
* check the travis log for this build and see no more img not found output (that is monika related)
* try causing a travis error and push to ur own repo and see if the error information is still shown.