### PR TITLE
Fix singleton

### DIFF
--- a/Monika After Story/game/python-packages/singleton.py
+++ b/Monika After Story/game/python-packages/singleton.py
@@ -44,7 +44,7 @@ class SingleInstance:
                 if e.errno in (13, 17):
                     # logger.error("Another instance is already running, quitting.")
                     raise SingleInstanceException(
-                        "Another instance is already running, quitting. If the issue persist, restart your computer or manually delete '{0}'".format(
+                        "Another instance is already running, quitting. If the issue persists, restart your computer or manually delete '{0}'".format(
                             self.lockfile
                         )
                     )
@@ -62,7 +62,7 @@ class SingleInstance:
             except IOError:
                 # logger.warning("Another instance is already running, quitting.")
                 raise SingleInstanceException(
-                    "Another instance is already running, quitting. If the issue persist, restart your computer or manually delete '{0}'".format(
+                    "Another instance is already running, quitting. If the issue persists, restart your computer or manually delete '{0}'".format(
                         self.lockfile
                     )
                 )

--- a/Monika After Story/game/python-packages/singleton.py
+++ b/Monika After Story/game/python-packages/singleton.py
@@ -3,12 +3,10 @@
 import sys
 import os
 import tempfile
-import logging
-
+# import logging
 
 class SingleInstanceException(BaseException):
     pass
-
 
 class SingleInstance:
 
@@ -24,9 +22,7 @@ class SingleInstance:
 
     Providing a flavor_id will augment the filename with the provided flavor_id, allowing you to create multiple singleton instances from the same file. This is particularly useful if you want specific functions to have their own singleton instances.
     """
-
     def __init__(self, flavor_id=""):
-        import sys
         self.initialized = False
         basename = os.path.splitext(os.path.abspath(sys.argv[0]))[0].replace(
             "/", "-").replace(":", "").replace("\\", "-") + '-%s' % flavor_id + '.lock'
@@ -34,68 +30,78 @@ class SingleInstance:
         self.lockfile = os.path.normpath(
             tempfile.gettempdir() + '/' + basename)
 
-        logger.debug("SingleInstance lockfile: " + self.lockfile)
+        # logger.debug("SingleInstance lockfile: " + self.lockfile)
         if sys.platform == 'win32':
             try:
                 # file already exists, we try to remove (in case previous
                 # execution was interrupted)
                 if os.path.exists(self.lockfile):
                     os.unlink(self.lockfile)
-                self.fd = os.open(
-                    self.lockfile, os.O_CREAT | os.O_EXCL | os.O_RDWR)
-            except OSError:
-                type, e, tb = sys.exc_info()
-                if e.errno == 13:
-                    logger.error(
-                        "Another instance is already running, quitting.")
-                    raise SingleInstanceException()
-                print(e.errno)
+                self.fd = os.open(self.lockfile, os.O_CREAT | os.O_EXCL | os.O_RDWR)
+
+            except OSError as e:
+                # _type, e, tb = sys.exc_info()
+                if e.errno in (13, 17):
+                    # logger.error("Another instance is already running, quitting.")
+                    raise SingleInstanceException(
+                        "Another instance is already running, quitting. If the issue persist, restart your computer or manually delete '{0}'".format(
+                            self.lockfile
+                        )
+                    )
+                # print(e.errno)
                 raise
-        else:  # non Windows
+
+        # non Windows
+        else:
             import fcntl
             self.fp = open(self.lockfile, 'w')
             self.fp.flush()
             try:
                 fcntl.lockf(self.fp, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
             except IOError:
-                logger.warning(
-                    "Another instance is already running, quitting.")
-                raise SingleInstanceException()
+                # logger.warning("Another instance is already running, quitting.")
+                raise SingleInstanceException(
+                    "Another instance is already running, quitting. If the issue persist, restart your computer or manually delete '{0}'".format(
+                        self.lockfile
+                    )
+                )
+
         self.initialized = True
 
     def __del__(self):
-        import sys
-        import os
         if not self.initialized:
             return
+
         try:
             if sys.platform == 'win32':
                 if hasattr(self, 'fd'):
                     os.close(self.fd)
                     os.unlink(self.lockfile)
+
             else:
                 import fcntl
                 fcntl.lockf(self.fp, fcntl.LOCK_UN)
                 # os.close(self.fp)
                 if os.path.isfile(self.lockfile):
                     os.unlink(self.lockfile)
+
         except Exception as e:
-            if logger:
-                logger.warning(e)
-            else:
-                print("Unloggable error: %s" % e)
+            # if logger:
+            #     logger.warning(e)
+            # else:
+            #     print("Unloggable error: %s" % e)
             sys.exit(-1)
 
+# def f(name):
+#     tmp = logger.level
+#     logger.setLevel(logging.CRITICAL)  # we do not want to see the warning
+#     try:
+#         me2 = SingleInstance(flavor_id=name)  # noqa
+#     except SingleInstanceException:
+#         sys.exit(-1)
+#     logger.setLevel(tmp)
+#     pass
 
-def f(name):
-    tmp = logger.level
-    logger.setLevel(logging.CRITICAL)  # we do not want to see the warning
-    try:
-        me2 = SingleInstance(flavor_id=name)  # noqa
-    except SingleInstanceException:
-        sys.exit(-1)
-    logger.setLevel(tmp)
-    pass
-
-logger = logging.getLogger("tendo.singleton")
-logger.addHandler(logging.StreamHandler())
+# logger = logging.getLogger("tendo.singleton")
+# logger.addHandler(logging.StreamHandler())


### PR DESCRIPTION
This saves us time explaining to people why they can't boot up the game and how to fix it.

### Changes:
- The exception now shows proper information to the user.
- We're catching `OSError 17` for windows now (because this is the actual "file already exists" error).
- Removed (commented out) logging; `singleton` logs to the same file in which renpy does, which leads to a big unreadable mess.
- Cleanup to make its code a bit more readable (no actual changes to how it works).

### Testing:
- verify we show the appropriate message on singleton crashes.