### PR TITLE
Fix escape not working and quick menu being disabled after open door greeting

### DIFF
--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1899,6 +1899,9 @@ label monikaroom_greeting_cleanup:
         # 5 - the music can be restarted
         mas_startup_song()
 
+        # 6 - enable escape so we can access settings and chat box keys
+        enable_esc()
+
     return
 
 #init 5 python:


### PR DESCRIPTION
Currently, when getting a Monika room (open door) greet, escape is not being enabled, which means we cannot access the settings menu or the chatbox keys (auto, settings, skip etc) without first going to something like the `Play` menu. This enables esc in `monikaroom_greeting_cleanup` label to correct the issue.

## Testing
verify it fixes the bug and that there are no unintended side effects