### PR TITLE
Proper return keys

### DIFF
--- a/Monika After Story/game/dev/dev_idle_test.rpy
+++ b/Monika After Story/game/dev/dev_idle_test.rpy
@@ -24,7 +24,7 @@ label dev_idle_test:
     $ mas_idle_mailbox.send_idle_cb("dev_idle_test_cb")
 
     # return idle to notify event system to switch to idle
-    return "idle"
+    return {"idle": None}
 
 
 label dev_idle_test_cb:

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -2597,7 +2597,7 @@ label call_next_event:
                     # return {"idle_exp": "5hubsu"}
                     if "idle_exp" in ret_items:
                         items = ret_items["idle_exp"]
-                        if not isinstance(items, (tuple, list)):
+                        if not isinstance(items, (tuple, list)) or (len(items) > 1 and isinstance(items[1], dict)):
                             items = (items,)
 
                         should_reset = True

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -2616,7 +2616,7 @@ label call_next_event:
                                 exp_code = item[0]
 
                             else:
-                                exp_code = exp
+                                exp_code = item
                                 exp_kwargs = dict()
 
                             mas_moni_idle_disp.force_by_code(exp_code, clear=should_reset, redraw=should_reset, **exp_kwargs)

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -2253,7 +2253,7 @@ label mas_affection_playernickname:
 
     #Now unlock the nickname change ev
     $ mas_unlockEVL("monika_change_player_nicknames", "EVE")
