### PR TITLE
Chess Update Scripts II

### DIFF
--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -377,7 +377,16 @@ label v0_3_1(version=version): # 0.3.1
 # 0.12.0.1
 label v0_12_0_1(version="v0_12_0_1"):
     python:
-        pass
+        missing_chess_persist_keys = [
+            "practice_wins",
+            "practice_losses",
+            "practice_draws"
+        ]
+
+        for missing_key in missing_chess_persist_keys:
+            if missing_key not in persistent._mas_chess_stats:
+                persistent._mas_chess_stats[missing_key] = 0
+
     return
 
 # 0.12.0


### PR DESCRIPTION
Copy of the dropfix for chess here.

Fixes the missing persist keys from chess for practice mode for those who started after release of 0.11.5 and before 0.11.7/8/9

## Testing:
- Verify that persists missing the practice chess keys will gain them when the update script runs.