### PR TITLE
Windowreacts but they're implemented how they should've been from the start

### DIFF
--- a/Monika After Story/game/dev/dev_active_window_check.rpy
+++ b/Monika After Story/game/dev/dev_active_window_check.rpy
@@ -20,7 +20,7 @@ label monika_check_window:
     if mas_isFocused():
         m 1hub "Me, yay!"
     else:
-        $ active_wind = mas_getActiveWindow(True)
+        $ active_wind = mas_getActiveWindowHandle(True)
         if active_wind:
             m 3eua "[active_wind]."
         else:

--- a/Monika After Story/game/dev/dev_active_window_check.rpy
+++ b/Monika After Story/game/dev/dev_active_window_check.rpy
@@ -13,7 +13,7 @@ init 5 python:
 
 label monika_check_window:
     m 1hub "Okay, [player]!"
-    m 2dsc "Let's see...your active window is.{w=0.5}.{w=0.5}."
+    m 2dsc "Let's see...your active window is.{w=0.5}.{w=0.5}.{nw}"
 
     pause 2.0
 

--- a/Monika After Story/game/dev/dev_active_window_check.rpy
+++ b/Monika After Story/game/dev/dev_active_window_check.rpy
@@ -20,7 +20,7 @@ label monika_check_window:
     if mas_isFocused():
         m 1hub "Me, yay!"
     else:
-        $ active_wind = mas_getActiveWindowHandle(True)
+        $ active_wind = mas_getActiveWindowHandle()
         if active_wind:
             m 3eua "[active_wind]."
         else:

--- a/Monika After Story/game/dev/dev_in_active_window_check.rpy
+++ b/Monika After Story/game/dev/dev_in_active_window_check.rpy
@@ -18,5 +18,5 @@ label monika_inActiveWindowCheck:
     m 1eua "Okay, I'll pause for 3 seconds, switch to the window and then I'll tell you if those keywords were in there."
     pause 3.0
     $ inActiveWindow = mas_isInActiveWindow(regexp=active_window_regexp)
-    m 1hua "Okay, your active window was: [mas_getActiveWindowHandle(True)], and your match returned [inActiveWindow]."
+    m 1hua "Okay, your active window was: [mas_getActiveWindowHandle()], and your match returned [inActiveWindow]."
     return

--- a/Monika After Story/game/dev/dev_in_active_window_check.rpy
+++ b/Monika After Story/game/dev/dev_in_active_window_check.rpy
@@ -18,5 +18,5 @@ label monika_inActiveWindowCheck:
     m 1eua "Okay, I'll pause for 3 seconds, switch to the window and then I'll tell you if those keywords were in there."
     pause 3.0
     $ inActiveWindow = mas_isInActiveWindow(regexp=active_window_regexp)
-    m 1hua "Okay, your active window was: [mas_getActiveWindow(True)], and your match returned [inActiveWindow]."
+    m 1hua "Okay, your active window was: [mas_getActiveWindowHandle(True)], and your match returned [inActiveWindow]."
     return

--- a/Monika After Story/game/dev/dev_in_active_window_check.rpy
+++ b/Monika After Story/game/dev/dev_in_active_window_check.rpy
@@ -12,25 +12,11 @@ init 5 python:
 
 
 label monika_inActiveWindowCheck:
-    $ active_window_keys = None
+    $ active_window_regexp = None
     m 1hub "Okay, [player]!"
-
-    m 3eua "Do you want it to be inclusive?{nw}"
-    $ _history_list.pop()
-    menu:
-        m "Do you want it to be inclusive?{fast}"
-
-        "Yes.":
-            $ non_inclusive = False
-
-        "No.":
-            $ non_inclusive = True
-
-    m 1hub "Okay!"
-    m 3eub "Put some keywords in the 'active_window_keys' list now."
+    m 3eub "Put a regexp into 'active_window_regexp' so I can use that to check."
     m 1eua "Okay, I'll pause for 3 seconds, switch to the window and then I'll tell you if those keywords were in there."
     pause 3.0
-    $ ActiveWindow = mas_getActiveWindow(True)
-    $ inActiveWindow = mas_isInActiveWindow(active_window_keys, non_inclusive)
-    m 1hua "Okay, your active window was: [ActiveWindow], and your keys returned [inActiveWindow]."
+    $ inActiveWindow = mas_isInActiveWindow(regexp=active_window_regexp)
+    m 1hua "Okay, your active window was: [mas_getActiveWindow(True)], and your match returned [inActiveWindow]."
     return