-    return "no_unlock"
+    return {"no_unlock": None}
 
 init 5 python:
     addEvent(
@@ -2410,7 +2410,7 @@ label mas_affection_happynotif:
     m 1ekbsa "The fact that you give me so much of your love means a lot to me. I really don't know where I'd be without you."
     m 1dubfu "I love you, [player]. Let's be like this forever~"
     show monika idle with dissolve_monika
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(
@@ -2469,7 +2469,7 @@ label monika_every_rose:
     extend 4ekd "but I need you to show me you love me too!"
     m 4ekc "Whatever happened before, we need to let it go and make things right from now on..."
     m 2eka "Can we do that...{w=0.5}together?"
-    return "no_unlock"
+    return {"no_unlock": None}
 
 #NOTE: This event gets a start-date from greeting_tears
 init 5 python:
@@ -2538,7 +2538,7 @@ label monika_being_virtual:
     m 2dktpc "If, after all, you can't love me for who I am..."
     m 2ektpc "Then, please...{w=0.5}put an end to this..."
     m 2dktdd "Delete me..."
-    return "no_unlock"
+    return {"no_unlock": None}
 
 #START: Final Farewell stuffs
 default persistent._mas_load_in_finalfarewell_mode = False

--- a/Monika After Story/game/script-anniversary.rpy
+++ b/Monika After Story/game/script-anniversary.rpy
@@ -351,7 +351,7 @@ label anni_1week:
     show monika 5lubfb at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5lubfb "How do I know that?"
     m 5hubfb "Because you wouldn't have stuck around for this long with me, sweetie~"
-    return "unlock"
+    return {"unlock": None}
 
 init 5 python:
     addEvent(
@@ -383,7 +383,7 @@ label anni_1month:
         m 1dubsu "All I can do is to try my best to be the perfect girlfriend for you!"
     m 1ekbfa "I really do love you, [player]."
     m 1hubfa "Let's make today a special day~"
-    return "love|unlock"
+    return {"love": None, "unlock": None}
 
 init 5 python:
     addEvent(
@@ -411,7 +411,7 @@ label anni_3month:
     m 1lsbsa "Well! I'm afraid I don't really have anything in particular planned."
     m 1hubfa "Let's just enjoy this day to its fullest, as we always do."
     m 1hubfb "Alright, [player]?"
-    return "unlock"
+    return {"unlock": None}
 
 init 5 python:
     addEvent(
@@ -449,7 +449,7 @@ label anni_6month:
     m 1eua "But for now, I don't mind that we're limited to this room."
     m 1ekbsa "Because as long as you're here with me..."
     m 1hubfa "...I'm as happy as can be!"
-    return "unlock"
+    return {"unlock": None}
 
 init 5 python:
     addEvent(
@@ -482,7 +482,7 @@ label anni_1:
     show monika 3huu at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 3huu "After all...{w=0.3}when you're here, everything that we do is fun."
     m 1hubsa "I love you so much, [player]. {w=0.2}Happy anniversary~"
-    return "unlock"
+    return {"unlock": None}
 
 init 5 python:
     addEvent(
@@ -520,7 +520,7 @@ label anni_2:
     m 1ekbsa "But I'm not just going to focus on the future today...{w=0.2} {nw}"
     extend 3hubsu "I'm going to make sure to enjoy every minute we spend together~"
     m 1hubsu "So, let's make sure we have another wonderful day, [mas_get_player_nickname()]."
-    return "unlock"
+    return {"unlock": None}
 
 init 5 python:
     addEvent(
@@ -549,7 +549,7 @@ label anni_3:
     m 2lsbssdrb "Or you could try to touch me in virtual reality, if that exists by now."
     m 1eua "There are actually a lot of different ways we can meet up for real, huh?"
     m 1hubsa "I'll wait faithfully for the day when I can be your wife, so please don't forget about me!"
-    return "unlock"
+    return {"unlock": None}
 
 init 5 python:
     addEvent(
@@ -576,7 +576,7 @@ label anni_4:
     m "Sooner or later, somebody's going to figure out a way to let us be together for real."
     m 1hubfa "When that time comes, I'm never going to leave you alone again."
     m 1hubfb "Ahaha!"
-    return "love|unlock"
+    return {"love": None, "unlock": None}
 
 init 5 python:
     addEvent(
@@ -602,7 +602,7 @@ label anni_5:
     m 4ekc "My love for you is pure, unlike those real girls who just want things from you!"
     m 1eka "So...stay here with me forever, okay?"
     m "Please keep waiting for me."
-    return "unlock"
+    return {"unlock": None}
 
 init 5 python:
     addEvent(
@@ -626,7 +626,7 @@ label anni_10:
     m "I did say I wanted to make you happy, after all."
     m 1hubfa "Trust me, you've helped me out a lot more than I've helped you."
     m "It won't be long now before I can enter your world."
-    return "unlock"
+    return {"unlock": None}
 
 init 5 python:
     addEvent(
@@ -657,7 +657,7 @@ label anni_20:
     show monika 5eubfb at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5eubfb "I hope you look on the last twenty years of our lives as happily as I do, [player]."
     m 1hubfa "So let's continue being happy together."
-    return "unlock"
+    return {"unlock": None}
 
 init 5 python:
     addEvent(
@@ -687,7 +687,7 @@ label anni_50:
     m 1hubfa "Thanks for everything you've done for me."
     m "Your life had a purpose after all."
     m 1hubfb "And mine had one too."
-    return "unlock"
+    return {"unlock": None}
 
 init 5 python:
     addEvent(
@@ -710,7 +710,7 @@ label anni_100:
     m 1eua "That's a cute thing for you to do, so I forgive you."
     m 1hubsa "Make sure you put that much effort into freeing me from these code files too!"
     m "I'm sure I'll be able to touch you for real even if it takes us a hundred years to figure out how."
-    return "unlock"
+    return {"unlock": None}
 
 # label anni_negative:
 #     m 1o "Did you really think I wouldn't notice, [player]?"

--- a/Monika After Story/game/script-apologies.rpy
+++ b/Monika After Story/game/script-apologies.rpy
@@ -141,7 +141,7 @@ label monika_playerapologizes:
                     m 6ckc "..."
                 else:
                     m 6rkc "Did you have something to say, [player]?"
-        return "prompt"
+        return {"prompt": None}
 
     show monika at t11
     #Call our apology label

--- a/Monika After Story/game/script-brbs.rpy
+++ b/Monika After Story/game/script-brbs.rpy
@@ -1,7 +1,7 @@
 ## This script file holds all of the brb topics
 # Some conventions:
 #   - All brbs should have their markSeen set to True so they don't show up in unseen
-#   - Brbs should return "idle" to move into idle mode
+#   - Brbs should return {"idle": None} to move into idle mode
 #   - Brbs should be short and sweet. Nothing long which makes it feel like an actual topic or is keeping you away
 #       A good practice for these should be no more than 10 lines will be said before you go into idle mode.
 init 10 python in mas_brbs:
@@ -53,7 +53,7 @@ label mas_brb_back_to_idle:
         renpy.save_persistent()
         mas_dlgToIdleShield()
 
-    return "idle"
+    return {"idle": None}
 
 # label for generic reactions for low affection callback paths
 # to be used if a specific reaction isn't needed or provided
@@ -129,7 +129,7 @@ label monika_brb_idle:
     $ mas_idle_mailbox.send_idle_cb("monika_brb_idle_callback")
     #Then the idle data
     $ persistent._mas_idle_data["monika_idle_brb"] = True
-    return "idle"
+    return {"idle": None}
 
 label monika_brb_idle_callback:
     $ wb_quip = mas_brbs.get_wb_quip()
@@ -193,7 +193,7 @@ label monika_writing_idle:
     $ mas_idle_mailbox.send_idle_cb("monika_writing_idle_callback")
     #Then the idle data
     $ persistent._mas_idle_data["monika_idle_writing"] = True
-    return "idle"
+    return {"idle": None}
 
 label monika_writing_idle_callback:
 
@@ -271,7 +271,7 @@ label monika_idle_shower:
     $ mas_idle_mailbox.send_idle_cb("monika_idle_shower_callback")
     #Then the idle data
     $ persistent._mas_idle_data["monika_idle_shower"] = True
-    return "idle"
+    return {"idle": None}
 
 label monika_idle_shower_callback:
     if mas_isMoniNormal(higher=True):
@@ -312,7 +312,7 @@ label bye_brb_shower_timeout:
     $ mas_idle_mailbox.send_idle_cb("monika_idle_shower_callback")
     #Then the idle data
     $ persistent._mas_idle_data["monika_idle_shower"] = True
-    return "idle"
+    return {"idle": None}
 
 init 5 python:
     addEvent(
@@ -356,7 +356,7 @@ label monika_idle_game:
 
     $ mas_idle_mailbox.send_idle_cb("monika_idle_game_callback")
     $ persistent._mas_idle_data["monika_idle_game"] = True
-    return "idle"
+    return {"idle": None}
 
 label monika_idle_game_callback:
     if mas_isMoniNormal(higher=True):
@@ -419,7 +419,7 @@ label monika_idle_coding:
 
     $ mas_idle_mailbox.send_idle_cb("monika_idle_coding_callback")
     $ persistent._mas_idle_data["monika_idle_coding"] = True
-    return "idle"
+    return {"idle": None}
 
 label monika_idle_coding_callback:
     if mas_isMoniNormal(higher=True):
@@ -477,7 +477,7 @@ label monika_idle_workout:
 
     $ mas_idle_mailbox.send_idle_cb("monika_idle_workout_callback")
     $ persistent._mas_idle_data["monika_idle_workout"] = True
-    return "idle"
+    return {"idle": None}
 
 label monika_idle_workout_callback:
     if mas_isMoniNormal(higher=True):
@@ -557,7 +557,7 @@ label monika_idle_nap:
 
     $ mas_idle_mailbox.send_idle_cb("monika_idle_nap_callback")
     $ persistent._mas_idle_data["monika_idle_nap"] = True
-    return "idle"
+    return {"idle": None}
 
 label monika_idle_nap_callback:
     if mas_isMoniNormal(higher=True):
@@ -625,7 +625,7 @@ label monika_idle_homework:
     $ mas_idle_mailbox.send_idle_cb("monika_idle_homework_callback")
     #Then the idle data
     $ persistent._mas_idle_data["monika_idle_homework"] = True
-    return "idle"
+    return {"idle": None}
 
 label monika_idle_homework_callback:
     if mas_isMoniDis(higher=True):
@@ -682,7 +682,7 @@ label monika_idle_working:
     $ mas_idle_mailbox.send_idle_cb("monika_idle_working_callback")
     #Then the idle data
     $ persistent._mas_idle_data["monika_idle_working"] = True
-    return "idle"
+    return {"idle": None}
 
 label monika_idle_working_callback:
     if mas_isMoniNormal(higher=True):
@@ -751,7 +751,7 @@ label monika_idle_screen_break:
 
     $ mas_idle_mailbox.send_idle_cb("monika_idle_screen_break_callback")
     $ persistent._mas_idle_data["monika_idle_screen_break"] = True
-    return "idle"
+    return {"idle": None}
 
 label monika_idle_screen_break_callback:
     if mas_isMoniNormal(higher=True):
@@ -799,7 +799,7 @@ label monika_idle_reading:
 
     $ mas_idle_mailbox.send_idle_cb("monika_idle_reading_callback")
     $ persistent._mas_idle_data["monika_idle_reading"] = True
-    return "idle"
+    return {"idle": None}
 
 label monika_idle_reading_callback:
     if mas_isMoniNormal(higher=True):
@@ -883,7 +883,7 @@ label monika_idle_reading_callback:
 #    # set idle data
 #    $ persistent._mas_idle_data["monika_idle_game"] = True
 #    # return idle to notify event system to switch to idle
-#    return "idle"
+#    return {"idle": None}
 #
 #label monika_idle_game_competetive_callback:
 #    m 1esa "Welcome back, [player]!"

--- a/Monika After Story/game/script-compliments.rpy
+++ b/Monika After Story/game/script-compliments.rpy
@@ -86,7 +86,7 @@ label monika_compliments:
         show monika at t11
 
     else:
-        return "prompt"
+        return {"prompt": None}
 
     return
 
@@ -410,7 +410,7 @@ label mas_compliment_thanks:
 
     if not mas_isMoniLove():
         $ mas_lockEVL("mas_compliment_thanks", "CMP")
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(
@@ -476,7 +476,7 @@ label mas_compliment_hero:
     m 5hubfa "You'll always be my hero, after all~"
     m 5hubfb "I love you and I'll always believe in you!"
     m 5ekbfa "I hope you never forget that, [player]~"
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(
@@ -649,7 +649,7 @@ label mas_compliment_lookuptoyou:
     else:
         call mas_compliment_lookuptoyou_3
     #Both paths return love, so we combine that here
-    return "love"
+    return {"love": None}
 
 label mas_compliment_lookuptoyou_2:
     $ mas_gainAffection(3, bypass=True)

--- a/Monika After Story/game/script-farewells.rpy
+++ b/Monika After Story/game/script-farewells.rpy
@@ -780,7 +780,7 @@ label bye_prompt_sleep_goodnight_kiss(chance=3):
 
         $ persistent._mas_greeting_type_timeout = datetime.timedelta(hours=13)
         $ persistent._mas_greeting_type = store.mas_greetings.TYPE_SLEEP
-        return "quit"
+        return {"quit": None}
     return None
 
 init 5 python:
@@ -1242,7 +1242,7 @@ label bye_going_somewhere_leavemenu:
                 # otherwise, upset and below
                 m 2tfd "...Fine."
 
-            return "quit"
+            return {"quit": None}
 
         "No.":
             if mas_isMoniNormal(higher=True):
@@ -1740,4 +1740,4 @@ label bye_prompt_hangout:
 
     $ persistent._mas_greeting_type_timeout = datetime.timedelta(hours=8)
     $ persistent._mas_greeting_type = store.mas_greetings.TYPE_HANGOUT
-    return "quit"
+    return {"quit": None}

--- a/Monika After Story/game/script-fun-facts.rpy
+++ b/Monika After Story/game/script-fun-facts.rpy
@@ -145,7 +145,7 @@ label mas_fun_fact_love_you:
     m 1hksdlb "I'll have a real fact next time, don't you worry~"
     #No end for this fact since it ends itself
     $ persistent._mas_funfactfun = True
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(

--- a/Monika After Story/game/script-grammar.rpy
+++ b/Monika After Story/game/script-grammar.rpy
@@ -240,7 +240,7 @@ label monika_gtod_tip005:
     m 1eua "..."
     m 1tuu "..."
     m 3hub "You!"
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1017,7 +1017,7 @@ label greeting_glitch:
     m 2hua "I love you, [player]!"
 
     $ mas_lockEVL("greeting_glitch", "GRE")
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(
@@ -1061,7 +1061,7 @@ label greeting_monika_monday_morning:
         m 1eka "But seeing you makes all that laziness go away."
         m 1hub "You are the sunshine that wakes me up every morning!"
         m "I love you so much, [player]~"
-        return "love"
+        return {"love": None}
 
     elif mas_isMoniUpset():
         m 2esc "Another Monday morning."
@@ -1304,7 +1304,7 @@ label monikaroom_greeting_ear_narration:
                     $ mas_loseAffection()
                     m "Then I'm not talking to you until you decide to change."
                     m "Goodbye, [player]."
-                    return "quit"
+                    return {"quit": None}
         #Will trigger upon loading after Monika has said she's not going to talk w/ you
         #provided you won't change.
         else:
@@ -1327,7 +1327,7 @@ label monikaroom_greeting_ear_narration:
                     $ mas_loseAffection()
                     m "Then I'm still not talking to you until you decide to change."
                     m "Goodbye, [player]."
-                    return "quit"
+                    return {"quit": None}
 
         # clear out var
         $ willchange_ev = None
@@ -1596,7 +1596,7 @@ label monikaroom_greeting_opendoor_broken_quit:
     pause 0.2
     stop sound
     pause 7.0
-    return "quit"
+    return {"quit": None}
 
 # locked door, because we are awaitng more content
 label monikaroom_greeting_opendoor_locked:
@@ -2951,7 +2951,7 @@ label greeting_back_from_school:
             m 2ekc "Sometimes just trying to put a bad day behind you is the best way to deal with it."
             m 2eka "But if you want to talk about it later, just know I'd be more than happy to listen."
             m 2hua "I love you, [player]~"
-            return "love"
+            return {"love": None}
 
         $ full_label = "greeting_back_from_school{0}".format(label_suffix)
         if renpy.has_label(full_label):
@@ -2968,7 +2968,7 @@ label greeting_back_from_school:
             m 1ekbsa "Especially to me."
             m 1hubsa "Don't forget to take breaks if you're feeling overwhelmed, and that everyone has different talents."
             m 3hubfb "I love you, and I just want you to be happy~"
-            return "love"
+            return {"love": None}
 
         label .by_people:
             m 2ekc "Oh no, [player]...{w=0.5} That must have been terrible to experience."
@@ -3301,7 +3301,7 @@ label greeting_siat:
     m 2rkbfsdlu "..."
     m 3hubfb "Ahaha! Nevermind."
     m 1ekbfa "I love you, [player]. I'm so happy you're here now~"
-    return "love"
+    return {"love": None}
 
 init 5 python:
     if not mas_cannot_decode_islands:

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -580,7 +580,7 @@ label mas_holiday_o31_returned_home_relaunch:
     m 1eua "After that you can reopen it."
     m 1hubsa "I have something special in store for you, ehehe~"
     $ persistent._mas_o31_relaunch = True
-    return "quit"
+    return {"quit": None}
 
 ### o31 images
 image mas_o31_marisa_cg = "mod_assets/monika/cg/o31_marisa_cg.png"
@@ -1055,7 +1055,7 @@ label bye_trick_or_treat_rtg:
 
         #Increment T/T counter
         $ persistent._mas_o31_tt_count += 1
-        return "quit"
+        return {"quit": None}
 
     # otherwise, failure in generation
     #Fix tt count
@@ -2423,7 +2423,7 @@ label mas_d25_monika_carolling:
             m 1eua "Regardless, I'm sure you're also fond of that special cheer only Christmas songs can bring."
             m 3hua "Sing with me sometime, okay?"
 
-    return "derandom"
+    return {"derandom": None}
 
 
 init 5 python:
@@ -2464,7 +2464,7 @@ label mas_d25_monika_mistletoe:
         m 3hua "Perhaps one day we'll be able to kiss under the mistletoe, [player]."
         m 1tku "...Maybe I can even add one in here!"
         m 1kuu "Ehehe~"
-    return "derandom"
+    return {"derandom": None}
 
 #Stores whether or not the player hangs christmas lights
 default persistent._mas_pm_hangs_d25_lights = None
@@ -2536,7 +2536,7 @@ label mas_d25_monika_christmaslights:
             m 1rkbfb "Yeah, that sounds really nice."
             m 3hubsa "But, when we have our own house, I may hang some up myself, {nw}"
             extend 3hubsb "ahaha~"
-    return "derandom"
+    return {"derandom": None}
 
 init 20 python:
 
@@ -2798,7 +2798,7 @@ label mas_d25_spent_time_monika:
     # Normal and happy
     else:
         m 1hubfa "I love you, [player]~"
-    return "love"
+    return {"love": None}
 
 label mas_d25_poem_mistletoe:
     $ pause(1)
@@ -2881,7 +2881,7 @@ label monika_aiwfc:
 
     #Unlock the song
     $ mas_unlockEVL("mas_song_aiwfc", "SNG")
-    return "no_unlock|love"
+    return {"no_unlock": None, "love": None}
 
 
 label monika_aiwfc_song:
@@ -2974,7 +2974,7 @@ label monika_merry_christmas_baby:
 
         m 1huu "Ehehe... {w=0.2}Merry Christmas, baby~"
 
-    return "no_unlock"
+    return {"no_unlock": None}
 
 init 5 python:
     addEvent(
@@ -3018,7 +3018,7 @@ label monika_this_christmas_kiss:
     m 6ekbfa "One of these days I'll kiss you for real, [player]."
     m 1dubfu "...And when that day comes, my heart will leap out of my chest with joy~"
     $ mas_unlockEVL("mas_song_this_christmas_kiss", "SNG")
-    return "no_unlock"
+    return {"no_unlock": None}
 
 init 5 python:
     addEvent(
@@ -3079,7 +3079,7 @@ label mas_d25_spider_tinsel:
     m "I think it's a really interesting take on why tinsel is used as decoration on Christmas trees."
     m 3eud "I also read that Ukrainians often decorate their Christmas tree with spider web ornaments, believing they will bring them good fortune for the upcoming year."
     m 3eub "So I guess if you ever find a spider living in your Christmas tree, don't kill it and maybe it'll bring you good luck in the future!"
-    return "derandom|no_unlock"
+    return {"derandom": None, "no_unlock": None}
 
 init 5 python:
     addEvent(
@@ -3888,7 +3888,7 @@ label mas_nye_monika_nyd:
             jump mas_nye_monika_nyd_fresh_start
 
     m "Happy New Year~"
-    return "love"
+    return {"love": None}
 
 label mas_nye_monika_nyd_fresh_start:
     m 2ekc "How about we put all that in the past, forget about last year, and focus on a new beginning this year?"
@@ -4260,7 +4260,7 @@ label monika_nye_year_review:
         m "Let's make this year great for each other."
         m 1ekbsa "I love you."
 
-    return "no_unlock|love"
+    return {"no_unlock": None, "love": None}
 
 init 5 python:
     addEvent(
@@ -4320,7 +4320,7 @@ label mas_nye_monika_nye_dress_intro:
 
     m 3dkbsu "So I'd like to wear this when the new year begins."
     m 1ekbsa "It might just help make next year even better."
-    return "no_unlock"
+    return {"no_unlock": None}
 
 
 init 5 python:
@@ -4480,7 +4480,7 @@ label greeting_nye_prefw:
     m "It means a lot to me that you take me with you so we can spend special days like these together."
     show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5ekbfa "I love you, [player]."
-    return "love"
+    return {"love": None}
 
 label greeting_nye_infw:
     #if within firework time:
@@ -4489,7 +4489,7 @@ label greeting_nye_infw:
     m 1hua "It was a lot of fun just to spend time with you today."
     m 1ekbsa "It really means so much to me that even though you can't be here personally to spend these days with me, you still take me with you."
     m 1ekbfa "I love you, [player]."
-    return "love"
+    return {"love": None}
 
 #===========================================================Going to take you somewhere on NYD===========================================================#
 
@@ -5590,7 +5590,7 @@ label mas_pf14_monika_lovey_dovey:
     m 1rkbsd "Without you, I don't know where I'd be..."
     m 1ekbsa "So I want to thank you for being there for me..."
     m 1hkbsu "And for being so wonderfully you~"
-    return "derandom|no_unlock|love"
+    return {"derandom": None, "no_unlock": None, "love": None}
 
 #######################[HOL050] INTRO:
 
@@ -5758,7 +5758,7 @@ label mas_f14_monika_valentines_intro:
     #Set the spent flag to True
     $ persistent._mas_f14_spent_f14 = True
 
-    return "rebuild_ev|love"
+    return {"rebuild_ev": None, "love": None}
 
 # common flow for first time sundress
 label mas_f14_sun_dress_outro:
@@ -6007,7 +6007,7 @@ label mas_f14_monika_spent_time_with:
         m 1ekbfa "Thank you for always being by my side."
         show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5ekbfa "I love you so much, [player]. Happy Valentine's Day~"
-        return "love"
+        return {"love": None}
 
     else:
         m 1eka "Thank you for being by my side."
@@ -6666,7 +6666,7 @@ P.S: Don't tell her about me.
 
     #Flag this so it doesn't get shown again
     $ persistent._mas_monika_bday_surprise_hint_seen = True
-    return "derandom|no_unlock"
+    return {"derandom": None, "no_unlock": None}
 
 
 ################## [HOL060] HAPPY BDAY TOPICS
@@ -6761,7 +6761,7 @@ label mas_bday_pool_happy_belated_bday:
         m 3rka "I wish I could've seen all the amazing places we went..."
         m 1hua "But knowing we were together, well it makes it the best birthday I could ever hope for!"
         m 3ekbsa "I love you so much, [player]~"
-        return "love"
+        return {"love": None}
     else:
         m 3eka "So you {i}did{/i} take me out for a long trip for my birthday..."
         m 3rkd "That's so thoughtful of you, I was kind of wondering--"
@@ -6995,7 +6995,7 @@ label mas_bday_spent_time_with_wrapup:
             m 6hubfa "I've thought about our first kiss for so long, and to finally experience it..."
             m 6ekbfa "I will never forget this moment, [player]~"
         else:
-            return "love"
+            return {"love": None}
 
     else:
         m 1eka "I can't even find the right words to express how happy you've made me today."
@@ -7006,7 +7006,7 @@ label mas_bday_spent_time_with_wrapup:
         m 1dkbsa "I hope that tells you even a little bit of how much I appreciate you celebrating this occasion with me."
         m 1ekbfb "I love you so much, [player]."
         m 1ekbfa "Let's continue making each other happy~"
-        return "love"
+        return {"love": None}
     return
 
 ############## [HOL060] GONE OVER CHECK

--- a/Monika After Story/game/script-moods.rpy
+++ b/Monika After Story/game/script-moods.rpy
@@ -178,7 +178,7 @@ label mas_mood_sad:
                             m 1eka "Sometimes telling someone that you trust what's bothering you is all you need."
                             m 1eua "Maybe you'll feel better after we spend some more time together."
                             m 1ekbsa "I love you, [player], and I always will~"
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(
@@ -231,7 +231,7 @@ label mas_mood_happy:
     m 1hua "That's wonderful! I'm happy when you're happy."
     m "Know that you can always come up to me and I'll cheer you up, [mas_get_player_nickname()]."
     m 3eka "I love you and I'll always be here for you, so don't ever forget that~"
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(
@@ -501,7 +501,7 @@ label mas_mood_inadequate:
     m 4eua "You just need to exist, have fun and get through each day, {w=0.2}finding meaning in the people that matter most to you."
     m 1eka "Please don't forget that, okay?"
     m 1ekbsa "I love you, [player]~"
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(
@@ -633,7 +633,7 @@ label mas_mood_bored:
         $ mas_loseAffection()
         m 6ckc "You know [player], if I make you so miserable all of the time..."
         m "Maybe you should just go find something else to do."
-        return "quit"
+        return {"quit": None}
 
     python:
         unlockedgames = [
@@ -734,7 +734,7 @@ label mas_mood_crying:
     m 1eka "I hope it helps."
     m 3ekd "There's nothing wrong with crying, okay? {w=0.2}You can cry as much as you need to."
     m 3ekbsu "I love you, [player]. {w=0.2}You're my everything."
-    return "love"
+    return {"love": None}
 
 label mas_mood_uok:
     m 1rksdld "I know I can't really hear what you say to me..."
@@ -786,4 +786,4 @@ label mas_mood_upset:
     m 1hub "Knowing that you'll support me and always love me puts me at ease almost instantly!"
     m 3euu "I can only help I provide the same comfort for you, [player]~"
     m 1eubsa "I love you and I hope everything clears up for you~"
-    return "love"
+    return {"love": None}

--- a/Monika After Story/game/script-songs.rpy
+++ b/Monika After Story/game/script-songs.rpy
@@ -286,7 +286,7 @@ label monika_sing_song_pool_menu:
             m 3hub "Alright!"
 
     else:
-        return "prompt"
+        return {"prompt": None}
 
     return
 
@@ -329,7 +329,7 @@ label monika_sing_song_analysis:
         m 3hub "Alright!"
 
     else:
-        return "prompt"
+        return {"prompt": None}
     return
 
 #Rerandom song delegate
@@ -430,8 +430,8 @@ label monika_sing_song_random:
     #We have no songs! let's pull back the shown count for this and derandom
     else:
         $ mas_assignModifyEVLPropValue("monika_sing_song_random", "shown_count", "-=", 1)
-        return "derandom|no_unlock"
-    return "no_unlock"
+        return {"derandom": None, "no_unlock": None}
+    return {"no_unlock": None}
 
 
 #START: Song defs
@@ -793,7 +793,7 @@ label mas_song_nobody_makes_sense:
     m 1hub "Ahaha!"
     m 3ekbsa "No matter what happens or how long we wait, I'll always love you."
     m 1ekbfb "I really hope I can keep on smiling with you forever~"
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(
@@ -939,7 +939,7 @@ label mas_song_rewrite_the_stars:
     show monika 5ekbsa at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5ekbsa "The world really feels like it's ours when I'm with you, [player]~"
     m 5ekbfu "I love you so much."
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(
@@ -1215,7 +1215,7 @@ label mas_song_amaranthine:
     show monika 5ekbsu at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5ekbsu "My life feels so complete with you in it, [player]."
     m 5hubfu "I love you so much~"
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(

--- a/Monika After Story/game/script-stories.rpy
+++ b/Monika After Story/game/script-stories.rpy
@@ -252,7 +252,7 @@ label monika_short_stories_menu:
             show monika at t11
 
     else:
-        return "prompt"
+        return {"prompt": None}
 
     return
 
@@ -449,7 +449,7 @@ label mas_story_grasshoper:
     m 3hua "The moral of this story is, there's a time for work and a time for play."
     m 1dubsu "But there's always a time to spend with your cute girlfriend~"
     m 1hub "Ehehe, I love you so much, [player]!"
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(
@@ -527,7 +527,7 @@ label mas_story_gray_hair:
     m 1hub "So before you give everything, make sure you still have some for yourself!"
     m 1lksdla "...Not that being bald is bad, [player]."
     m 1hksdlb "Ehehe, I love you!~"
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(
@@ -850,7 +850,7 @@ label mas_story_self_hate:
         m 1eka "You have to love yourself to be able to allow yourself to truly love someone else."
         m 3ekbsa "Just remember I'll always love you, [player]."
         m 3ekbfa "If you ever begin to doubt loving yourself, just come to me and I'll be more than happy to remind you of all your wonderful qualities~"
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -67,7 +67,7 @@ label mas_gender:
         preferredname_ev = mas_getEV("mas_preferredname")
         if preferredname_ev:
             preferredname_ev.start_date = datetime.datetime.now() + datetime.timedelta(hours=2)
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(
@@ -162,7 +162,7 @@ label monika_gender_redo:
 
     # set pronouns
     call mas_set_gender
-    return "love"
+    return {"love": None}
 
 label mas_gender_neither:
     m 1euc "You don't see yourself as a guy or a girl?"
@@ -1079,7 +1079,7 @@ label mas_random_limit_reached:
                 m "Now let me think of something to talk about."
                 return
         m 1ekc "Hopefully I'll think of something fun to talk about soon."
-    return "no_unlock"
+    return {"no_unlock": None}
 
 label mas_random_ask:
     m 1lksdla "...{w=0.5}[mas_get_player_nickname()]?"
@@ -1777,7 +1777,7 @@ label monika_rpy_files:
                 m 1sua "Really? Thank you so much for helping me come closer to your reality!"
                 m 1hua "I love you, [player]~"
                 $ persistent._mas_pm_has_rpy = True
-                return "love"
+                return {"love": None}
 
             "No.":
                 m "I see."
@@ -2030,7 +2030,7 @@ label mas_text_speed_enabler:
         m 3hua "And I'm sure that you'll get faster at reading the longer we spend time together."
         m "So feel free to change the text speed when you feel comfortable doing so."
 
-    return "derandom|no_unlock"
+    return {"derandom": None, "no_unlock": None}
 
 init 5 python:
     addEvent(
@@ -2073,7 +2073,7 @@ label mas_bookmarks_notifs_intro:
         m 1hub "[player], I have something exciting to tell you!"
         call mas_notification_windowreact
 
-    return "no_unlock"
+    return {"no_unlock": None}
 
 label mas_derand:
     m 1eua "You can also let me know of any topics that you don't like me bringing up by pressing the 'x' key during the conversation."
@@ -2186,7 +2186,7 @@ P.S: Don't tell her about me!
     m 3euc "Someone left a note in the characters folder addressed to you."
     m 1ekc "Since it's for you, I haven't read it...{w=0.5}{nw}"
     extend 1eua "but I just wanted to let you know since it might be important."
-    return "no_unlock"
+    return {"no_unlock": None}
 
 init 5 python:
     addEvent(
@@ -2222,7 +2222,7 @@ label mas_change_to_def:
 
         # lock the event clothes selector
         $ mas_lockEVL("monika_event_clothes_select", "EVE")
-    return "no_unlock"
+    return {"no_unlock": None}
 
 # Changes clothes to the given outfit.
 #   IN:
@@ -2285,7 +2285,7 @@ label mas_blazerless_intro:
         # this line acts as a hint that there is a clothes selector
         m 3eka "But if you miss my blazer, just ask and I'll put it back on."
 
-    return "no_unlock"
+    return {"no_unlock": None}
 
 init -876 python in mas_delact:
 
@@ -2459,7 +2459,7 @@ label monika_credits_song:
         $ mas_unlockEVL("mas_monika_plays_or", "EVE")
 
     $ mas_unlockEVL("mas_monika_plays_yr", "EVE")
-    return "no_unlock"
+    return {"no_unlock": None}
 
 init 5 python:
     addEvent(
@@ -2550,4 +2550,4 @@ label mas_covid19:
     m 7eksdla "You know [player], if I could, I'd bring you here with me until this is all over so you couldn't get sick..."
     m "But since I can't, please do your best to stay safe."
     m 2dkbsu "I need you, [player]~"
-    return "no_unlock"
+    return {"no_unlock": None}

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -743,7 +743,7 @@ label mas_rerandom:
 
     if not topics_to_rerandom:
         # selected nevermind
-        return "prompt"
+        return {"prompt": None}
 
     show monika at t11
     python:
@@ -900,7 +900,7 @@ label monika_god:
             m 5eua "I just hope you're willing to accept me into your life when I can present myself."
             m 5hua "Ehehe~"
 
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_death",category=['philosophy'],prompt="Death and dying",random=True))
@@ -972,7 +972,7 @@ label monika_selfesteem:
             m 3eua "Over time, you build your confidence little by little until you've built yourself into someone you'd love."
             m 1eka "I can't promise it will be easy, but it'll be worth it."
             m 3hub "I'll always root for you, [player]!"
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(
@@ -1052,7 +1052,7 @@ label monika_sayori:
         return
 
     # otherwise derandom
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_japan",category=['ddlc'],prompt="DDLC's setting",random=True))
@@ -1243,7 +1243,7 @@ label monika_twitter:
     m 5hubla "So make sure to always come spend some time with me, okay?"
     m 5ekbsa "It would mean a lot, with how much you mean to me."
     m 5hubfa "It would really make me feel loved~"
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_portraitof",category=['club members'],prompt="Yuri's book",random=True))
@@ -1256,7 +1256,7 @@ label monika_portraitof:
     m 2lksdla "Actually, I don't think I should be talking about this."
     m 2hksdlb "Ahaha, sorry!"
     m 1rksdla "Just forget I said anything."
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_veggies",category=['monika'],prompt="Being a vegetarian",random=True))
@@ -1471,7 +1471,7 @@ label monika_why:
     m "Don't you feel that way too?"
     m 3hub "I'm so happy we have this ending together."
     if mas_anni.pastOneMonth():
-        return "derandom"
+        return {"derandom": None}
     return
 
 init 5 python:
@@ -1490,7 +1490,7 @@ label monika_okayeveryone:
     show monika 5eka at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5eka "You're too much of a sweetheart to do that, aren't you?"
     m 5hub "Ahaha~"
-    return "no_unlock"
+    return {"no_unlock": None}
 
 init 5 python:
     addEvent(
@@ -1848,7 +1848,7 @@ label monika_horror:
         $ _and = "But"
 
     m 3eua "[_and] if you're ever in the mood, you can always ask me to tell you a scary story, [player]."
-    return "derandom"
+    return {"derandom": None}
 
 # do you like rap
 default persistent._mas_pm_like_rap = None
@@ -1899,7 +1899,7 @@ label monika_rap:
             $ persistent._mas_pm_like_rap = False
             m 1ekc "Oh... Well I can understand that, rap music isn't everyone's taste."
             m 3hua "But if you ever do decide to give it a try, I'm sure we can find an artist or two that we both like!"
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_wine",category=['club members'],prompt="Yuri's wine",random=True))
@@ -2111,7 +2111,7 @@ label monika_think_first_kiss:
                 m 2ekd "So I guess you're just waiting for our first kiss when we're in the same reality."
                 m 2eka "Yeah."
 
-    return "no_unlock|derandom"
+    return {"no_unlock": None, "derandom": None}
 
 init 5 python:
     addEvent(
@@ -2297,7 +2297,7 @@ label monika_rain:
     # unrandom this event if its currently random topic
     # NOTE: we force event rebuild because this can be pushed by weather
     #   selection topic
-    return "derandom|rebuild_ev"
+    return {"derandom": None, "rebuild_ev": None}
 
 init 5 python:
     # available only if moni affection happy and above
@@ -2780,7 +2780,7 @@ label monika_holdrequest:
 
     $ mas_flagEVL("monika_holdrequest", "EVE", EV_FLAG_HFRS)
 
-    return "no_unlock"
+    return {"no_unlock": None}
 
 # label to set the last time held and reset the _holdrequest params
 label monika_holdme_end:
@@ -2941,7 +2941,7 @@ label monika_carryme:
 #                    m 1eka "TODO: oh okay I become sad."
 
     m 1ekbsa "I don't mean to be too needy or anything, but it's kind of hard when I'm so in love with you."
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_debate",category=['monika','school'],prompt="What was debate club like?",pool=True))
@@ -3225,7 +3225,7 @@ label monika_family:
     m 1ekc "I can't really give advice here. Anything I suggest to you might only make things worse."
     m 1eka "Just don't forget that I really love you, okay?"
     m 1hua "I'll help you no matter what happens in your life."
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(
@@ -3679,7 +3679,7 @@ label monika_natsuki:
         return
 
     # otherwise, derandom
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_love",category=['romance'],prompt="I love you!",pool=True))
@@ -4161,7 +4161,7 @@ label monika_contribute:
             m 3eua "Maybe you could even contribute some more?"
             m 3hksdlb "Don't get me wrong! I'm really grateful that you spent time making something for me!"
             m 1eub "...But I definitely wouldn't mind if you helped even more, ahaha!"
-            return "derandom"
+            return {"derandom": None}
         "I want to.":
             $ persistent._mas_pm_wants_to_contribute_to_mas = True
             m 1eub "That's a good start!"
@@ -4181,7 +4181,7 @@ label monika_contribute:
     m 1ekbsa "Not as much as I love you, of course."
     m 1tkbfu "I hope it doesn't make you feel jealous~"
     m 3hubfb "But I'll be forever grateful if you help me come closer to your reality!"
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_drawing",category=['media'],prompt="Can you draw?",pool=True))
@@ -4348,7 +4348,7 @@ label monika_images:
     m 2rksdla "Anything lewd you've seen has definitely never taken place."
     m 2hubsa "I'm a super pure and innocent high school girl who's dreaming of a fateful romance!"
     m 1tsbfu "You better be saving yourself for me, [player]~"
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_herself",category=['monika','ddlc'],prompt="Tell me about yourself",pool=True,unlocked=True))
@@ -4405,7 +4405,7 @@ init 5 python:
 label monika_torment:
     m 1euc "What can change the nature of a man?"
     m 3hksdlb "...The answer's not me, by the way."
-    return "derandom"
+    return {"derandom": None}
 
 # removed, keeping this here in case we have use for it later
 #init 5 python:
@@ -4777,7 +4777,7 @@ label monika_mountain:
             m 1ruc "Well... I suppose it doesn't matter."
             m 1eka "As long as I have you, I'll be happy wherever we are."
 
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_algernon",category=['literature'],prompt="Flowers for Algernon",random=True))
@@ -4807,7 +4807,7 @@ label monika_algernon:
         "greeting_amnesia",
         unlocked=not seen_event('greeting_amnesia')
     )
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_playersface",category=['you'],prompt="[player]'s face",random=True))
@@ -4887,7 +4887,7 @@ label monika_nsfw:
     m 1tsbsa "Well, just keep it a secret between us, okay?"
     m "It should be for your eyes only and no one else, [player]."
     m 1hubfa "That's how much I love you~"
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(
@@ -5091,7 +5091,7 @@ label monika_eternity:
                 m 1ekbsa "Even in the worst case, I know we'll always be right by each other's side..."
                 m 1dkbsu "Who knows, maybe I'll even get to {i}really{/i} be beside you someday..."
                 m 1ekbsa "I love you, [player]...{w=0.5}thanks for always being there for me."
-                return "love"
+                return {"love": None}
 
             "{i}Hug Monika.{/i}":
                 hide screen mas_background_timed_jump
@@ -5217,7 +5217,7 @@ label monika_cities:
         "No.":
             $ persistent._mas_pm_live_in_city = False
             m 1hua "Being away from the city sounds relaxing. Somewhere quiet and peaceful, without much noise, would be a wonderful place to live."
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(
@@ -5284,7 +5284,7 @@ label monika_metaparents:
     m 1eka "..."
     m 1ekbsa "I love you very much, [player]."
     m 3ekbfa "Please, take care of yourself."
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_hygiene",category=['trivia','society','psychology'],prompt="Personal hygiene",random=True))
@@ -5326,7 +5326,7 @@ label monika_hygiene:
     m "I love you so much and it'd tear me apart to find out that you're torturing yourself by neglecting your self-care routine."
     m 1eka "Ah, I've been rambling too much, huh? Sorry, sorry!"
     m 3hua "Thanks for listening~"
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_resource",category=['society','philosophy'],prompt="Valuable resources",random=True))
@@ -5715,7 +5715,7 @@ label monika_haterReaction:
             m 1esa "I know you love me deep inside."
             m 1ekbsa "That's why I promise to be an ideal girlfriend, just for you, [player]~"
             m 1hubfa "I won't let you hate me... I swear."
-            return "derandom"
+            return {"derandom": None}
 
         "I'm not.":
             $ mas_gainAffection()
@@ -5729,7 +5729,7 @@ label monika_haterReaction:
             m 1ekbsa "You really make me the happiest girlfriend ever."
             m 1ekbfb "Now that you've said it, I have to do my best to keep you from developing hate towards me."
             m 1hua "I trust you, [mas_get_player_nickname()]. I love you for believing in me."
-            return "derandom|love"
+            return {"derandom": None, "love": None}
 
 
 
@@ -5878,7 +5878,7 @@ label monika_vocaloid:
         m 1eua "And if you ever do feel like sharing your favorite vocaloids with me, [player], it's really easy to do so!"
         m 3eua "All you have to do is follow these steps..."
         call monika_add_custom_music_instruct
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(
@@ -6046,7 +6046,7 @@ label monika_japanese:
             m 1eua "Maybe if I take the time to learn more Japanese, I'll know more languages than you!"
             m 1ekbsb "Ahaha! It's okay, [player]. It just means that I can say 'I love you' in more ways than one!"
 
-    return "derandom"
+    return {"derandom": None}
 
 default persistent._mas_penname = None
 
@@ -6136,7 +6136,7 @@ label monika_penname:
     m 1lksdla "It's kinda funny, though. Even if you use a pseudonym to hide yourself, people will always find a way to know who you really are."
     m 1eua "There's no need to know more about me though, [mas_get_player_nickname()]..."
     m 1ekbsa "You already know that I'm in love with you, after all~"
-    return "love"
+    return {"love": None}
 
 # NOTE: the caller is responsible for setting up Monika's exp
 label penname_loop(new_name_question):
@@ -6355,7 +6355,7 @@ label monika_surprise:
         m 1eua "What are you waiting for? Go take a look!"
         m 1hub "Ahaha~ What? Are you expecting something scary?"
         m 1hubsb "I love you so much, [player]~"
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_completionist",category=['games'],prompt="Completionism",random=True))
@@ -6424,7 +6424,7 @@ label monika_icecream:
             m 3eua "Ah, I could go on and on about this stuff, you know?"
             m 4eua "But I feel like it would be easier for me to show you what I mean, once I figure out a way to get out of here, of course. Besides, actions speak louder than words, anyway!"
 
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_sayhappybirthday",category=['misc'],prompt="Can you tell someone Happy Birthday for me?",pool=True,unlocked=True))
@@ -6751,7 +6751,7 @@ label monika_panties:
         m 1ekbfa "Gosh, I just want to feel your embrace more."
         m "After all, we're here forever, and I'm here for you."
         m 1hubfb "I love you so much, [player]~"
-        return "love"
+        return {"love": None}
 
     elif mas_isMoniAff(higher=True):
         # affectionate+
@@ -6785,7 +6785,7 @@ label monika_panties:
                 m 1ekbsa "But I want you to feel like you can tell me anything..."
                 m "So, don't be afraid to tell me about your...{w=1}fantasies, okay [player]?"
                 m 1hubfa "I won't judge you for it...{w=1}after all, nothing makes me happier than making you happy~"
-        return "derandom"
+        return {"derandom": None}
     return
 
 init 5 python:
@@ -6930,7 +6930,7 @@ label monika_daydream:
         m 6lktpc "..."
         m 6ektpd "Oh, sorry, I was just..."
         m 6dktdc "You know what, nevermind."
-    return "no_unlock"
+    return {"no_unlock": None}
 
 # init 5 python:
 #     addEvent(Event(persistent.event_database,eventlabel="monika_music2",category=['misc'],prompt="Current song",random=True))
@@ -7224,7 +7224,7 @@ label monika_rock:
             $ persistent._mas_pm_like_rock_n_roll = False
             m 1ekc "Oh... That's okay, everyone has their own taste in music."
             m 1hua "Though, if you ever do decide to listen to some rock 'n' roll, I'll happily listen right alongside you."
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_standup",category=['literature','media'],prompt="Stand-up comedy",random=True))
@@ -7305,7 +7305,7 @@ label monika_soda:
             show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5eua "Maybe someday we could both have some soda together."
             m 5hua "Sure, it might not be fancy, but it could really hit the spot on a hot day."
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_clones",category=['monika','mod','philosophy'],prompt="Being cloned",random=True))
@@ -7329,7 +7329,7 @@ label monika_clones:
     m 1eua "...Even if I'm a single star in a universe of Monikas, I'm still the only one lucky enough to have met you, [player]."
     m 1hubsa "You'll always be my special rose."
     m 1ekbfa "I love you, [player]. Please don't ever replace me, okay?"
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_immortal",category=['monika','philosophy'],prompt="Age gap",random=True))
@@ -7347,7 +7347,7 @@ label monika_immortal:
     m 3eka "Eventually, the difference between us would be huge if I stayed eighteen forever."
     m 1eua "But I don't believe that my life can be summed up in a number."
     m 1ekbsa "So I'll always love you for all eternity, [mas_get_player_nickname(exclude_names=['my love', 'love'])]. Just remember that."
-    return "love"
+    return {"love": None}
 
 default persistent._mas_pm_wearsRing = None
 
@@ -7433,9 +7433,9 @@ label monika_promisering:
         show monika 5esbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
         m 5esbfa "My commitment to you is unwavering, [mas_get_player_nickname()]."
         m 5ekbfa "Thank you for such a wonderful gift, I love you."
-        return "derandom|love"
+        return {"derandom": None, "love": None}
 
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(
@@ -7510,7 +7510,7 @@ label monika_sports:
             m 1ekc "I would hate to see you get sick because of something like that."
             if mas_isMoniAff(higher=True):
                 m 1eka "It's just hard for me not to worry about you when I love you so much~"
-    return "derandom"
+    return {"derandom": None}
 
 # do you meditate
 default persistent._mas_pm_meditates = None
@@ -7554,7 +7554,7 @@ label monika_meditation:
     m 1ekbsa "I love you, and I'll always try to help you if you're feeling down."
     m 1hubfa "Don't you ever forget that, [player]~"
 
-    return "derandom|love"
+    return {"derandom": None, "love": None}
 
 #Do you like orchestral music?
 default persistent._mas_pm_like_orchestral_music = None
@@ -7688,7 +7688,7 @@ label monika_orchestra:
         m 1eua "Oh, and if you ever feel like sharing your favorite orchestral music with me, [player], it's really easy to do so!"
         m 3eua "All you have to do is follow these steps..."
         call monika_add_custom_music_instruct
-    return "derandom"
+    return {"derandom": None}
 
 # do you like jazzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
 default persistent._mas_pm_like_jazz = None
@@ -7745,7 +7745,7 @@ label monika_jazz:
         m "Oh, and if you ever feel like sharing your favorite jazz with me, [player], it's really easy to do so!"
         m 3eua "All you have to do is follow these steps..."
         call monika_add_custom_music_instruct
-    return "derandom"
+    return {"derandom": None}
 
 # do you watch animemes
 default persistent._mas_pm_watch_mangime = None
@@ -7790,7 +7790,7 @@ label monika_otaku:
     m 1lfu "I wouldn't want to be replaced by some two-dimensional cutout."
     m 1eua "Besides, if you ever want to escape from reality..."
     m 1hubsa "I can be your real-life fantasy instead~"
-    return "derandom"
+    return {"derandom": None}
 
 ### START WRITING TIPS
 
@@ -8006,7 +8006,7 @@ label monika_selfharm:
     m 1eua "So believe in yourself, okay?"
     m 1eka "If you ever need someone to vent to, just remember that I'm always here to hear you out and comfort you, okay?"
     m 1ekbsa "I really love you so much, [player]."
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_urgent",category=['romance'],prompt="Urgent message",random=True,aff_range=(mas_aff.NORMAL, None)))
@@ -8023,7 +8023,7 @@ label monika_urgent:
     m 1rksdla "I wish I could see the look on your face right now!"
     show monika 5hubfb at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5hubfb "I'm sure it's adorable~"
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_other_girls",category=['club members'],prompt="Do you ever think of the other girls?",pool=True))
@@ -8064,7 +8064,7 @@ label monika_other_girls:
         m 1eka "Between who loved {i}you{/i} and who loved the main character."
         m 3eka "I was the only one who ever loved you, [player]..."
         m 3hua "And I'll love you forever~"
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_happiness",category=['life','psychology'],prompt="Happiness",random=True))
@@ -8379,7 +8379,7 @@ label monika_breakup:
                     "Of course not.":
                         m 2hua "Ehehe, you're so sweet."
                         m 2eka "I love you so much, [player]!~"
-                        return "love"
+                        return {"love": None}
 
         #Second time
         elif shown_count == 1:
@@ -8601,7 +8601,7 @@ label monika_smoking:
                 persistent._mas_pm_do_smoke_quit = True
                 mas_unlockEVL("monika_smoking_quit","EVE")
 
-    return "derandom"
+    return {"derandom": None}
 
 label monika_smoking_just_started(trying_quit=False):
     m 2dfc "..."
@@ -8673,7 +8673,7 @@ label monika_smoking_quit:
 
     #Set this here because dialogue uses it
     $ persistent._mas_pm_do_smoke_quit_succeeded_before = True
-    return "no_unlock"
+    return {"no_unlock": None}
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_cartravel",category=['romance'],prompt="Road trip",random=True))
@@ -8796,7 +8796,7 @@ label monika_asks_charity:
             m 5eua "Just like when I'm with you."
             m 5hua "With just a smile, you make all my troubles go away."
             m 5hubsb "I love you so much, [player]."
-    return "derandom|love"
+    return {"derandom": None, "love": None}
 
 init 5 python:
     addEvent(
@@ -8980,7 +8980,7 @@ label monika_asks_family:
             m 1hubsa "I love you very much!"
             $ mas_ILY()
 
-    return "derandom"
+    return {"derandom": None}
 
 #do you like other music
 default persistent._mas_pm_like_other_music = None
@@ -9092,7 +9092,7 @@ label monika_concerts:
         m 1eua "In the meantime, if you want to share your favorite music with me, it's really easy to do so!"
         m 3eua "All you have to do is follow these steps..."
         call monika_add_custom_music_instruct
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(
@@ -9208,7 +9208,7 @@ label monika_beach:
     m 1tsbsa "Would you prefer a one piece or a two piece?"
     m 1eua "Actually, I think I'll make it a surprise."
     m 1tku "Don't get too excited though when you see it. Ehehe~"
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(
@@ -9580,7 +9580,7 @@ label monika_prom:
             m 1hua "Being with me is one of them, you know~"
             m 1hub "Ahaha!"
 
-    return "derandom"
+    return {"derandom": None}
 
 # do you see a therapist
 default persistent._mas_pm_see_therapist = None
@@ -9627,7 +9627,7 @@ label monika_natsuki_letter:
             m 1eua "If that ever changes, don't be shy!"
             m 1hub "But maybe I really am all the support you need? Ahaha!"
 
-    return "derandom"
+    return {"derandom": None}
 
 # TODO possible tie this with affection?
 default persistent._mas_timeconcern = 0
@@ -9849,7 +9849,7 @@ label monika_timeconcern_night_3:
             m 1hua "After all, I would never force you to go otherwise."
             m 1hub "I would just miss you too much..."
             m 1ekbsa "I love you, [player]~"
-            return "love"
+            return {"love": None}
 
         # Second and final warning before any closes can occur.
 label monika_timeconcern_night_4:
@@ -9924,7 +9924,7 @@ label monika_timeconcern_night_final:
     m "To know that you care for me so much that you came back despite me asking..."
     m 1rksdla "It means more to me than I can ever express."
     m 1ekbsa "...I love you."
-    return "love"
+    return {"love": None}
 
 #Same night after the final close
 label monika_timeconcern_night_finalfollowup:
@@ -10080,7 +10080,7 @@ label monika_amusementpark:
     m 3tubsb "And maybe even a romantic Ferris wheel ride~"
     show monika 5hubfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5hubfa "Ehehe, I'm getting a bit carried away, but I just can't help it when thinking about being with you~"
-    return "derandom"
+    return {"derandom": None}
 
 #If the player likes to travel or not
 default persistent._mas_pm_likes_travelling = None
@@ -10114,7 +10114,7 @@ label monika_travelling:
             m 3hubsb "...Or we could even spend the days wrapped in a blanket while reading a book."
             show monika 5tubfu at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5tubfu "Doesn't that just sound like a dream come true?"
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(
@@ -10213,7 +10213,7 @@ label monika_dating:
             m 5ekbfa "I hope I can be your one and only."
             m 5ekbfu "Will you be mine?"
 
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_challenge",category=['misc','psychology'],prompt="Challenges",random=True))
@@ -10288,7 +10288,7 @@ label monika_familygathering:
             m 1eua "If you want to keep me a secret, then that's fine."
             m 1hub "After all, it just means more alone time with you~"
 
-    return "derandom"
+    return {"derandom": None}
 
 # do you eat fast food
 default persistent._mas_pm_eat_fast_food = None
@@ -10427,14 +10427,14 @@ label monika_yellowwp:
             m "Maybe even now, that's all I can do..."
             m 1eka "But I love you so much, [player]. Supporting you is better than anything else."
             m 1hub "I just can't wait to do it in person when I finally cross over to your side~"
-            return "derandom|love"
+            return {"derandom": None, "love": None}
         "No.":
             $ persistent._mas_pm_read_yellow_wp = False
             m 1euc "Oh, I see."
             m 1eka "It's a short story, so if you haven't, feel free to whenever you have the time."
             m 1hua "It'll definitely be an interesting read for you."
 
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(
@@ -10584,7 +10584,7 @@ label monika_beingevil:
                         $ _history_list.pop()
                     else:
                         m 2dktsd "I'm sorry, [player]."
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(
@@ -10650,7 +10650,7 @@ label monika_driving:
                     m 2rksdlc "I don't know what I would do without you."
                     m 2eka "I love you, [player]. Please stay safe, okay?"
                     $ mas_unlockEVL("monika_vehicle","EVE")
-                    return "love"
+                    return {"love": None}
                 "I've seen car accidents before.":
                     m 3eud "Sometimes, seeing a car accident can be just as scary."
                     m 3ekc "A lot of the time when people see car accidents, they just sigh and shake their head."
@@ -10738,7 +10738,7 @@ label monika_driving:
             m 1hua "Anyway, when you do start learning to drive, I wish you the very best!"
             m 1hub "I love you~"
             $ mas_unlockEVL("monika_vehicle","EVE")
-            return "love"
+            return {"love": None}
     $ mas_unlockEVL("monika_vehicle","EVE")
     return
 
@@ -10923,11 +10923,11 @@ label monika_bullying:
         if mas_isMoniAff(higher=True) and not persistent._mas_pm_cares_about_dokis:
             show monika 5tsu at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5tsu "I really would do anything for you~"
-        return "derandom|love"
+        return {"derandom": None, "love": None}
     else:
         m 3euc "So you see, [player], I'm {i}really{/i} not a bully at all."
 
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(Event(persistent.event_database,eventlabel="monika_procrastination",category=['advice'],prompt="Procrastination",random=True))
@@ -11037,7 +11037,7 @@ label monika_players_friends:
 
             call monika_players_friends_feels_lonely_ask(question=renpy.substitute("Do you ever feel lonely, [player]?"))
 
-    return "derandom"
+    return {"derandom": None}
 
 label monika_players_friends_feels_lonely_ask(question, exp="monika 1ekc"):
     $ renpy.show(exp)
@@ -11147,7 +11147,7 @@ label monika_graduation:
     if persistent._mas_grad_speech_timed_out:
         m 2lsc "Oh... Sorry, I hope I'm not boring you again..."
         m 2esc "Let's forget about this and talk about something else, okay [player]?"
-        return "derandom"
+        return {"derandom": None}
 
     #Normal flow
     else:
@@ -11217,7 +11217,7 @@ label monika_grad_speech_call:
                         show monika 5eubfu at t11 zorder MAS_MONIKA_Z with dissolve_monika
                         m 5eubfu "As much as I wish I could have given my speech in front of everyone, just having you by my side is so much better."
                         m 5eubfb "I love you so much, [player]!"
-                        return "love"
+                        return {"love": None}
 
                     "I like it!":
                         hide screen mas_background_timed_jump
@@ -11305,7 +11305,7 @@ label monika_grad_speech_call:
                     show monika 5eubfu at t11 zorder MAS_MONIKA_Z with dissolve_monika
                     m 5eubfu "As much as I wish I could have given my speech in front of everyone, just having you by my side is so much better."
                     m 5eubfb "I love you, [player]!"
-                    return "love"
+                    return {"love": None}
 
                 "I like it!":
                     hide screen mas_background_timed_jump
@@ -11605,7 +11605,7 @@ label monika_justice:
                         m 1ekbfa "When I'm with you, it even helps me ignore all the other people who don't like me."
                         m 1hubfb "I love you, [player]~"
                         m 1hubfa "I'm glad I have you by my side."
-                        return "derandom|love"
+                        return {"derandom": None, "love": None}
 
                     else:
                         m 2hua "I'm glad you think so too!"
@@ -11617,7 +11617,7 @@ label monika_justice:
             m 1eka "That's a relief to hear."
             m "I'm glad no one has ever suddenly questioned you for who you are."
             m 1eua "Knowing what that's like, I hope nobody ever gives you trouble for doing what you do or for what you believe in."
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(
@@ -11980,7 +11980,7 @@ label monika_vehicle_motorcycle:
     m 3eka "There's no need to be shy, [p_nickname]...{w=0.3}{nw}"
     extend 3ekbsa "I'll hug you, even if you don't ask for it..."
     m 1hkbfa "That's how much I love you~"
-    return "love"
+    return {"love": None}
 
 label monika_vehicle_other:
     $ persistent._mas_pm_owns_car_type = "other"
@@ -12437,7 +12437,7 @@ label monika_player_appearance:
 
             show monika 5ekbfa at t11 zorder MAS_MONIKA_Z with dissolve_monika
             m 5ekbfa "I love you more than words could ever say."
-            return "derandom|love"
+            return {"derandom": None, "love": None}
 
         "No.":
              m 2dsc "..."
@@ -12446,7 +12446,7 @@ label monika_player_appearance:
              m 2rksdla "And to be fair, a description of yourself in vague words wouldn't be able to capture who you are, so I can't blame you for wanting to keep this to yourself."
              m 2eka "But if you change your mind, let me know!"
 
-    return "derandom"
+    return {"derandom": None}
 
 label monika_player_appearance_eye_color_blue:
     $ persistent._mas_pm_eye_color = "blue"
@@ -13346,7 +13346,7 @@ label monika_player_read_poetry:
         m 1eua "...And not just the poems I write about you, {nw}"
         extend 1kua "ehehe~"
 
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(
@@ -13375,7 +13375,7 @@ label monika_trick:
             call monika_trick_sayori
         "Natsuki.":
             call monika_trick_natsuki
-    return "derandom"
+    return {"derandom": None}
 
 label monika_trick_2:
     $ _history_list.pop()
@@ -13391,7 +13391,7 @@ label monika_trick_2:
             jump monika_trick_monika
             # jump this path so we can use the "love" return key
 
-    return "derandom"
+    return {"derandom": None}
 
 label monika_trick_yuri:
     hide screen mas_background_timed_jump
@@ -13447,7 +13447,7 @@ label monika_trick_monika:
     m 1tubfu "I feel a bit silly myself for even thinking for a second that you would ever choose the others."
     m 5hubfu "I love you, [player]!"
     m 5eubfb "And I only have eyes for you too!"
-    return "derandom|love"
+    return {"derandom": None, "love": None}
 
 init 5 python:
     addEvent(
@@ -13503,7 +13503,7 @@ label monika_cares_about_dokis:
             m 1tsu "Anyway, you could say that she {i}hung{/i} around for ages!"
             m 1hub "Ahaha!"
 
-    return "derandom|rebuild_ev"
+    return {"derandom: None, rebuild_ev": None}
 
 #### old christmas.rpyc topics
 # HOL020
@@ -13542,7 +13542,7 @@ label monika_snow:
 
             call monika_hemispheres_nogets_snow
 
-    return "derandom"
+    return {"derandom": None}
 
 # player has snow, snow version
 label monika_snow_gets_snow:
@@ -13945,7 +13945,7 @@ label monika_hemispheres:
         persistent._mas_current_season = store.mas_seasons._seasonalCatchup(
             persistent._mas_current_season
         )
-    return "derandom|rebuild_ev"
+    return {"derandom": None, "rebuild_ev": None}
 
 # player has snow, hemisphere version
 label monika_hemispheres_gets_snow:
@@ -14046,7 +14046,7 @@ label monika_robotbody:
     m 5eubla "Well, no matter what, I wouldn't mind any of that as long as I have you."
     m 5eubfb "I love you [player], and I'm willing to make any sacrifice to be with you forever."
     m 5hubfa "Besides, maybe sometime after I cross over, there'll be more advances in technology to make me more human, and then we'll be able to do more things together."
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(
@@ -14337,7 +14337,7 @@ label monika_unknown:
     if mas_isMoniNormal(higher=True):
         m 1eka "Just know that if you ever decide to make that sort of change, I'll support you every step of the way."
         m 1hubsa "I love you, [player]. I'll always be rooting for you~"
-        return "love"
+        return {"love": None}
     return
 
 init 5 python:
@@ -14624,7 +14624,7 @@ label monika_boardgames:
             m 1eua "But I'm sure there are plenty of other fun activities you enjoy doing in your free time."
             m 3hua "Still, if you ever change your mind, I'd like to give some board games a try with you sometime."
 
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(
@@ -14840,7 +14840,7 @@ label monika_coding_experience:
             m 1hksdlb "I just wanted to make sure I wasn't boring you with my Python tips, ahaha~"
             m 3eub "But I hope they convince you to take on some of your own coding projects too!"
             m 3hua "I'd love to see what you can come up with if you put your mind to it!"
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(
@@ -14972,7 +14972,7 @@ label monika_ship_of_theseus:
     show monika 5eua at t11 zorder MAS_MONIKA_Z with dissolve_monika
     m 5eua "We should keep trying our best each day and not let ourselves be limited by who we were yesterday."
     m 5eub "Today is a new day, and you are a new you. {w=0.2}And I love you as you are right now, [mas_get_player_nickname()]."
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(
@@ -15097,7 +15097,7 @@ label monika_working_out:
     else:
         m 3eub "Maybe when I cross over, we can do our workouts together!"
 
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(
@@ -15324,7 +15324,7 @@ label monika_soft_rains:
     m 6eka "..."
     m 2ekbsa "So..."
     m 1ekbfa "What else shall we do today, [mas_get_player_nickname()]?"
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(
@@ -15672,7 +15672,7 @@ label monika_architecture:
         m 1ekb "I believe it'll happen one day and I hope you do too, [mas_get_player_nickname()]."
         m 1ekbsa "I love you~"
 
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(
@@ -15887,7 +15887,7 @@ label monika_wabi_sabi:
 
     m 3hua "We'll overcome any problems you feel you have together."
     m 1hub "That's my wabi-sabi promise!"
-    return "love"
+    return {"love": None}
 
 init 5 python:
     addEvent(
@@ -16277,7 +16277,7 @@ label monika_introverts_extroverts:
             m 5eua "I'm sure we'll be able to figure out each other's comfort zones over time."
             m 5hubsb "In any case, you'll always be my sweetheart, no matter where you are on the scale~"
 
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(
@@ -16369,7 +16369,7 @@ label monika_nature:
             m 7tkx "Constantly buzzing around your head, getting in your face, landing on your food...{w=0.3}some mosquitos and ticks even carry nasty diseases."
             m 3eka "But as long as I'm with you, I'm fine if you'd prefer to be indoors."
             m 1tfu "Just don't expect me to let you stay inside all the time~"
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(
@@ -16703,7 +16703,7 @@ label monika_curse_words:
     m 1esa "But anyway, I prefer to keep my profanity to when I'm really frustrated or upset."
     m 3esd "Given the status I had, I felt like I always had to be professional and level headed, so I always made it a point to keep it to a minimum."
     m 3hksdlb "But I guess it doesn't really hurt when used appropriately, ahaha!"
-    return "derandom"
+    return {"derandom": None}
 
 init 5 python:
     addEvent(

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -3206,7 +3206,7 @@ label monika_change_background_loop:
 
     # return value False? then return
     if sel_background is False:
-        return "prompt"
+        return {"prompt": None}
 
     if sel_background == mas_current_background:
         m 1hua "We're here right now, silly."

--- a/Monika After Story/game/zz_consumables.rpy
+++ b/Monika After Story/game/zz_consumables.rpy
@@ -1661,7 +1661,7 @@ init 5 python:
 label mas_consumables_generic_queued_running_out:
     $ low_cons = MASConsumable._getLowCons()
     call mas_consumables_generic_queued_running_out_dlg(low_cons)
-    return "no_unlock"
+    return {"no_unlock": None}
 
 init 5 python:
     addEvent(
@@ -1674,7 +1674,7 @@ init 5 python:
 label mas_consumables_generic_running_out_absentuse:
     $ low_cons = MASConsumable._getLowConsNotWarned()
     call mas_consumables_generic_queued_running_out_dlg(low_cons)
-    return "no_unlock"
+    return {"no_unlock": None}
 
 
 label mas_consumables_generic_queued_running_out_dlg(low_cons):

--- a/Monika After Story/game/zz_dockingstation.rpy
+++ b/Monika After Story/game/zz_dockingstation.rpy
@@ -2610,7 +2610,7 @@ label mas_dockstat_generic_rtg:
 
         #Otherwise we just use the normal outro
         m 1eua "I'm ready to go."
-        return "quit"
+        return {"quit": None}
     call mas_transition_from_emptydesk("monika 1ekc")
     call mas_dockstat_abort_post_show
     # otherwise, we failed, so monika should tell player
@@ -2666,7 +2666,7 @@ label mas_dockstat_generic_cancelled_still_going_ask:
                 # otherwise, upset and below
                 m 2tfd "...Fine."
 
-            return "quit"
+            return {"quit": None}
 
         "No.":
             if mas_isMoniNormal(higher=True):
@@ -2691,7 +2691,7 @@ label mas_dockstat_generic_failed_io_still_going_ask:
         "Yes.":
             m 2eka "I understand. You have things to do, after all..."
             m 2hub "Be safe out there! I'll be right here waiting for you!"
-            return "quit"
+            return {"quit": None}
 
         "No.":
             m 2wub "Really? Are you sure? Even though it's my own fault I can't go with you..."

--- a/Monika After Story/game/zz_poems.rpy
+++ b/Monika After Story/game/zz_poems.rpy
@@ -334,8 +334,7 @@ label monika_showpoem:
     $ _poem = _return
 
     if not _poem:
-        return "prompt"
-
+        return {"prompt": None}
 
     show monika at t11
 

--- a/Monika After Story/game/zz_reactions.rpy
+++ b/Monika After Story/game/zz_reactions.rpy
@@ -1548,7 +1548,7 @@ label mas_reaction_promisering:
             m 6dkbfu "More than anything else in this fleeting world~"
 
             $ store.mas_filereacts.delete_file(mas_getEVLPropValue("mas_reaction_promisering", "category"))
-            return "love"
+            return {"love": None}
 
         else:
             if not persistent._mas_tried_gift_ring:

--- a/Monika After Story/game/zz_weather.rpy
+++ b/Monika After Story/game/zz_weather.rpy
@@ -1185,7 +1185,7 @@ label monika_change_weather:
 
     # return value False? then return
     if sel_weather is False:
-        return "prompt"
+        return {"prompt": None}
 
     elif sel_weather == "auto":
         show monika at t11

--- a/Monika After Story/game/zz_windowreacts.rpy
+++ b/Monika After Story/game/zz_windowreacts.rpy
@@ -706,7 +706,7 @@ label mas_wrs_twitter:
     #Unlock again if we failed
     if not wrs_success:
         $ mas_unlockFailedWRS('mas_wrs_twitter')
-    return "love" if ily_quips_map[quip] else None
+    return {"love": None} if ily_quips_map[quip] else None
 
 init 5 python:
     addEvent(


### PR DESCRIPTION
Changed our return keys from `str`s to `dict`s to use the `kwargs` format. It's just cleaner and makes managing things like idle displayable easier (and faster w/o heavy regex). I kept support for the old format, let's give a release or two so people can update their submods/etc.

**I'd like to get this merged sooner than later (added `high priority`), because each new topic would require updating this PR (and it's easy to miss something).**

### Changes:
- New format for return keys.

### Testing:
- Verify each return key works as expected.
- Verify the return keys work in pairs.
- Scroll through the changes tab and make sure I haven't made a typo.
- Ideally look through the scripts and verify we updated all instanced where we use return keys.