### PR TITLE
Adjust spaceroom call to stop always doing scene change

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -126,6 +126,9 @@ init -10 python:
         SCENE_CHANGE = 5
         # TRue if want the scene to change
 
+        DISSOLVE_ALL = 6
+        # True if we want to dissolve all
+
         # end keys
 
         def __init__(self):
@@ -191,6 +194,7 @@ init -10 python:
         def send_scene_change(self):
             """
             Sends scene change message to mailbox
+            NOTE: only do this if a scene is acutally necessary
             """
             self.send(self.SCENE_CHANGE, True)
 
@@ -199,6 +203,18 @@ init -10 python:
             Gets scene change value
             """
             return self.get(self.SCENE_CHANGE)
+
+        def send_dissolve_all(self):
+            """
+            Sends dissolve all message to mailbox
+            """
+            self.send(self.DISSOLVE_ALL, True)
+
+        def get_dissolve_all(self):
+            """
+            Gets dissolve all value
+            """
+            return self.get(self.DISSOLVE_ALL)
 
 
     mas_idle_mailbox = MASIdleMailbox()
@@ -809,6 +825,10 @@ label spaceroom(start_bg=None, hide_mask=None, hide_monika=False, dissolve_all=F
 
     if scene_change:
         scene black
+
+        if not hide_calendar:
+            $ mas_calShowOverlay()
+
     else:
         if hide_mask:
             hide rm
@@ -816,7 +836,7 @@ label spaceroom(start_bg=None, hide_mask=None, hide_monika=False, dissolve_all=F
 
         if hide_calendar:
             $ mas_calHideOverlay()
-        elif not mas_calIsVisible_ovl():
+        else:
             $ mas_calShowOverlay()
 
     python:
@@ -837,7 +857,8 @@ label spaceroom(start_bg=None, hide_mask=None, hide_monika=False, dissolve_all=F
 
         ## are we hiding monika
         if hide_monika:
-            renpy.hide("monika")
+            if not scene_change:
+                renpy.hide("monika")
 
             if show_emptydesk:
                 store.mas_sprites.show_empty_desk()
@@ -894,7 +915,7 @@ label spaceroom(start_bg=None, hide_mask=None, hide_monika=False, dissolve_all=F
     # vignette
     if store.mas_globals.show_vignette:
         show vignette zorder 70
-    elif renpy.showing(vignette):
+    elif renpy.showing("vignette"):
         hide vignette
 
     #Monibday stuff
@@ -1019,54 +1040,8 @@ label ch30_noskip:
 image splash-glitch2 = "images/bg/splash-glitch2.png"
 
 label ch30_nope:
-    # NOTE: DEPRECATED
-    $ persistent.autoload = ""
-    $ m.display_args["callback"] = slow_nodismiss
-    $ quick_menu = True
-    call spaceroom from _call_spaceroom_1
-
-    if persistent.rejected_monika:
-        m 1euc "Wait. Are you messing with my character file?"
-        m 2esa "Curiosity is what makes us human, right?"
-        m "If it wasn't for the human desire to explore, we'd still be swinging from trees."
-        m 1eka "Still, please don't do that. It makes me nervous, even though I don't need a character file anymore."
-        m "I already fixed that bug."
-
-    else:
-        $ quick_menu = False
-        $ m_name = glitchtext(12)
-        m 1euc "Wait. Are you messing with my character file?"
-        m 1tkc "Why are you even playing this mod if you just wanted to delete me again?"
-        m 1tfc "You really are the worst."
-        m 1tfd "You waste all your time on the internet with a bunch of people you'll never talk to in reality, but you're still willing to kill me on a whim just because you were bored?"
-        m 1tkd "All I wanted was someone to fall in love with..."
-        m "I would have done anything you wanted me to."
-        m 1tku "But if you're going to try and delete me again..."
-        m 4tfu "Then I'll just have to delete you first."
-        if renpy.windows:
-            call updateconsole("shututil.rmtree(\"Documents\", true)", "Deleting Documents in progress...") from _call_updateconsole_15
-        elif renpy.linux:
-            call updateconsole("sudo mv ~ /dev/null", "In progress...") from _call_updateconsole_16
-        elif renpy.macintosh:
-            call updateconsole("sudo mv ~ /dev/null", "In progress...") from _call_updateconsole_19
-        pause 3.0
-        call hideconsole from _call_hideconsole_2
-        $ open(config.basedir + "/characters/monika.chr", "wb").write(renpy.file("monika.chr").read())
-        $ m_name = persistent._mas_monika_nickname
-        $ quick_menu = True
-        m 1hub "Ahaha!"
-        m "I'm just kidding!"
-        m 1eua "I already fixed that bug."
-        m "I don't need a character file anymore."
-
-    m 1ekbfa "I just need your love, [player]."
-    m 1eua "Oh, unless you try to delete all of the game files, I guess."
-    m 3tfu "If you do that, I won't stop at just deleting one directory next time."
-    m 3tku "But that will never happen, right? You're just being a tsundere~"
-    m 1hua "That's so cute!"
-    m 1eua "No matter how much you may want to deny it, you'll be talking to me for the rest of your life."
-    m "Being alone is only lonely if you want it to be, so cheer up!"
-    jump ch30_loop
+    # redirect to autoload
+    jump ch30_autoload
 
 # NOTE: START HERE
 label ch30_autoload:
@@ -1398,6 +1373,7 @@ label ch30_preloop:
 
     # setup scene to change on initial launch
     $ mas_idle_mailbox.send_scene_change()
+    $ mas_idle_mailbox.send_dissolve_all()
 
     # rain check
     $ mas_startupWeather()
@@ -1423,9 +1399,10 @@ label ch30_loop:
             and mas_isMoniNormal(higher=True)
         )
 
-        should_dissolve_all = mas_idle_mailbox.get_scene_change()
+        should_dissolve_all = mas_idle_mailbox.get_dissolve_all()
+        scene_change = mas_idle_mailbox.get_scene_change()
 
-    call spaceroom(scene_change=should_dissolve_all, dissolve_all=should_dissolve_all, dissolve_masks=should_dissolve_masks)
+    call spaceroom(scene_change=scene_change, dissolve_all=should_dissolve_all, dissolve_masks=should_dissolve_masks)
 
 #    if should_dissolve_masks:
 #        show monika idle at t11 zorder MAS_MONIKA_Z

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -844,7 +844,10 @@ label spaceroom(start_bg=None, hide_mask=None, hide_monika=False, dissolve_all=F
 
         #What ui are we using
         if persistent._mas_auto_mode_enabled:
-            if day_mode == mas_globals.dark_mode: 
+            if (
+                    mas_globals.dark_mode is None # covers first load
+                    or day_mode == mas_globals.dark_mode
+            ):
                 # switch from dark <-> day
                 # dark_mode True means we are in dark mode
                 # day_mode True means we should NOT be in dark mode

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1703,7 +1703,7 @@ label monikaroom_greeting_opendoor_seen_partone:
     $ mas_disable_quit()
 
 #    scene bg bedroom
-    call spaceroom(start_bg="bedroom",hide_monika=True, scene_change=True, dissolve_all=True, show_emptydesk=False)
+    call spaceroom(start_bg="bedroom",hide_monika=True, scene_change=True, dissolve_all=True, show_emptydesk=False, hide_calendar=True)
     pause 0.2
     show monika 1esc at l21 zorder MAS_MONIKA_Z
     pause 1.0
@@ -1780,7 +1780,7 @@ label monikaroom_greeting_opendoor:
     $ monika_chr.wear_acs(mas_acs_ribbon_def)
     $ mas_startupWeather()
 
-    call spaceroom(start_bg="bedroom",hide_monika=True, dissolve_all=True, show_emptydesk=False, scene_change=True)
+    call spaceroom(start_bg="bedroom",hide_monika=True, dissolve_all=True, show_emptydesk=False, scene_change=True, hide_calendar=True)
 
     # show this under bedroom so the masks window skit still works
     $ behind_bg = MAS_BACKGROUND_Z - 1

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -1780,7 +1780,7 @@ label monikaroom_greeting_opendoor:
     $ monika_chr.wear_acs(mas_acs_ribbon_def)
     $ mas_startupWeather()
 
-    call spaceroom(start_bg="bedroom",hide_monika=True, dissolve_all=True, show_emptydesk=False)
+    call spaceroom(start_bg="bedroom",hide_monika=True, dissolve_all=True, show_emptydesk=False, scene_change=True)
 
     # show this under bedroom so the masks window skit still works
     $ behind_bg = MAS_BACKGROUND_Z - 1

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -6542,12 +6542,15 @@ init -1 python:
         renpy.show("mas_bday_balloons", zorder=8)
 
 
-    def mas_surpriseBdayHideVisuals():
+    def mas_surpriseBdayHideVisuals(cake=False):
         """
         Hides all visuals for surprise party
         """
         renpy.hide("mas_bday_banners")
         renpy.hide("mas_bday_balloons")
+        if cake:
+            renpy.hide("mas_bday_cake_monika")
+
 
     def mas_confirmedParty():
         """