--- a/Monika After Story/game/script-windowreacts.rpy
+++ b/Monika After Story/game/script-windowreacts.rpy
@@ -86,7 +86,7 @@ label mas_wrs_wikipedia:
 
     #Items in here will get the wiki article you're looking at for reacts.
     python:
-        wind_name = mas_getActiveWindow(friendly=True)
+        wind_name = mas_getActiveWindowHandle(friendly=True)
         try:
             cutoff_index = wind_name.index(" - Wikipedia")
 

--- a/Monika After Story/game/script-windowreacts.rpy
+++ b/Monika After Story/game/script-windowreacts.rpy
@@ -3,7 +3,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_pinterest",
-            category=["pinterest"],
+            category=["Pinterest"],
             rules={
                 "notif-group": "Window Reactions",
                 "skip alert": None,
@@ -35,7 +35,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_duolingo",
-            category=['duolingo'],
+            category=["Duolingo"],
             rules={
                 "notif-group": "Window Reactions",
                 "skip alert": None,
@@ -67,7 +67,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_wikipedia",
-            category=["wikipedia"],
+            category=["- Wikipedia"],
             rules={
                 "notif-group": "Window Reactions",
                 "skip alert": None,
@@ -86,7 +86,7 @@ label mas_wrs_wikipedia:
 
     #Items in here will get the wiki article you're looking at for reacts.
     python:
-        wind_name = mas_getActiveWindowHandle(friendly=True)
+        wind_name = mas_getActiveWindowHandle()
         try:
             cutoff_index = wind_name.index(" - Wikipedia")
 
@@ -117,7 +117,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_virtualpiano",
-            category=["^virtualpiano"],
+            category=["^Virtual Piano"],
             rules={
                 "notif-group": "Window Reactions",
                 "skip alert": None,
@@ -153,7 +153,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_youtube",
-            category=["youtube"],
+            category=["- YouTube"],
             rules={
                 "notif-group": "Window Reactions",
                 "skip alert": None,
@@ -184,7 +184,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_r34m",
-            category=["((r34|rule34).*monika)|(post\d+:\w+monika)|(\w*monika[\w?():]*(r34|rule34))"],
+            category=[r"(?i)(((r34|rule\s?34).*monika)|(post \d+:[\w ]+monika)|([\w ]*monika[\w?(): ]*(r34|rule34)))"],
             rules={"skip alert": None, "notif-group": "Window Reactions"},
             show_in_idle=True
         ),
@@ -227,7 +227,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_monikamoddev",
-            category=["monikamoddev"],
+            category=["MonikaModDev"],
             rules={
                 "notif-group": "Window Reactions",
                 "skip alert": None,
@@ -258,7 +258,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_twitter",
-            category=["twitter"],
+            category=["/ Twitter"],
             rules={
                 "notif-group": "Window Reactions",
                 "skip alert": None,
@@ -298,7 +298,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_4chan",
-            category=["4chan"],
+            category=["- 4chan"],
             rules={
                 "notif-group": "Window Reactions",
                 "skip alert": None,
@@ -332,7 +332,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_pixiv",
-            category=["pixiv"],
+            category=["- pixiv"],
             rules={
                 "notif-group": "Window Reactions",
                 "skip alert": None,
@@ -380,7 +380,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_reddit",
-            category=["reddit"],
+            category=[r"(?i)reddit"],
             rules={
                 "notif-group": "Window Reactions",
                 "skip alert": None,
@@ -412,7 +412,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_mal",
-            category=["myanimelist"],
+            category=["MyAnimeList"],
             rules={
                 "notif-group": "Window Reactions",
                 "skip alert": None,
@@ -445,7 +445,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_deviantart",
-            category=["deviantart"],
+            category=["DeviantArt"],
             rules={
                 "notif-group": "Window Reactions",
                 "skip alert": None,
@@ -476,7 +476,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_netflix",
-            category=["netflix"],
+            category=["Netflix"],
             rules={
                 "notif-group": "Window Reactions",
                 "skip alert": None,
@@ -508,7 +508,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_twitch",
-            category=["-twitch"],
+            category=["- Twitch"],
             rules={
                 "notif-group": "Window Reactions",
                 "skip alert": None,

--- a/Monika After Story/game/script-windowreacts.rpy
+++ b/Monika After Story/game/script-windowreacts.rpy
@@ -3,7 +3,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_pinterest",
-            category=['pinterest'],
+            category=["pinterest"],
             rules={
                 "notif-group": "Window Reactions",
                 "skip alert": None,
@@ -67,7 +67,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_wikipedia",
-            category=['wikipedia'],
+            category=["wikipedia"],
             rules={
                 "notif-group": "Window Reactions",
                 "skip alert": None,
@@ -117,7 +117,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_virtualpiano",
-            category=["virtual", "piano"],
+            category=["^virtualpiano"],
             rules={
                 "notif-group": "Window Reactions",
                 "skip alert": None,
@@ -153,7 +153,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_youtube",
-            category=['youtube'],
+            category=["youtube"],
             rules={
                 "notif-group": "Window Reactions",
                 "skip alert": None,
@@ -184,34 +184,42 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_r34m",
-            category=['rule34', 'monika'],
-            rules={"skip alert": None},
+            category=["((r34|rule34).+monika)|(post[\d\w:_]+monika)"],
+            rules={"skip alert": None, "notif-group": "Window Reactions"},
             show_in_idle=True
         ),
         code="WRS"
     )
 
 label mas_wrs_r34m:
-    $ mas_display_notif(m_name, ["Hey, [player]...what are you looking at?"],'Window Reactions')
+    python:
+        mas_display_notif(m_name, ["Hey, [player]...what are you looking at?"],'Window Reactions')
 
-    $ choice = random.randint(1,10)
-    if choice == 1:
-        $ queueEvent('monika_nsfw')
+        choice = random.randint(1,10)
 
-    elif choice == 2:
-        $ queueEvent('monika_pleasure')
+        if choice == 1:
+            queueEvent('monika_nsfw')
 
-    elif choice < 4:
-        show monika 1rsbssdlu
-        pause 5.0
+        elif choice == 2:
+            queueEvent('monika_pleasure')
 
-    elif choice < 7:
-        show monika 2tuu
-        pause 5.0
+        else:
+            if mas_isMoniEnamored(higher=True):
+                if choice < 4:
+                    exp_to_force = "1rsbssdlu"
+                elif choice < 7:
+                    exp_to_force = "2tuu"
+                else:
+                    exp_to_force = "2ttu"
+            else:
+                if choice < 4:
+                    exp_to_force = "1rksdlc"
+                elif choice < 7:
+                    exp_to_force = "2rssdlc"
+                else:
+                    exp_to_force = "2tssdlc"
 
-    else:
-        show monika 2ttu
-        pause 5.0
+            mas_moni_idle_disp.force_by_code(exp_to_force)
     return
 
 init 5 python:
@@ -219,7 +227,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_monikamoddev",
-            category=['monikamoddev'],
+            category=["monikamoddev"],
             rules={
                 "notif-group": "Window Reactions",
                 "skip alert": None,
@@ -250,7 +258,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_twitter",
-            category=['twitter'],
+            category=["twitter"],
             rules={
                 "notif-group": "Window Reactions",
                 "skip alert": None,
@@ -289,40 +297,8 @@ init 5 python:
     addEvent(
         Event(
             persistent._mas_windowreacts_database,
-            eventlabel="mas_wrs_monikatwitter",
-            category=['twitter', 'lilmonix3'],
-            rules={
-                "notif-group": "Window Reactions",
-                "skip alert": None,
-                "keep_idle_exp": None
-            },
-            show_in_idle=True
-        ),
-        code="WRS"
-    )
-
-label mas_wrs_monikatwitter:
-    $ wrs_success = mas_display_notif(
-        m_name,
-        [
-            "Are you here to confess your love for me to the entire world, [player]?",
-            "You're not spying on me, are you?\nAhaha, just kidding~",
-            "I don't care how many followers I have as long as I have you~"
-        ],
-        'Window Reactions'
-    )
-
-    #Unlock again if we failed
-    if not wrs_success:
-        $ mas_unlockFailedWRS('mas_wrs_monikatwitter')
-    return
-
-init 5 python:
-    addEvent(
-        Event(
-            persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_4chan",
-            category=['4chan'],
+            category=["4chan"],
             rules={
                 "notif-group": "Window Reactions",
                 "skip alert": None,
@@ -356,7 +332,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_pixiv",
-            category=['pixiv'],
+            category=["pixiv"],
             rules={
                 "notif-group": "Window Reactions",
                 "skip alert": None,
@@ -404,7 +380,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_reddit",
-            category=['reddit'],
+            category=["reddit"],
             rules={
                 "notif-group": "Window Reactions",
                 "skip alert": None,
@@ -436,7 +412,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_mal",
-            category=['myanimelist'],
+            category=["myanimelist"],
             rules={
                 "notif-group": "Window Reactions",
                 "skip alert": None,
@@ -469,7 +445,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_deviantart",
-            category=['deviantart'],
+            category=["deviantart"],
             rules={
                 "notif-group": "Window Reactions",
                 "skip alert": None,
@@ -500,7 +476,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_netflix",
-            category=['netflix'],
+            category=["netflix"],
             rules={
                 "notif-group": "Window Reactions",
                 "skip alert": None,
@@ -532,7 +508,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_twitch",
-            category=['-twitch'],
+            category=["-twitch"],
             rules={
                 "notif-group": "Window Reactions",
                 "skip alert": None,

--- a/Monika After Story/game/script-windowreacts.rpy
+++ b/Monika After Story/game/script-windowreacts.rpy
@@ -184,7 +184,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_r34m",
-            category=[r"(?i)(((r34|rule\s?34).*monika)|(post \d+:[\w ]+monika)|([[\w \]\-()]*monika[\w?()\-: ]*(r34|rule34)))"],
+            category=[r"(?i)(((r34|rule\s?34).*monika)|(post \d+:[\w ]+monika)|(.*monika.*(r34|rule34)))"],
             rules={"skip alert": None, "notif-group": "Window Reactions"},
             show_in_idle=True
         ),

--- a/Monika After Story/game/script-windowreacts.rpy
+++ b/Monika After Story/game/script-windowreacts.rpy
@@ -219,7 +219,7 @@ label mas_wrs_r34m:
                 else:
                     exp_to_force = "2tssdlc"
 
-            mas_moni_idle_disp.force_by_code(exp_to_force)
+            mas_moni_idle_disp.force_by_code(exp_to_force, duration=5)
     return
 
 init 5 python:

--- a/Monika After Story/game/script-windowreacts.rpy
+++ b/Monika After Story/game/script-windowreacts.rpy
@@ -184,7 +184,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_r34m",
-            category=["((r34|rule34).+monika)|(post[\d\w:_]+monika)"],
+            category=["((r34|rule34).*monika)|(post\d+:\w+monika)|(\w*monika[\w?():]*(r34|rule34))"],
             rules={"skip alert": None, "notif-group": "Window Reactions"},
             show_in_idle=True
         ),

--- a/Monika After Story/game/script-windowreacts.rpy
+++ b/Monika After Story/game/script-windowreacts.rpy
@@ -184,7 +184,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_r34m",
-            category=[r"(?i)(((r34|rule\s?34).*monika)|(post \d+:[\w ]+monika)|(.*monika.*(r34|rule34)))"],
+            category=[r"(?i)(((r34|rule\s?34).*monika)|(post \d+:[\w\s]+monika)|(monika.*(r34|rule\s?34)))"],
             rules={"skip alert": None, "notif-group": "Window Reactions"},
             show_in_idle=True
         ),

--- a/Monika After Story/game/script-windowreacts.rpy
+++ b/Monika After Story/game/script-windowreacts.rpy
@@ -197,10 +197,10 @@ label mas_wrs_r34m:
 
         choice = random.randint(1,10)
 
-        if choice == 1:
+        if choice == 1 and mas_isMoniNormal(higher=True):
             queueEvent('monika_nsfw')
 
-        elif choice == 2:
+        elif choice == 2 and mas_isMoniAff(higher=True):
             queueEvent('monika_pleasure')
 
         else:

--- a/Monika After Story/game/script-windowreacts.rpy
+++ b/Monika After Story/game/script-windowreacts.rpy
@@ -184,7 +184,7 @@ init 5 python:
         Event(
             persistent._mas_windowreacts_database,
             eventlabel="mas_wrs_r34m",
-            category=[r"(?i)(((r34|rule\s?34).*monika)|(post \d+:[\w ]+monika)|([\w ]*monika[\w?(): ]*(r34|rule34)))"],
+            category=[r"(?i)(((r34|rule\s?34).*monika)|(post \d+:[\w ]+monika)|([[\w \]\-()]*monika[\w?()\-: ]*(r34|rule34)))"],
             rules={"skip alert": None, "notif-group": "Window Reactions"},
             show_in_idle=True
         ),

--- a/Monika After Story/game/zz_windowutils.rpy
+++ b/Monika After Story/game/zz_windowutils.rpy
@@ -697,6 +697,7 @@ init python:
         for ev_label, ev in mas_windowreacts.windowreact_db.iteritems():
             if (
                 Event._filterEvent(ev, unlocked=True, aff=store.mas_curr_affection)
+                and ev.checkConditional()
                 and mas_isInActiveWindow(ev.category[0], active_window_handle)
                 and ((not store.mas_globals.in_idle_mode) or (store.mas_globals.in_idle_mode and ev.show_in_idle))
                 and mas_notifsEnabledForGroup(ev.rules.get("notif-group"))

--- a/Monika After Story/game/zz_windowutils.rpy
+++ b/Monika After Story/game/zz_windowutils.rpy
@@ -261,8 +261,7 @@ init python in mas_windowutils:
 
         ASSUMES: OS IS WINDOWS (renpy.windows)
         """
-        window_handle = GetWindowText(GetForegroundWindow())
-        return window_handle
+        return unicode(GetWindowText(GetForegroundWindow()))
 
     def _getActiveWindowHandle_Linux():
         """

--- a/Monika After Story/game/zz_windowutils.rpy
+++ b/Monika After Story/game/zz_windowutils.rpy
@@ -243,7 +243,7 @@ init python in mas_windowutils:
             return None
 
     #Next, the active window handle getters
-    def _getActiveWindowHandle_Windows(friendly):
+    def _getActiveWindowHandle_Windows():
         """
         Funtion to get the active window on Windows systems
 
@@ -505,6 +505,42 @@ init python in mas_windowutils:
         cur_x, cur_y = getMousePos()
 
         return cur_y > bottom
+
+    def getMousePosRelative():
+        """
+        Gets the mouse position relative to the MAS window.
+        Returned as a set of coordinates (0, 0) being within the MAS window, (1, 0) being to the left, (0, 1) being above, etc.
+
+        OUT:
+            Tuple representing the location of the mouse relative to the MAS window in terms of coordinates
+        """
+        pos_tuple = getMASWindowPos()
+
+        if pos_tuple is None:
+            return (0, 0)
+
+        left, top, right, bottom = pos_tuple
+
+        curr_x, curr_y = getMousePos()
+
+        half_mas_window_x = (right - left)/2
+        half_mas_window_y = (bottom - top)/2
+
+        mid_mas_window_x = left + half_mas_window_x
+        mid_mas_window_y = top + half_mas_window_y
+
+        mas_window_to_cursor_x_comp = curr_x - mid_mas_window_x
+        mas_window_to_cursor_y_comp = curr_y - mid_mas_window_y
+
+        #Divide to handle the middle case
+        mas_window_to_cursor_x_comp = int(float(mas_window_to_cursor_x_comp)/half_mas_window_x)
+        mas_window_to_cursor_y_comp = -int(float(mas_window_to_cursor_y_comp)/half_mas_window_y)
+
+        #Now return the unit vector direction
+        return (
+            mas_window_to_cursor_x_comp/abs(mas_window_to_cursor_x_comp) if mas_window_to_cursor_x_comp else 0,
+            mas_window_to_cursor_y_comp/abs(mas_window_to_cursor_y_comp) if mas_window_to_cursor_y_comp else 0
+        )
 
     #Fallback functions because Mac
     def return_true():

--- a/Monika After Story/game/zz_windowutils.rpy
+++ b/Monika After Story/game/zz_windowutils.rpy
@@ -722,7 +722,7 @@ init python:
         for ev_label, ev in mas_windowreacts.windowreact_db.iteritems():
             if (
                 Event._filterEvent(ev, unlocked=True, aff=store.mas_curr_affection)
-                and mas_isInActiveWindow(mas_getEVLPropValue(ev_label, "category", [""])[0], active_window_handle)
+                and mas_isInActiveWindow(ev.category[0], active_window_handle)
                 and ((not store.mas_globals.in_idle_mode) or (store.mas_globals.in_idle_mode and ev.show_in_idle))
                 and mas_notifsEnabledForGroup(ev.rules.get("notif-group"))
             ):

--- a/Monika After Story/game/zz_windowutils.rpy
+++ b/Monika After Story/game/zz_windowutils.rpy
@@ -408,104 +408,6 @@ init python in mas_windowutils:
             )
         return None
 
-    def isCursorInMASWindow():
-        """
-        Checks if the cursor is within the MAS window
-
-        OUT:
-            True if cursor is within the mas window (within x/y), False otherwise
-            Also returns True if we cannot get window position
-        """
-        pos_tuple = getMASWindowPos()
-
-        if pos_tuple is None:
-            return True
-
-        left, top, right, bottom = pos_tuple
-
-        cur_x, cur_y = getMousePos()
-
-        if not (left <= cur_x <= right):
-            return False
-
-        return (top <= cur_y <= bottom)
-
-    def isCursorLeftOfMASWindow():
-        """
-        Checks if the cursor is to the left of the MAS window (must be explicitly to the left of the left window bound)
-
-        OUT:
-            True if cursor is to the left of the window, False otherwise
-            Also returns False if we cannot get window position
-        """
-        pos_tuple = getMASWindowPos()
-
-        if pos_tuple is None:
-            return False
-
-        left, top, right, bottom = pos_tuple
-
-        cur_x, cur_y = getMousePos()
-
-        return cur_x < left
-
-    def isCursorRightOfMASWindow():
-        """
-        Checks if the cursor is to the right of the MAS window (must be explicitly to the right of the right window bound)
-
-        OUT:
-            True if cursor is to the right of the window, False otherwise
-            Also returns False if we cannot get window position
-        """
-        pos_tuple = getMASWindowPos()
-
-        if pos_tuple is None:
-            return False
-
-        left, top, right, bottom = pos_tuple
-
-        cur_x, cur_y = getMousePos()
-
-        return cur_x > right
-
-    def isCursorAboveMASWindow():
-        """
-        Checks if the cursor is above the MAS window (must be explicitly above the window bound)
-
-        OUT:
-            True if cursor is above the window, False otherwise
-            False as well if we're unable to get a window position
-        """
-        pos_tuple = getMASWindowPos()
-
-        if pos_tuple is None:
-            return False
-
-        left, top, right, bottom = pos_tuple
-
-        cur_x, cur_y = getMousePos()
-
-        return cur_y < top
-
-    def isCursorBelowMASWindow():
-        """
-        Checks if the cursor is above the MAS window (must be explicitly above the window bound)
-
-        OUT:
-            True if cursor is above the window, False otherwise
-            False as well if we're unable to get a window position
-        """
-        pos_tuple = getMASWindowPos()
-
-        if pos_tuple is None:
-            return False
-
-        left, top, right, bottom = pos_tuple
-
-        cur_x, cur_y = getMousePos()
-
-        return cur_y > bottom
-
     def getMousePosRelative():
         """
         Gets the mouse position relative to the MAS window.
@@ -541,6 +443,56 @@ init python in mas_windowutils:
             mas_window_to_cursor_x_comp/abs(mas_window_to_cursor_x_comp) if mas_window_to_cursor_x_comp else 0,
             mas_window_to_cursor_y_comp/abs(mas_window_to_cursor_y_comp) if mas_window_to_cursor_y_comp else 0
         )
+
+    def isCursorInMASWindow():
+        """
+        Checks if the cursor is within the MAS window
+
+        OUT:
+            True if cursor is within the mas window (within x/y), False otherwise
+            Also returns True if we cannot get window position
+        """
+        return getMousePosRelative() == (0, 0)
+
+    def isCursorLeftOfMASWindow():
+        """
+        Checks if the cursor is to the left of the MAS window (must be explicitly to the left of the left window bound)
+
+        OUT:
+            True if cursor is to the left of the window, False otherwise
+            Also returns False if we cannot get window position
+        """
+        return getMousePosRelative()[0] == -1
+
+    def isCursorRightOfMASWindow():
+        """
+        Checks if the cursor is to the right of the MAS window (must be explicitly to the right of the right window bound)
+
+        OUT:
+            True if cursor is to the right of the window, False otherwise
+            Also returns False if we cannot get window position
+        """
+        return getMousePosRelative()[0] == 1
+
+    def isCursorAboveMASWindow():
+        """
+        Checks if the cursor is above the MAS window (must be explicitly above the window bound)
+
+        OUT:
+            True if cursor is above the window, False otherwise
+            False as well if we're unable to get a window position
+        """
+        return getMousePosRelative()[1] == 1
+
+    def isCursorBelowMASWindow():
+        """
+        Checks if the cursor is above the MAS window (must be explicitly above the window bound)
+
+        OUT:
+            True if cursor is above the window, False otherwise
+            False as well if we're unable to get a window position
+        """
+        return getMousePosRelative()[1] == -1
 
     #Fallback functions because Mac
     def return_true():

--- a/Monika After Story/game/zz_windowutils.rpy
+++ b/Monika After Story/game/zz_windowutils.rpy
@@ -247,26 +247,17 @@ init python in mas_windowutils:
         """
         Funtion to get the active window on Windows systems
 
-        IN:
-            friendly - Whether or not we want the active window handle in a usable format
-
         OUT:
             string representing the active window handle
 
         ASSUMES: OS IS WINDOWS (renpy.windows)
         """
         window_handle = GetWindowText(GetForegroundWindow())
-        if friendly:
-            return window_handle
-        else:
-            return window_handle.replace(" ","")
+        return window_handle
 
-    def _getActiveWindowHandle_Linux(friendly):
+    def _getActiveWindowHandle_Linux():
         """
         Funtion to get the active window on Linux systems
-
-        IN:
-            friendly - Whether or not we want the active window handle in a usable format
 
         OUT:
             string representing the active window handle
@@ -285,11 +276,7 @@ init python in mas_windowutils:
 
             if active_winname_prop is not None:
                 active_winname = unicode(active_winname_prop.value)
-                return (
-                    active_winname.replace("\n", "")
-                    if friendly
-                    else active_winname.replace(" ", "").replace("\n", "")
-                )
+                return active_winname.replace("\n", "")
 
             else:
                 return ""
@@ -297,12 +284,9 @@ init python in mas_windowutils:
         except BadWindow:
             return ""
 
-    def _getActiveWindow_OSX(friendly):
+    def _getActiveWindowHandle_OSX():
         """
         Gets the active window on macOS
-
-        IN:
-            friendly - Whether or not we want the output in a usable state
 
         NOTE: This currently just returns an empty string, this is because we do not have active window detection
         for MacOS
@@ -552,7 +536,7 @@ init python in mas_windowutils:
             #We'll store an internal ref of the mas window here
             MAS_WINDOW = __getMASWindowLinux()
         else:
-            _window_get = _getActiveWindow_OSX
+            _window_get = _getActiveWindowHandle_OSX
             _tryShowNotif = _tryShowNotification_OSX
 
             #Because we have no method of testing on Mac, we'll use the dummy function for these
@@ -600,12 +584,9 @@ init python:
             and (persistent._mas_windowreacts_windowreacts_enabled or persistent._mas_enable_notifications)
         )
 
-    def mas_getActiveWindowHandle(friendly=False):
+    def mas_getActiveWindowHandle():
         """
         Gets the active window name
-        IN:
-            friendly: whether or not the active window name is returned in a state usable by the user
-                (Default: False)
 
         OUT:
             The active window handle if found. If it is not possible to get, we return an empty string
@@ -613,7 +594,7 @@ init python:
         NOTE: THIS SHOULD NEVER RETURN NONE
         """
         if mas_windowreacts.can_show_notifs and mas_canCheckActiveWindow():
-            return store.mas_windowutils._window_get(friendly)
+            return store.mas_windowutils._window_get()
         return ""
 
         #TODO: Remove this alias at some point
@@ -676,7 +657,7 @@ init python:
         Checks if MAS is the focused window
         """
         #TODO: Mac vers (if possible)
-        return store.mas_windowreacts.can_show_notifs and mas_getActiveWindowHandle(True) == config.window_title
+        return store.mas_windowreacts.can_show_notifs and mas_getActiveWindowHandle() == config.window_title
 
     def mas_isInActiveWindow(regexp, active_window_handle=None):
         """
@@ -699,7 +680,7 @@ init python:
         if active_window_handle is None:
             active_window_handle = mas_getActiveWindowHandle()
 
-        return bool(re.findall(regexp, active_window_handle, re.IGNORECASE))
+        return bool(re.findall(regexp, active_window_handle))
 
     def mas_clearNotifs():
         """

--- a/Monika After Story/game/zz_windowutils.rpy
+++ b/Monika After Story/game/zz_windowutils.rpy
@@ -243,7 +243,7 @@ init python in mas_windowutils:
             return None
 
     #Next, the active window handle getters
-    def _getActiveWindow_Windows(friendly):
+    def _getActiveWindowHandle_Windows(friendly):
         """
         Funtion to get the active window on Windows systems
 
@@ -259,9 +259,9 @@ init python in mas_windowutils:
         if friendly:
             return window_handle
         else:
-            return window_handle.lower().replace(" ","")
+            return window_handle.replace(" ","")
 
-    def _getActiveWindow_Linux(friendly):
+    def _getActiveWindowHandle_Linux(friendly):
         """
         Funtion to get the active window on Linux systems
 
@@ -288,7 +288,7 @@ init python in mas_windowutils:
                 return (
                     active_winname.replace("\n", "")
                     if friendly
-                    else active_winname.lower().replace(" ", "").replace("\n", "")
+                    else active_winname.replace(" ", "").replace("\n", "")
                 )
 
             else:
@@ -537,14 +537,14 @@ init python in mas_windowutils:
 
     #Finally, we set vars accordingly to use the appropriate functions without needing to run constant runtime checks
     if renpy.windows:
-        _window_get = _getActiveWindow_Windows
+        _window_get = _getActiveWindowHandle_Windows
         _tryShowNotif = _tryShowNotification_Windows
         getMASWindowPos = _getMASWindowPos_Windows
         getMousePos = _getAbsoluteMousePos_Windows
 
     else:
         if renpy.linux:
-            _window_get = _getActiveWindow_Linux
+            _window_get = _getActiveWindowHandle_Linux
             _tryShowNotif = _tryShowNotification_Linux
             getMASWindowPos = _getMASWindowPos_Linux
             getMousePos = _getAbsoluteMousePos_Linux
@@ -696,7 +696,7 @@ init python:
         if active_window_handle is None:
             active_window_handle = mas_getActiveWindow()
 
-        return bool(re.findall(regexp, active_window_handle))
+        return bool(re.findall(regexp, active_window_handle, re.IGNORECASE))
 
     def mas_clearNotifs():
         """

--- a/Monika After Story/game/zz_windowutils.rpy
+++ b/Monika After Story/game/zz_windowutils.rpy
@@ -600,7 +600,7 @@ init python:
             and (persistent._mas_windowreacts_windowreacts_enabled or persistent._mas_enable_notifications)
         )
 
-    def mas_getActiveWindow(friendly=False):
+    def mas_getActiveWindowHandle(friendly=False):
         """
         Gets the active window name
         IN:
@@ -615,6 +615,9 @@ init python:
         if mas_windowreacts.can_show_notifs and mas_canCheckActiveWindow():
             return store.mas_windowutils._window_get(friendly)
         return ""
+
+        #TODO: Remove this alias at some point
+        mas_getActiveWindow = mas_getActiveWindowHandle
 
     def mas_display_notif(title, body, group=None, skip_checks=False):
         """
@@ -665,7 +668,7 @@ init python:
             return notif_success
         return False
 
-    #Alias for depreciation
+    #TODO: Remove this at some point | Alias for depreciation
     display_notif = mas_display_notif
 
     def mas_isFocused():
@@ -673,7 +676,7 @@ init python:
         Checks if MAS is the focused window
         """
         #TODO: Mac vers (if possible)
-        return store.mas_windowreacts.can_show_notifs and mas_getActiveWindow(True) == config.window_title
+        return store.mas_windowreacts.can_show_notifs and mas_getActiveWindowHandle(True) == config.window_title
 
     def mas_isInActiveWindow(regexp, active_window_handle=None):
         """
@@ -694,7 +697,7 @@ init python:
 
         #Otherwise, let's get the active window
         if active_window_handle is None:
-            active_window_handle = mas_getActiveWindow()
+            active_window_handle = mas_getActiveWindowHandle()
 
         return bool(re.findall(regexp, active_window_handle, re.IGNORECASE))
 
@@ -715,7 +718,7 @@ init python:
         if not persistent._mas_windowreacts_windowreacts_enabled or not store.mas_windowreacts.can_show_notifs:
             return
 
-        active_window_handle = mas_getActiveWindow()
+        active_window_handle = mas_getActiveWindowHandle()
         for ev_label, ev in mas_windowreacts.windowreact_db.iteritems():
             if (
                 Event._filterEvent(ev, unlocked=True, aff=store.mas_curr_affection)


### PR DESCRIPTION
Windowreacts now use regexp's to check the active window handle content

## Changes:
- `mas_getActiveWindow` has been renamed to `mas_getActiveWindowHandle` to be more specific to what it does
- `_getActiveWindow_Linux` renamed -> `_mas_getActiveWindowHandle_Linux`
- `_getActiveWindow_Windows` renamed -> `_mas_getActiveWindowHandle_Window`
- The `inclusive` rule for checking active window keys has been removed as this can be entirely handled by regex much better
- Windowreacts no longer uses `.lower()`, (#6802). Instead, this must be manually handled using the `(?i)` flag
- `mas_wrs_r34m` actually checks affection for the exp response. It also makes use of the new idle disp. Additionally, it works for more than just one site now.
- WRS Dev topics have been updated accordingly.

## Testing:
- Verify all windowreacts still work
- Verify r34 reaction has appropriate reactions for aff levels (just two levels, below enam, and enam+)
- Verify no crashes
- Verify other language chars work properly now (again ref to #6802)