### PR TITLE
Update mas_showEVL to pop from the derand list.

### DIFF
--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -767,8 +767,8 @@ init 6 python:
             use mas_protectedShowEVL
         """
 
-        if _random and ev_label in persistent._mas_player_derandomed:
-            persistent._mas_player_derandomed.remove(ev_label)
+        if _random:
+            store.mas_bookmarks_derand.removeDerand(ev_label)
 
         store.mas_showEvent(
             mas_all_ev_db_map.get(code, {}).get(ev_label, None),

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -758,7 +758,18 @@ init 6 python:
                 (Default: False)
             _pool - True if we want to random thsi event
                 (Default: False)
+
+        NOTE:
+            if using this to random, it does not protect labels that are in persistent._mas_player_derandomed
+            and thus will remove the label from that list if present.
+
+            if the label should not be randomed if it's in persistent._mas_player_derandomed
+            use mas_protectedShowEVL
         """
+
+        if _random and ev_label in persistent._mas_player_derandomed:
+            persistent._mas_player_derandomed.remove(ev_label)
+
         store.mas_showEvent(
             mas_all_ev_db_map.get(code, {}).get(ev_label, None),
             unlock=unlock,

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -701,6 +701,22 @@ init python in mas_bookmarks_derand:
         """
         store.mas_gainAffection(amount, modifier, bypass)
 
+    def removeDerand(eventlabel):
+        """
+        Removes a derandomed eventlabel from ALL derandom dbs
+
+        IN:
+            eventlabel - Eventlabel to remove
+        """
+        derand_dbs = [
+            label_prefix_data["derand_persist_key"]
+            for label_prefix_data in label_prefix_map.itervalues()
+            if "derand_persist_key" in label_prefix_data
+        ]
+
+        for derand_db in derand_dbs:
+            if eventlabel in derand_db:
+                persistent.__dict__[derand_db].remove(eventlabel)
 
 ##Generic rerandom work label
 #IN:


### PR DESCRIPTION
Currently, when `mas_showEVL()` is used to random an event, it does not take into account if that event is present in `persistent._mas_player_derandomed` which essentially means the event will not be properly randomed, since we run checks in ch30_reset via `mas_check_player_derand()`. This will make it so `mas_showEVL()` pops the event from `persistent._mas_player_derandomed` essentially making it an override in the case where we so drastically change a topic, it deserves to be re-randed. In the event where we do not want to override the player's pref (the most common scenario), `mas_protectedShowEVL()` would be used.

Also adds `removeDerand()` which will remove a player_derandomed event from any of the derand lists (currently eve and sng, but more could be added later and this will cover any of them).