### PR TITLE
Jsonified Sprite Maps

### DIFF
--- a/Monika After Story/game/mod_assets/sprite_map.json
+++ b/Monika After Story/game/mod_assets/sprite_map.json
@@ -1,0 +1,94 @@
+{
+    "eyebrows": {
+        "f": "furrowed",
+        "u": "up",
+        "k": "knit",
+        "s": "mid",
+        "t": "think"
+    },
+    "eyes": {
+        "e": "normal",
+        "w": "wide",
+        "s": "sparkle",
+        "t": "smug",
+        "c": "crazy",
+        "r": "right",
+        "l": "left",
+        "h": "closedhappy",
+        "d": "closedsad",
+        "k": "winkleft",
+        "n": "winkright",
+        "f": "soft",
+        "m": "smugleft",
+        "g": "smugright"
+    },
+    "mouth": {
+        "a": "smile",
+        "b": "big",
+        "c": "smirk",
+        "d": "small",
+        "o": "gasp",
+        "u": "smug",
+        "w": "wide",
+        "x": "angry",
+        "p": "pout",
+        "t": "triangle"
+    },
+    "arms": {
+        "1": "steepling",
+        "2": "crossed",
+        "3": "restleftpointright",
+        "4": "pointright",
+        "5": ["def", "def"],
+        "6": "down",
+        "7": "downleftpointright"
+    },
+    "head": {
+        "eua": "a",
+        "eub": "b",
+        "euc": "c",
+        "eud": "d",
+        "eka": "e",
+        "ekc": "f",
+        "ekd": "g",
+        "esc": "h",
+        "esd": "i",
+        "hua": "j",
+        "hub": "k",
+        "hkb": "l",
+        "lka": "m",
+        "lkb": "n",
+        "lkc": "o",
+        "lkd": "p",
+        "dsc": "q",
+        "dsd": "r"
+    },
+    "sides": {
+        "1": ["1l", "1r"],
+        "2": ["1l", "2r"],
+        "3": ["2l", "2r"],
+        "4": ["2l", "2r"],
+        "5": ["", ""],
+        "6": ["1l", "1r"],
+        "7": ["1l", "2r"]
+    },
+    "single": {
+        "a": "3a",
+        "u": "3a"
+    },
+    "blush": {
+        "bl": "lines",
+        "bs": "shade",
+        "bf": "full"
+    },
+    "tears": {
+        "ts": "streaming",
+        "td": "dried",
+        "tp": "pooled",
+        "tu": "up"
+    },
+    "sweat": {
+        "sdl": "def",
+        "sdr": "right"
+    }
+}

--- a/Monika After Story/game/sprite-decoder.rpy
+++ b/Monika After Story/game/sprite-decoder.rpy
@@ -50,6 +50,12 @@ init python in mas_sprite_decoder:
         TEAR_MAP = jobj["tears"]
         SWEAT_MAP = jobj["sweat"]
 
