### PR TITLE
fix zoomout when loading in emptydesk

### DIFF
--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -8993,6 +8993,7 @@ label mas_transition_to_emptydesk(hide_dlg_box=True):
 label mas_transition_from_emptydesk(exp="monika 1eua", show_dlg_box=True):
     if show_dlg_box:
         window auto
-    show expression exp as monika at i11 zorder MAS_MONIKA_Z with dissolve_monika
+    $ renpy.show(exp, tag="monika", at_list=[i11], zorder=MAS_MONIKA_Z)
+    $ renpy.with_statement(dissolve_monika)
     hide emptydesk
     return

--- a/Monika After Story/game/zz_dockingstation.rpy
+++ b/Monika After Story/game/zz_dockingstation.rpy
@@ -2315,9 +2315,6 @@ label mas_dockstat_empty_desk:
             mas_startupWeather()
             skip_setting_weather = True
 
-        # reset zoom before showing spaceroom
-        store.mas_sprites.reset_zoom()
-
         mas_from_empty = True
 
         checkout_time = store.mas_dockstat.getCheckTimes()[0]
@@ -2325,12 +2322,15 @@ label mas_dockstat_empty_desk:
         if mas_isD25Season() and persistent._mas_d25_deco_active:
             store.mas_d25ShowVisuals()
 
+        #NOTE: Player bday and Moni bday do a zoom reset so deco is shown properly
         if mas_confirmedParty() and mas_isMonikaBirthday():
             persistent._mas_bday_visuals = True
+            store.mas_sprites.reset_zoom()
             store.mas_surpriseBdayShowVisuals(cake=not persistent._mas_bday_sbp_reacted)
 
         #NOTE: elif'd so we don't try and show two types of visuals here
         elif persistent._mas_player_bday_decor:
+            store.mas_sprites.reset_zoom()
             store.mas_surpriseBdayShowVisuals()
 
     call spaceroom(hide_monika=True, scene_change=True)


### PR DESCRIPTION
When loading into emptydesk after taking Monika out, the zoom value is reset and never restored, nor do we have a major reason to do this aside for bday decor.

This PR moves the zoom reset to the bday deco paths only, that way deco is given full view (including cake)

## Testing:
- Verify emptydesk no longer resets zoom without bday
- Verify with bday (both player, and Monika's), zoom is reset when loading in emptydesk.