### PR TITLE
Animation fixes

### DIFF
--- a/Monika After Story/game/zz_transforms.rpy
+++ b/Monika After Story/game/zz_transforms.rpy
@@ -170,6 +170,7 @@ transform mas_chlongjump(x, y, ymax, travel_time=1.0):
 
 #START: Transforms for Monika's sprite animations (blinking/winking/tear-specific-blinking)
 transform blink_transform(open_eyes_img, closed_eyes_img):
+    animation
     block:
         open_eyes_img
         block:
@@ -180,16 +181,24 @@ transform blink_transform(open_eyes_img, closed_eyes_img):
             choice:
                 7
         closed_eyes_img
+        choice 0.02:
+            0.03
+            open_eyes_img
+            0.1
+            closed_eyes_img
+        choice 0.98:
+            pass
         0.06
         repeat
 
-transform wink_transform(wink_img, open_eye_img):
+transform wink_transform(wink_img, open_eyes_img):
     block:
         wink_img
         1
-        open_eye_img
+        open_eyes_img
 
 transform streaming_tears_transform(open_eyes_img, closed_eyes_img):
+    animation
     block:
         open_eyes_img
         block:


### PR DESCRIPTION
Some fixed to our transforms. *Ideally* this should fix the issue when the blink transform ends mid-animation, or bug when eyes stay at the same place during pose change. Stuff like those.

This also adds a chance for Monika to blink twice in a short time. Because it's cute. Feel free to adjust the timings if you want.

### Testing:
- There's not much you can do, those bugs are inconsistent, just give it a try and see if everything looks good overall.
- For testing purposes you can kick up the chance for double blink.