### PR TITLE
Return home consumables fix

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1334,9 +1334,6 @@ label ch30_post_exp_check:
 
         $ pushEvent(selected_greeting)
 
-    #Now we check if we should drink
-    $ MASConsumable._checkConsumables(startup=True)
-
     # if not persistent.tried_skip:
     #     $ config.allow_skipping = True
     # else:
@@ -2041,6 +2038,11 @@ label ch30_reset:
 
     # build background filter data and update the current filter progression
     $ store.mas_background.buildupdate()
+
+    #Now we check if we should drink
+    # NOTE: the consumables check must be called before the reset in the retmoni check block, otherwise there's
+    # a chance to return home and have a consumable already on the table
+    $ MASConsumable._checkConsumables(startup=True)
 
     ## certain things may need to be reset if we took monika out
     # NOTE: this should be at the end of this label, much of this code might

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1334,6 +1334,9 @@ label ch30_post_exp_check:
 
         $ pushEvent(selected_greeting)
 
+    #Now we check if we should drink
+    $ MASConsumable._checkConsumables(startup=not mas_globals.returned_home_this_sesh)
+
     # if not persistent.tried_skip:
     #     $ config.allow_skipping = True
     # else:
@@ -2038,11 +2041,6 @@ label ch30_reset:
 
     # build background filter data and update the current filter progression
     $ store.mas_background.buildupdate()
-
-    #Now we check if we should drink
-    # NOTE: the consumables check must be called before the reset in the retmoni check block, otherwise there's
-    # a chance to return home and have a consumable already on the table
-    $ MASConsumable._checkConsumables(startup=True)
 
     ## certain things may need to be reset if we took monika out
     # NOTE: this should be at the end of this label, much of this code might


### PR DESCRIPTION
Closes #6938

This changes the `startup` argument of `_checkConsumables` in `ch30_post_exp_check` to `not mas_globals.returned_home_this_sesh` instead of `True`.

## Testing:
- Verify that no consumables magically appear on the table after returning home from a date or while Monika is out of the room.
- Verify that, loading in during a consumable's normal hours, a consumable is already on Monika's desk (without her having to make/get any) assuming she decided to have some.