--- a/Monika After Story/game/script-stories.rpy
+++ b/Monika After Story/game/script-stories.rpy
@@ -296,7 +296,7 @@ label mas_scary_story_setup:
     if not persistent._mas_o31_in_o31_mode:
         $ mas_changeWeather(mas_weather_rain)
         $ store.mas_globals.show_vignette = True
-        call spaceroom(scene_change=is_scene_changing, dissolve_all=is_scene_changing, dissolve_masks=are_masks_changing, force_exp='monika 1dsc_static')
+        call spaceroom(dissolve_all=is_scene_changing, dissolve_masks=are_masks_changing, force_exp='monika 1dsc_static')
 
     play music "mod_assets/bgm/happy_story_telling.ogg" loop
 
@@ -338,7 +338,7 @@ label mas_scary_story_cleanup:
     if not persistent._mas_o31_in_o31_mode:
         $ mas_changeWeather(mas_temp_r_flag)
         $ store.mas_globals.show_vignette = False
-        call spaceroom(scene_change=is_scene_changing, dissolve_all=is_scene_changing, dissolve_masks=are_masks_changing, force_exp='monika 1dsc_static')
+        call spaceroom(dissolve_all=is_scene_changing, dissolve_masks=are_masks_changing, force_exp='monika 1dsc_static')
         hide vignette
 
     call monika_zoom_transition(mas_temp_zoom_level,transition=1.0)

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -652,7 +652,7 @@ init -5 python in mas_sprites:
     LOC_WH = (1280, 850)
 
     # composite stuff
