### PR TITLE
Enable to change the calendar note font for the translation submod

### DIFF
--- a/Monika After Story/game/zz_calendar.rpy
+++ b/Monika After Story/game/zz_calendar.rpy
@@ -690,6 +690,7 @@ M̼̤̱͇̤ ͈̰̬͈̭ͅw̩̜͇͈ͅa̲̩̭̩ͅs̙ ̣͔͓͚̰h̠̯̫̼͉e̗̗̮r�
                                 size=note_text_size,
                                 color=note_color,
                                 outlines=[],
+                                xsize=110,
                                 pos=(8, note_ystart + k * 17)
                             )
                             text_container.add(note_text)

--- a/Monika After Story/game/zz_calendar.rpy
+++ b/Monika After Story/game/zz_calendar.rpy
@@ -84,6 +84,9 @@ init -1 python:
         # Color used for the note
         NOTE_COLOR = "#181818"
 
+        # Font used for the note
+        NOTE_FONT = "gui/font/m1.TTF"
+
         # Month names constant array
         MONTH_NAMES = ["Unknown", "January", "February",
             "March", "April", "May", "June", "July",
@@ -523,7 +526,7 @@ M̼̤̱͇̤ ͈̰̬͈̭ͅw̩̜͇͈ͅa̲̩̭̩ͅs̙ ̣͔͓͚̰h̠̯̫̼͉e̗̗̮r�
             self.day_button_texts = []
 
             # set the note style attributes
-            note_font = "gui/font/m1.TTF"
+            note_font = self.NOTE_FONT
             note_text_size = self.NOTE_TEXT_SIZE
             note_color = self.NOTE_COLOR
             note_ystart = 1

--- a/Monika After Story/game/zz_calendar.rpy
+++ b/Monika After Story/game/zz_calendar.rpy
@@ -85,7 +85,7 @@ init -1 python:
         NOTE_COLOR = "#181818"
 
         # Font used for the note
-        NOTE_FONT = "gui/font/m1.TTF"
+        NOTE_FONT = "mod_assets/font/m1_fixed.ttf"
 
         # Month names constant array
         MONTH_NAMES = ["Unknown", "January", "February",

--- a/Monika After Story/game/zz_calendar.rpy
+++ b/Monika After Story/game/zz_calendar.rpy
@@ -690,7 +690,6 @@ M̼̤̱͇̤ ͈̰̬͈̭ͅw̩̜͇͈ͅa̲̩̭̩ͅs̙ ̣͔͓͚̰h̠̯̫̼͉e̗̗̮r�
                                 size=note_text_size,
                                 color=note_color,
                                 outlines=[],
-                                xsize=110,
                                 pos=(8, note_ystart + k * 17)
                             )
                             text_container.add(note_text)


### PR DESCRIPTION
It makes it easy to change the calendar node font and wraps it if the note is long.