### PR TITLE
Optimize conditionals

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -519,6 +519,11 @@ python early:
         # NOTE: action code should be callable on a given event object
         ACTION_MAP = dict()
 
+        # Conditional cache
+        # A map from conditional string to compiled code objects
+        # (speeds up event checks)
+        _conditional_cache = dict()
+
         # NOTE: _eventlabel is required, its the key to this event
         # its also how we handle equality. also it cannot be None
         def __init__(self,
@@ -707,22 +712,52 @@ python early:
             # setup lock entry
             Event.INIT_LOCKDB.setdefault(eventlabel, mas_init_lockdb_template)
 
+            # Cache conditional
+            if self.conditional is not None and self.conditional not in Event._conditional_cache:
+                Event._conditional_cache[self.conditional] = renpy.python.py_compile(self.conditional, "eval")
 
-        # equality override
         def __eq__(self, other):
+            """
+            Equality override
+
+            IN:
+                other - the object to compare this event with
+
+            OUT:
+                boolean
+            """
             if isinstance(self, other.__class__):
                 return self.eventlabel == other.eventlabel
             return False
 
-        # equality override
         def __ne__(self, other):
+            """
+            Non-equality override
+
+            IN:
+                other - the object to compare this event with
+
+            OUT:
+                boolean
+            """
             return not self.__eq__(other)
 
-        # set attr overrride
         def __setattr__(self, name, value):
-            #
-            # Override of setattr so we can do cool things
-            #
+            """
+            Override of setattr so we can do cool things
+
+            IN:
+                name - the name of the prop to change (str)
+                value - the new value
+            """
+            # Special handling for the conditional property
+            if (
+                name == "conditional"
+                and value is not None
+                and value not in Event._conditional_cache
+            ):
+                Event._conditional_cache[value] = renpy.python.py_compile(value, "eval")
+
             if name in self.N_EVENT_NAMES:
                 super(Event, self).__setattr__(name, value)
 #                self.__dict__[name] = value
@@ -842,6 +877,31 @@ python early:
             # otheerwise check the range
             low, high = self.aff_range
             return store.mas_affection._betweenAff(low, aff_level, high)
+
+        def checkConditional(self, globals=None, locals=None):
+            """
+            Checks conditional of this event
+
+            IN:
+                globals - global scope for eval. If None, the base store is used.
+                    (Default: None)
+                locals - local scope for eval. If None, set to globals.
+                    (Default: None)
+
+            OUT:
+                boolean:
+                    True if passed, False if not
+            """
+            if self.conditional is None:
+                return True
+
+            if globals is None:
+                globals = renpy.store.__dict__
+
+            if locals is None:
+                locals = globals
+
+            return eval(Event._conditional_cache[self.conditional], globals=globals, locals=locals)
 
         def canRepeat(self):
             """
@@ -972,13 +1032,34 @@ python early:
             """
             self.flags &= ~flags
 
+        @classmethod
+        def validateConditionals(cls):
+            """
+            A method to validate conditionals
+
+            ASSUMES:
+                mas_all_ev_db
+            """
+            for ev in mas_all_ev_db.itervalues():
+                if ev.conditional is not None:
+                    try:
+                        eval(cls._conditional_cache[ev.conditional], globals=renpy.store.__dict__, locals=renpy.store.__dict__)
+
+                    except Exception as e:
+                        raise EventException(
+                            "Failed to evaluate the '{0}' conditional for the event with the '{1}' label:\n{2}.".format(
+                                ev.conditional,
+                                ev.eventlabel,
+                                e
+                            )
+                        )
+
         @staticmethod
         def getSortPrompt(ev):
             #
             # Special function we use to get a lowercased version of the prompt
             # for sorting purposes
             return renpy.substitute(ev.prompt).lower()
-
 
         @staticmethod
         def getSortShownCount(ev):
@@ -1670,7 +1751,7 @@ python early:
                 return False
 
             # now check conditional, if needed
-            if ev.conditional is not None and not eval(ev.conditional):
+            if not ev.checkConditional():
                 return False
 
             # check if valid action

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -1747,13 +1747,13 @@ init python:
             raise EventException("'" + str(event) + "' is not an Event object")
         if not renpy.has_label(event.eventlabel):
             raise EventException("'" + event.eventlabel + "' does NOT exist")
-        if event.conditional is not None:
-            eval(event.conditional)
-#            try:
-#                if eval(event.conditional, globals()):
-#                    pass
-#            except:
-#                raise EventException("Syntax error in conditional statement for event '" + event.eventlabel + "'.")
+        # if event.conditional is not None:
+        #     eval(event.conditional)
+        #    try:
+        #        if eval(event.conditional, globals()):
+        #            pass
+        #    except:
+        #        raise EventException("Syntax error in conditional statement for event '" + event.eventlabel + "'.")
         # if should not skip calendar check and event has a start_date
         if not skipCalendar and type(event.start_date) is datetime.datetime:
             # add it to the calendar database

--- a/Monika After Story/game/script-farewells.rpy
+++ b/Monika After Story/game/script-farewells.rpy
@@ -111,7 +111,7 @@ init -1 python in mas_farewells:
             return False
 
         #Conditional check (Since it's ideally least likely to be used)
-        if ev.conditional is not None and not eval(ev.conditional, store.__dict__):
+        if not ev.checkConditional():
             return False
 
         # otherwise, we passed all tests

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -189,7 +189,7 @@ init -1 python in mas_greetings:
             return False
 
         # conditional check
-        if ev.conditional is not None and not eval(ev.conditional, store.__dict__):
+        if not ev.checkConditional():
             return False
 
         # otherwise, we passed all tests

--- a/Monika After Story/game/splash.rpy
+++ b/Monika After Story/game/splash.rpy
@@ -172,6 +172,9 @@ label splashscreen:
         # set zoom
         store.mas_sprites.adjust_zoom()
 
+        # We're about to start, all things should be loaded, we can check event conditionals
+        Event.validateConditionals()
+
     if mas_corrupted_per and (mas_no_backups_found or mas_backup_copy_failed):
         # we have a corrupted persistent but was unable to recover via the
         # backup system

--- a/Monika After Story/game/zz_games.rpy
+++ b/Monika After Story/game/zz_games.rpy
@@ -77,7 +77,7 @@ init 8 python:
         if game_ev:
             return (
                 game_ev.unlocked
-                and (not game_ev.conditional or (game_ev.conditional and eval(game_ev.conditional)))
+                and game_ev.checkConditional()
                 and game_ev.checkAffection(store.mas_curr_affection)
             )
         return False

--- a/Monika After Story/game/zz_windowutils.rpy
+++ b/Monika After Story/game/zz_windowutils.rpy
@@ -719,19 +719,13 @@ init python:
         for ev_label, ev in mas_windowreacts.windowreact_db.iteritems():
             if (
                 Event._filterEvent(ev, unlocked=True, aff=store.mas_curr_affection)
+                and ev.checkConditional()
                 and mas_isInActiveWindow(ev.category, "non inclusive" in ev.rules)
                 and ((not store.mas_globals.in_idle_mode) or (store.mas_globals.in_idle_mode and ev.show_in_idle))
                 and mas_notifsEnabledForGroup(ev.rules.get("notif-group"))
             ):
-                #If we have a conditional, eval it and queue if true
-                if ev.conditional and eval(ev.conditional):
-                    queueEvent(ev_label)
-                    ev.unlocked=False
-
-                #Otherwise we just queue
-                elif not ev.conditional:
-                    queueEvent(ev_label)
-                    ev.unlocked=False
+                queueEvent(ev_label)
+                ev.unlocked = False
 
                 #Add the blacklist
                 if "no_unlock" in ev.rules:


### PR DESCRIPTION
We use `conditional`s quite often, and we're evaluating them once per minute. One thing we can do is compile `str` into py code to speed `eval` up.

### Changes:
- All `Event` objects compile their `conditional`s (if they aren't `None`) and add them to the conditional cache which can be accessed later on.
- Added new method to the `Event` class `checkConditional`. Allows to check `conditional` of a single `Event` object. Respects `None`, accepts `globals` and `locals`. Note: you can still use `eval` directly.
- Added new class method to the `Event` class `validateConditionals`. Validates `conditional`s of all events in `mas_all_ev_db`. Raises exceptions if there's an error in a `conditional`. We run it in `splashscreen`, after aff setup. Technically, we can use *any* functions/methods for `conditional`s now.

### Testing:
- Verify general stability.
- Add a `conditional` with an error to an event. Verify it crashes you on loading with the appropriate traceback (make sure it looks informative and not too confusing).
- Add/remove a `conditional` from an event. Verify it appears in the cache, adds to/gets removed from the event's props.