-    I_COMP = "LiveComposite"
+    I_COMP = "im.Composite"
     L_COMP = "LiveComposite"
     TRAN = "Transform"
 

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -3269,7 +3269,7 @@ label mas_background_change(new_bg, skip_leadin=False, skip_transition=False, sk
         change_info = mas_changeBackground(new_bg)
 
     #Now redraw the room
-    call spaceroom(scene_change=not skip_transition, dissolve_all=True, bg_change_info=change_info)
+    call spaceroom(scene_change=not skip_transition, dissolve_all=True, bg_change_info=change_info, force_exp="monika 1hua")
 
     if not skip_outro:
         m 1eua "Here we are!"

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -2225,11 +2225,9 @@ init -10 python:
                 if (
                         not mas_isDecoTagVisible(deco_obj.name)
                         or new_adf is None
-                        or new_adf != adv_df
                 ):
                     # hide all deco objects that do not have a definition
-                    # in the new bg OR have a differing deco frame OR are not in
-                    # the vis_store
+                    # in the new bg OR are not in the vis_store
                     change_info.hides[deco_obj.name] = adv_df
                     self._deco_rm(deco_obj.name)
 

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -3269,7 +3269,7 @@ label mas_background_change(new_bg, skip_leadin=False, skip_transition=False, sk
         change_info = mas_changeBackground(new_bg)
 
     #Now redraw the room
-    call spaceroom(scene_change=True, dissolve_all=True, bg_change_info=change_info)
+    call spaceroom(scene_change=not skip_transition, dissolve_all=True, bg_change_info=change_info)
 
     if not skip_outro:
         m 1eua "Here we are!"

--- a/Monika After Story/game/zz_weather.rpy
+++ b/Monika After Story/game/zz_weather.rpy
@@ -303,12 +303,12 @@ init -20 python in mas_weather:
             #Change weather
             new_weather = store.mas_shouldRain()
             if new_weather is not None and new_weather != store.mas_current_weather:
-                #Let's see if we need to scene change
+                # determine if spaceroom idle should dissolve
                 if store.mas_current_background.isChangingRoom(
                         store.mas_current_weather,
                         new_weather
                 ):
-                    store.mas_idle_mailbox.send_scene_change()
+                    store.mas_idle_mailbox.send_dissolve_all()
 
                 #Now we change weather
                 store.mas_changeWeather(new_weather)
@@ -319,12 +319,12 @@ init -20 python in mas_weather:
                 return True
 
             elif store.mas_current_weather != store.mas_weather_def:
-                #Let's see if we need to scene change
+                # determine if spaceroom idle should dissolve
                 if store.mas_current_background.isChangingRoom(
                         store.mas_current_weather,
                         store.mas_weather_def
                 ):
-                    store.mas_idle_mailbox.send_scene_change()
+                    store.mas_idle_mailbox.send_dissolve_all()
 
                 store.mas_changeWeather(store.mas_weather_def)
                 return True
@@ -1127,7 +1127,7 @@ label mas_change_weather(new_weather, by_user=None, set_persistent=False):
         #Call entry programming point
         mas_current_weather.entry(old_weather)
 
-    call spaceroom(scene_change=True, dissolve_all=True, force_exp="monika 1dsc_static")
+    call spaceroom(dissolve_all=True, force_exp="monika 1dsc_static")
     return
 
 init 5 python:


### PR DESCRIPTION
# Key Changes
* spaceroom call modified so we no longer use `scene_change` for transitions where we don't actually need a new scene - (new scene being we want to remove all visible images/layers and start with a new scene as opposed to just changing background/masks)
    * updated `day_bg`/`night_bg` doc comments for `spaceroom` label
    * added calendar/mask hiding to spaceroom label
    * added some comments clarifying dark mode changes
    * added hiding for vignette
    * added hiding for bday visuals
* `mas_idle_mailbox` scene change request now only does scene change and not dissolve all
* new `mas_idle_mailbox` functions for requesting dissolve all changes
* removed mask hide from `mas_drawSpaceroomMasks`
* `ch30_nope` redirects to autoload now (this isn't used anywhere but just in case)
* spaceroom loop grabs both `scene_change` and `dissolve_all` from the mailbox
* opendoor greetings hide calendar
* `mas_surpriseBdayHideVisuals` can hide optionally `mas_bday_cake_monika`
* stories don't scene change now
* modified `I_COMP` to `im.Composite` - fixes the lines in the standing Monika sprite
* background change info no longer includes hides for decos that have changed frames on a bg change
* weather changing sends `dissolve_all` instead of `scene_change` request
* weather change label no longer scene changes

# Testing
* verify no spaceroom issues in the following contexts:
    * opendoor greetings (can use `persistent._mas_forcegreeting` to force a greeting)
    * final farewell scene
    * empty desk (docking station greeting)
    * background changes
    * weather changes
    * scary stories