### PR TITLE
Fix dismissable text during waits and extends and non-dismissable text after UI setting changes

### DIFF
--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -1371,10 +1371,10 @@ screen preferences():
 
                     #Handle buttons
                     textbutton _("UI: Night Mode"):
-                        action [Function(mas_darkMode, persistent._mas_dark_mode_enabled), Function(mas_settings._dark_mode_toggle)]
+                        action [Function(mas_darkMode, persistent._mas_dark_mode_enabled), Function(mas_settings._dark_mode_toggle), RestartStatement()]
                         selected persistent._mas_dark_mode_enabled
                     textbutton _("UI: D/N Cycle"):
-                        action [Function(mas_darkMode, mas_current_background.isFltDay()), Function(mas_settings._auto_mode_toggle)]
+                        action [Function(mas_darkMode, mas_current_background.isFltDay()), Function(mas_settings._auto_mode_toggle), RestartStatement()]
                         selected persistent._mas_auto_mode_enabled
 
 

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -1371,10 +1371,10 @@ screen preferences():
 
                     #Handle buttons
                     textbutton _("UI: Night Mode"):
-                        action [Function(mas_darkMode, persistent._mas_dark_mode_enabled), Function(mas_settings._dark_mode_toggle), RestartStatement()]
+                        action [Function(mas_settings._ui_change_wrapper, persistent._mas_dark_mode_enabled), Function(mas_settings._dark_mode_toggle)]
                         selected persistent._mas_dark_mode_enabled
                     textbutton _("UI: D/N Cycle"):
-                        action [Function(mas_darkMode, mas_current_background.isFltDay()), Function(mas_settings._auto_mode_toggle), RestartStatement()]
+                        action [Function(mas_settings._ui_change_wrapper, mas_current_background.isFltDay()), Function(mas_settings._auto_mode_toggle)]
                         selected persistent._mas_auto_mode_enabled
 
 

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -447,8 +447,9 @@ init python:
                 show -> right before dialogue is shown
                 show_done -> right after dialogue is shown
                 slow_done -> called after text finishes showing
-                    May happen after "end"
                 end -> end of dialogue (user has interacted)
+                    NOTE: dismiss needs to be possible for end to be reached
+                        when mouse is clicked after an interaction ends.
         """
         # skip check
         # if config.skipping and not config.developer:
@@ -458,7 +459,7 @@ init python:
         #     renpy.jump("ch30_noskip")
         #     return
 
-        if event == "begin":
+        if event == "show":
             store.mas_hotkeys.allow_dismiss = False
 #            config.keymap['dismiss'] = []
 #            renpy.display.behavior.clear_keymap_cache()

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -459,13 +459,13 @@ init python:
         #     renpy.jump("ch30_noskip")
         #     return
 
-        if event == "show":
-            store.mas_hotkeys.allow_dismiss = False
+        if event == "show" or event == "begin":
+            store.mas_hotkeys.set_dismiss(False)
 #            config.keymap['dismiss'] = []
 #            renpy.display.behavior.clear_keymap_cache()
 
         elif event == "slow_done":
-            store.mas_hotkeys.allow_dismiss = True
+            store.mas_hotkeys.set_dismiss(True)
 #            config.keymap['dismiss'] = dismiss_keys
 #            renpy.display.behavior.clear_keymap_cache()
 

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -129,7 +129,7 @@ default persistent._mas_force_hair = False
 default persistent._mas_last_ahoge_dt = None
 # set to the dt of when we last set the ahoge
 
-define m = DynamicCharacter('m_name', image='monika', what_prefix='', what_suffix='', ctc="ctc", ctc_position="fixed")
+define m = DynamicCharacter('m_name', image='monika', what_prefix='', what_suffix='', ctc="ctc", ctc_position="fixed", show_function=store.mas_core.show_display_say)
 
 #image night_filter = Solid("#20101897", xsize=1280, ysize=850)
 
@@ -137,6 +137,18 @@ image mas_finalnote_idle = "mod_assets/poem_finalfarewell_desk.png"
 
 # Monika's piano sprite
 image mas_piano = MASFilterSwitch("mod_assets/other/mas_piano.png")
+
+init -10 python in mas_core:
+    _last_text = None
+
+    def show_display_say(who, what_string, **kwargs):
+        """
+        semi-override of show_display_say so we can force text to render
+        immediately.
+        """
+        global _last_text
+        _last_text = renpy.character.show_display_say(who, what_string, **kwargs)
+        return _last_text
 
 ### ACS TYPE + DEFAULTING FRAMEWORK ###########################################
 # this contains special acs type mappings

--- a/Monika After Story/game/styles.rpy
+++ b/Monika After Story/game/styles.rpy
@@ -222,6 +222,7 @@ init python in mas_settings:
     _persistent = renpy.game.persistent
 
     ui_changed = False
+    dark_mode_clicked = False
 
     import store
     def _auto_mode_toggle():
@@ -249,6 +250,9 @@ init python in mas_settings:
         else:
             _persistent._mas_dark_mode_enabled = True
             _persistent._mas_auto_mode_enabled = False
+
+        global dark_mode_clicked
+        dark_mode_clicked = True
 
     def _ui_change_wrapper(*args):
         """