+        #Since tuples aren't supported in json, we need to do some conversion here
+        ARM_MAP["5"] = tuple(ARM_MAP["5"])
+
+        for side_key, side_list in SIDES_MAP.iteritems():
+            SIDES_MAP[side_key] = tuple(side_list)
+
     def __process_blush(spcode, index, export_dict, *prefixes):
         """
         Processes a blush off the given sprite code at the given index

--- a/Monika After Story/game/sprite-decoder.rpy
+++ b/Monika After Story/game/sprite-decoder.rpy
@@ -1,111 +1,54 @@
 #Runtime code equivalent of our spritemaker tool
 init python in mas_sprite_decoder:
+    import json
     import store
 
-    EYEBROW_MAP = {
-        "f": "furrowed",
-        "u": "up",
-        "k": "knit",
-        "s": "mid",
-        "t": "think",
-    }
-
-    EYE_MAP = {
-        "e": "normal",
-        "w": "wide",
-        "s": "sparkle",
-        "t": "smug",
-        "c": "crazy",
-        "r": "right",
-        "l": "left",
-        "h": "closedhappy",
-        "d": "closedsad",
-        "k": "winkleft",
-        "n": "winkright",
-        "f": "soft",
-        "m": "smugleft",
-        "g": "smugright",
-    }
-
-    MOUTH_MAP = {
-        "a": "smile",
-        "b": "big",
-        "c": "smirk",
-        "d": "small",
-        "o": "gasp",
-        "u": "smug",
-        "w": "wide",
-        "x": "angry",
-        "p": "pout",
-        "t": "triangle",
-    }
-
-    ARM_MAP = {
-        "1": "steepling",
-        "2": "crossed",
-        "3": "restleftpointright",
-        "4": "pointright",
-        "5": ("def", "def"),
-        "6": "down",
-        "7": "downleftpointright",
-    }
-
+    EYEBROW_MAP = dict()
+    EYE_MAP = dict()
+    MOUTH_MAP = dict()
+    ARM_MAP = dict()
     #Standing sprite parts
-    HEAD_MAP = {
-        # exact eye - eyebrow - mouth match
-        "eua": "a",
-        "eub": "b",
-        "euc": "c",
-        "eud": "d",
-        "eka": "e",
-        "ekc": "f",
-        "ekd": "g",
-        "esc": "h",
-        "esd": "i",
-        "hua": "j",
-        "hub": "k",
-        "hkb": "l", #sdl
-        "lka": "m", #sdl
-        "lkb": "n", #sdl
-        "lkc": "o", #sdl
-        "lkd": "p", #sdl
-        "dsc": "q",
-        "dsd": "r",
-    }
-
-    SIDES_MAP = {
-        "1": ("1l", "1r"),
-        "2": ("1l", "2r"),
-        "3": ("2l", "2r"),
-        "4": ("2l", "2r"),
-        "5": ("", ""),
-        "6": ("1l", "1r"),
-        "7": ("1l", "2r"),
-    }
-
+    # exact eye - eyebrow - mouth match
+    # "hkb": "l", #sdl
+    # "lka": "m", #sdl
+    # "lkb": "n", #sdl
+    # "lkc": "o", #sdl
+    # "lkd": "p", #sdl
+    HEAD_MAP = dict()
+    SIDES_MAP = dict()
     #NOTE: Everything not present here is assumed 3b
-    SINGLE_MAP = {
-        "a": "3a",
-        "u": "3a",
-    }
+    SINGLE_MAP = dict()
+    BLUSH_MAP = dict()
+    TEAR_MAP = dict()
+    SWEAT_MAP = dict()
 
-    BLUSH_MAP = {
-        "bl": "lines",
-        "bs": "shade",
-        "bf": "full"
-    }
+    def __loadSpriteMapData():
+        """
+        Loads sprite map data from the sprite map json file
+        """
+        global EYEBROW_MAP, EYE_MAP, MOUTH_MAP, ARM_MAP, HEAD_MAP
+        global SIDES_MAP, SINGLE_MAP, BLUSH_MAP, TEAR_MAP, SWEAT_MAP
 
-    TEAR_MAP = {
-        "ts": "streaming",
-        "td": "dried",
-        "tp": "pooled",
-        "tu": "up",
-    }
+        jobj = None
 
-    SWEAT_MAP = {
-        "sdl": "def",
-        "sdr": "right"
-    }
+        with open(store.os.path.join(renpy.config.gamedir, "mod_assets", "sprite_map.json"), "r") as jsonfile:
+            jobj = json.load(jsonfile)
+
+        # is file json
+        if jobj is None:
+            store.mas_utils.writelog("[ERROR]: Failed to load sprite_map json.")
+            return
+
+        EYEBROW_MAP = jobj["eyebrows"]
+        EYE_MAP = jobj["eyes"]
+        MOUTH_MAP = jobj["mouth"]
+        ARM_MAP = jobj["arms"]
+        HEAD_MAP = jobj["head"]
+        SIDES_MAP = jobj["sides"]
+        SINGLE_MAP = jobj["single"]
+        BLUSH_MAP = jobj["blush"]
+        TEAR_MAP = jobj["tears"]
+        SWEAT_MAP = jobj["sweat"]
 
     def __process_blush(spcode, index, export_dict, *prefixes):
         """