--- a/Monika After Story/game/styles.rpy
+++ b/Monika After Story/game/styles.rpy
@@ -220,6 +220,9 @@ init python:
 # START: Settings menu helpers
 init python in mas_settings:
     _persistent = renpy.game.persistent
+
+    ui_changed = False
+
     import store
     def _auto_mode_toggle():
         """
@@ -246,7 +249,17 @@ init python in mas_settings:
         else:
             _persistent._mas_dark_mode_enabled = True
             _persistent._mas_auto_mode_enabled = False
-        renpy.restart_interaction()
+
+    def _ui_change_wrapper(*args):
+        """
+        Wrapper around UI changes
+
+        IN:
+            *args - values to pass to dark mode
+        """
+        global ui_changed
+        ui_changed = True
+        store.mas_darkMode(*args)
 
 
 # START: Generic button styles

--- a/Monika After Story/game/zz_hotkeys.rpy
+++ b/Monika After Story/game/zz_hotkeys.rpy
@@ -7,11 +7,27 @@ init -10 python in mas_hotkeys:
     # True means allow Dismiss, False means do not
     allow_dismiss = True
 
+    # True will lock dismiss, False will mean dismiss can be changed
+    lock_dismiss = False
+
+
     def allowdismiss():
         """
         Justreturns current state of no_dismiss
         """
         return allow_dismiss
+
+    
+    def set_dismiss(value):
+        """
+        Sets dismiss to the given value, if it is not locked.
+
+        IN:
+            value - True will allow dismiss, False will not
+        """
+        if not lock_dismiss:
+            global allow_dismiss
+            allow_dismiss = value
 
 
 init -1 python in mas_hotkeys:
@@ -239,10 +255,14 @@ init python:
                 store.mas_settings.ui_changed
                 and store.mas_core._last_text is not None
         ):
-            store.mas_core._last_text.call_slow_done(0)
+                store.mas_core._last_text.call_slow_done(0)
+
+        elif store.mas_settings.dark_mode_clicked:
+            renpy.restart_interaction()
 
         # reset these vars so we don't run weird shit
         store.mas_settings.ui_changed = False
+        store.mas_settings.dark_mode_clicked = False
         store.mas_core._last_text = None
 
 

--- a/Monika After Story/game/zz_hotkeys.rpy
+++ b/Monika After Story/game/zz_hotkeys.rpy
@@ -234,6 +234,17 @@ init python:
         ):
             store.mas_background.buildupdate()
 
+        # dismiss last text if ui changed
+        if (
+                store.mas_settings.ui_changed
+                and store.mas_core._last_text is not None
+        ):
+            store.mas_core._last_text.call_slow_done(0)
+
+        # reset these vars so we don't run weird shit
+        store.mas_settings.ui_changed = False
+        store.mas_core._last_text = None
+
 
     def _mas_game_menu():
         """

--- a/Monika After Story/game/zz_shields.rpy
+++ b/Monika After Story/game/zz_shields.rpy
@@ -191,6 +191,7 @@ init python:
             - Music Menu
             - Calendar overlay
             - Window hiding
+            - dismiss
 
         Shows:
             - hotkey buttons
@@ -201,6 +202,8 @@ init python:
         mas_calDropOverlayShield()
         HKBShowButtons()
         mas_hotkeys.no_window_hiding = False