@@ -228,7 +171,7 @@ init python in mas_sprite_decoder:
 
         #Checks passed. Let's add this
         export_dict["tears"] = tears
-        return True, 1
+        return (True, 1)
 
     PROCESS_MAP = {
         "b": __process_blush,
@@ -348,3 +291,5 @@ init python in mas_sprite_decoder:
         #Otherwise this is invalid
         except:
             return False
+
+    __loadSpriteMapData()

--- a/Monika After Story/game/sprite-decoder.rpy
+++ b/Monika After Story/game/sprite-decoder.rpy
@@ -36,7 +36,7 @@ init python in mas_sprite_decoder:
 
         # is file json
         if jobj is None:
-            store.mas_utils.writelog("[ERROR]: Failed to load sprite_map json.")
+            raise Exception("[ERROR]: Failed to load sprite_map json.")
             return
 
         EYEBROW_MAP = jobj["eyebrows"]

--- a/Monika After Story/game/sprite-decoder.rpy
+++ b/Monika After Story/game/sprite-decoder.rpy
@@ -22,6 +22,13 @@ init python in mas_sprite_decoder:
     TEAR_MAP = dict()
     SWEAT_MAP = dict()
 
+    class MASSpriteException(Exception):
+        def __init__(self, message):
+            self.message = message
+
+        def __str__(self):
+            return self.message
+
     def __loadSpriteMapData():
         """
         Loads sprite map data from the sprite map json file
@@ -31,30 +38,30 @@ init python in mas_sprite_decoder:
 
         jobj = None
 
-        with open(store.os.path.join(renpy.config.gamedir, "mod_assets", "sprite_map.json"), "r") as jsonfile:
-            jobj = json.load(jsonfile)
+        try:
+            with open(store.os.path.join(renpy.config.gamedir, "mod_assets", "sprite_map.json"), "r") as jsonfile:
+                jobj = json.load(jsonfile)
 
-        # is file json
-        if jobj is None:
-            raise Exception("[ERROR]: Failed to load sprite_map json.")
-            return
+            EYEBROW_MAP = jobj["eyebrows"]
+            EYE_MAP = jobj["eyes"]
+            MOUTH_MAP = jobj["mouth"]
+            ARM_MAP = jobj["arms"]
+            HEAD_MAP = jobj["head"]
+            SIDES_MAP = jobj["sides"]
+            SINGLE_MAP = jobj["single"]
+            BLUSH_MAP = jobj["blush"]
+            TEAR_MAP = jobj["tears"]
+            SWEAT_MAP = jobj["sweat"]
 
-        EYEBROW_MAP = jobj["eyebrows"]
-        EYE_MAP = jobj["eyes"]
-        MOUTH_MAP = jobj["mouth"]
-        ARM_MAP = jobj["arms"]
-        HEAD_MAP = jobj["head"]
-        SIDES_MAP = jobj["sides"]
-        SINGLE_MAP = jobj["single"]
-        BLUSH_MAP = jobj["blush"]
-        TEAR_MAP = jobj["tears"]
-        SWEAT_MAP = jobj["sweat"]
+            #Since tuples aren't supported in json, we need to do some conversion here
+            ARM_MAP["5"] = tuple(ARM_MAP["5"])
 
-        #Since tuples aren't supported in json, we need to do some conversion here
-        ARM_MAP["5"] = tuple(ARM_MAP["5"])
+            for side_key, side_list in SIDES_MAP.iteritems():
+                SIDES_MAP[side_key] = tuple(side_list)
 
-        for side_key, side_list in SIDES_MAP.iteritems():
-            SIDES_MAP[side_key] = tuple(side_list)
+        #I don't really like this but it's a cleaner way of bringing up this exception once instead of multiple times
+        except Exception as e:
+            raise MASSpriteException(repr(e) + "\n\nPLEASE REINSTALL MAS TO CORRECT THIS ERROR")
 
     def __process_blush(spcode, index, export_dict, *prefixes):
         """

--- a/tools/sprite.py
+++ b/tools/sprite.py
@@ -894,12 +894,9 @@ class StaticSprite(object):
         """
         jobj = None
 
+        #NOTE: this raises its own exceptions when it encounters issues
         with open(gamedir.REL_PATH_GAME + "mod_assets/sprite_map.json", "r") as jsonfile:
             jobj = json.load(jsonfile)
-
-        # is file json
-        if jobj is None:
-            raise Exception("[ERROR]: Failed to load sprite_map json.")
 
         StaticSprite._sprite_map["position"] = jobj["arms"]
         StaticSprite._sprite_map["eyebrows"] = jobj["eyebrows"]

--- a/tools/sprite.py
+++ b/tools/sprite.py
@@ -1,3 +1,5 @@
+import gamedir
+import json
 # definitions of sprite objects
 
 DRAW_MONIKA = "mas_drawmonika"
@@ -23,107 +25,25 @@ class StaticSprite(object):
             "6": False,
             "7": False,
         },
-        "position": {
-            "1": "steepling",
-            "2": "crossed",
-            "3": "restleftpointright",
-            "4": "pointright",
-            "5": ("def", "def"),
-            "6": "down",
-            "7": "downleftpointright",
-        },
-        "sides": {
-            "1": ("1l", "1r"),
-            "2": ("1l", "2r"),
-            "3": ("2l", "2r"),
-            "4": ("2l", "2r"),
-            "5": ("", ""),
-            "6": ("1l", "1r"),
-            "7": ("1l", "2r"),
-        },
-        "eyes": {
-            "e": "normal",
-            "w": "wide",
-            "s": "sparkle",
-            "t": "smug",
-            "c": "crazy",
-            "r": "right",
-            "l": "left",
-            "h": "closedhappy",
-            "d": "closedsad",
-            "k": "winkleft",
-            "n": "winkright",
-            "f": "soft",
-        },
-        "eyebrows": {
-            "f": "furrowed",
-            "u": "up",
-            "k": "knit",
-            "s": "mid",
-            "t": "think"
-        },
+        "position": dict(),
+        "sides": dict(),
+        "eyes": dict(),
+        "eyebrows": dict(),
         "nose": {
             "nd": "def"
         },
         "eyebags": { # NOTE: this is retired
             "ebd": "def"
         },
-        "blush": {
-            "bl": "lines",
-            "bs": "shade",
-            "bf": "full"
-        },
-        "tears": {
-            "ts": "streaming",
-            "td": "dried",
-            "tp": "pooled",
-            "tu": "up",
-        },
-        "sweat": {
-            "sdl": "def",
-            "sdr": "right"
-        },
+        "blush": dict(),
+        "tears": dict(),
+        "sweat": dict(),
         "emote": {
             "ec": "confuse"
         },
-        "mouth": {
-            "a": "smile",
-            "b": "big",
-            "c": "smirk",
-            "d": "small",
-            "o": "gasp",
-            "u": "smug",
-            "w": "wide",
-            "x": "angry",
-            "p": "pout",
-            "t": "triangle",
-#            "g": "disgust",
-        },
-        "single": { # everything else will be 3b
-            "a": "3a",
-            "u": "3a",
-        },
-        "head": {
-            # exact eye - eyebrow - mouth match
-            "eua": "a",
-            "eub": "b",
-            "euc": "c",
-            "eud": "d",
-            "eka": "e",
-            "ekc": "f",
-            "ekd": "g",
-            "esc": "h",
-            "esd": "i",
-            "hua": "j",
-            "hub": "k",
-            "hkb": "l", # sdl
-            "lka": "m", # sdl
-            "lkb": "n", # sdl
-            "lkc": "o", # sdl
-            "lkd": "p", # sdl
-            "dsc": "q",
-            "dsd": "r",
-        },
+        "mouth": dict(),
+        "single": dict(),
+        "head": dict(),
     }
 
     _mod_map = {
@@ -186,7 +106,6 @@ class StaticSprite(object):
         """
         self._init_props()
         self.spcode = spcode
-
         self.__process_map = {
             "b": self.__process_blush,
             "e": self.__process_emote,
@@ -967,3 +886,28 @@ class StaticSprite(object):
         instead.
         """
         return "".join([self.spcode[0], eyecode, self.spcode[2:]])
+
+    @staticmethod
+    def _loadSpriteMapData():
+        """
+        Loads sprite map data from the sprite map json file
+        """
+        jobj = None
+
+        with open(gamedir.REL_PATH_GAME + "mod_assets/sprite_map.json", "r") as jsonfile:
+            jobj = json.load(jsonfile)
+
+        # is file json
+        if jobj is None:
+            raise Exception("[ERROR]: Failed to load sprite_map json.")
+
+        StaticSprite._sprite_map["position"] = jobj["arms"]
+        StaticSprite._sprite_map["eyebrows"] = jobj["eyebrows"]
+        StaticSprite._sprite_map["eyes"] = jobj["eyes"]
+        StaticSprite._sprite_map["mouth"] = jobj["mouth"]
+        StaticSprite._sprite_map["head"] = jobj["head"]
+        StaticSprite._sprite_map["sides"] = jobj["sides"]
+        StaticSprite._sprite_map["single"] = jobj["single"]
+        StaticSprite._sprite_map["blush"] = jobj["blush"]
+        StaticSprite._sprite_map["tears"] = jobj["tears"]
+        StaticSprite._sprite_map["sweat"] = jobj["sweat"]

--- a/tools/spritechecker.py
+++ b/tools/spritechecker.py
@@ -1,5 +1,5 @@
 # module that checks dialogue lines for proper expression code usage
-# 
+#
 # this will NOT catch issues with non-standard code usage
 # TODO: add special functions for non-standard usages
 #
@@ -90,6 +90,9 @@ def check_file(fpath, sp_dict, gen_if_missing):
     sp_mismatches = list()
     ln_count = 1
 
+    #Loadd spritemap data
+    StaticSprite._loadSpriteMapData()
+
     with open(fpath, "r") as rpy_file:
         for line in rpy_file:
 
@@ -109,7 +112,7 @@ def check_file(fpath, sp_dict, gen_if_missing):
 
                     else:
                         sp_dict[_code] = gen_spr
-                   
+
                 else:
                     sp_mismatches.append(
                         SpriteMismatch(_code, ln_count, fpath)
@@ -319,7 +322,7 @@ def run_chk(quiet=False, inc_dev=False, use_dyn=False):
             return
 
         use_dyn = menutils.menu(menu_are_dyn, 1)
-        
+
         if use_dyn is None:
             return
 
@@ -340,7 +343,7 @@ def run_chk(quiet=False, inc_dev=False, use_dyn=False):
 
     if not quiet:
         print("\nDone")
-        menutils.e_pause()   
+        menutils.e_pause()
 
 
 ############## menus ############

--- a/tools/toolsmenu.py
+++ b/tools/toolsmenu.py
@@ -36,4 +36,3 @@ while choice is not None:
 
     if choice is not None:
         choice()
-


### PR DESCRIPTION
Since #6864, we've had smugleft and right but not had them added to the sprite checker's map, causing Travis issues (#7101)

This PR addresses it by jsonifying the sprite maps and reading from the json within MAS and within the `StaticSprite` class in the spritechecker utility.

This way, we can add sprites by simply adding them to the map, and both MAS and the utils get updated together.

## Testing:
- Verify in-MAS sprites still work correctly with this system
- Verify spritechecker works with the new system and smug left/right works properly.