+        mas_hotkeys.lock_dismiss = False
+        mas_hotkeys.allow_dismiss = True
 
     def mas_RaiseShield_timedtext():
         """
@@ -211,6 +214,7 @@ init python:
             - Music Menu
             - Calendar overlay
             - Window hiding
+            - dismiss
 
         Hides:
             - hotkey buttons
@@ -221,6 +225,8 @@ init python:
         mas_calRaiseOverlayShield()
         HKBHideButtons()
         mas_hotkeys.no_window_hiding = True
+        mas_hotkeys.lock_dismiss = True
+        mas_hotkeys.allow_dismiss = False
 
 
 ################################## GENERALIZED ################################


### PR DESCRIPTION
# Two issues:
1. It is possible to skip lines by spam clicking in dialogue that contains wait tags or `extend`
2. The dialogue box becomes non-dismissable / frozen when a UI change button is clicked while Monika is in the middle of talking.

# Causes
1. `slow_nodismiss` blocks dismiss when the say screen `begin`s and allows dismiss when text has finished rendering (`slow_done`). However, `begin` only runs once during a say interaction while `slow_done` can be run multiple times depending on the text shown. Oddly enough the majority of the time when the say screen is run, it runs in its entirety for every line/wait/pause, so dismiss is working properly. However the mechanics of the wait tags and `extend` mean this assumption isn't true all the time.
    1. With wait tags, the full text can be broken up into multiple parts depending on how many wait tags there are. Each line + wait will call `slow_done`, so it's possible for dismiss to be enabled while the second line is rendering.
    2. With `extend`, a `{fast}` tag is inserted between the two lines, and this tag acts like a pause with no delay. Just like with wait tags, dismiss can be enabled while the second line is rendering.
2. When a UI change button is clicked, the `slow_done` call never occurs, which means dismiss continues to be disabled even after the text is rendered. The reasons as to why this happens is unknown, but my guess is that when `mas_darkMode` runs, it rebuilds the styles which causes the say screen, the text displayable being rendered, or the `SlowDone` callback to silently crash before it gets to call `slow_nodismiss` again.

# Key Changes
1. `slow_nodismiss` changed so it also disables dismiss at `show` event. This event is called right before text starts rendering.
2. new `mas_hotkeys.lock_dismiss` global that locks dismiss from being set by the `slow_nodismiss` function. Use then when text wait is high priority.
3. `mas_hotleys.set_dismiss` - use when setting dismiss while respecting locking
4. the `timedtext` shields now set and lock dismiss so you cant skip waits in song mode
5. `show_display_say` function passed into the Monika `Character` object's `show_function` param. This allows us to override the default show function for Monika (`renpy.character.show_display_say`) and save the text object that is being rendered when the say screen is shown. 
6. the UI change buttons now call `mas_settings._ui_change_wrapper`, which is a wrapper around the `mas_darkMode` function that sets a global var `mas_settings.ui_changed`
7. `_dark_mode_toggle` now sets `mas_settings.dark_mode_clicked` to True
8. In the callback for when the game menu closes (`_mas_game_menu_end`), if both `ui_changed` is True and the text object is set, `call_slow_done` is called on the text object. This will force the current text to render instantly, show the "Click to Continue" indicator (although this is not 100% consistent), and restart the interaction. Otherwise, the interaction is restarted if `mas_settings.dark_mode_clicked` is true.

# Testing
* for all testing, make sure `m.what_args["slow_abortable"]` is False.

### Known issues
* it seems that waits are dismissable, and there probably isn't a good way around it since there's no way to know if a standard dialogue line ends until the user advances the text (aka interacts, aka dismisses it).

### issue 1
1. spam click while Monika is talking in a topic with lots of waits + delays and `extend` 
2. Verify text does not dismiss, or at least very very rarely does.

### issue 1.1
1. Run a topic that uses `timedtext` shields (AIWFC song) (grad speech is probably a better test, the waits are more obvious)
2. Verify spam clicking/space bar does not skip waits (the lyrics should line up with the song).

### issue 2
1. When Monika is mid-sentence, open the settings menu and click any of the UI change buttons. (recommended use a topic where Monika uses long sentences)
2. Verify the UI changes as appropriate
3. Verify when leaving the game menu, Monika's current line appears instantly, and the textbox can be advanced when she is done talking.