### PR TITLE
Update screen fixes

### DIFF
--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -2346,10 +2346,12 @@ screen updater:
         hbox:
             spacing gui._scale(25)
 
-            if u.state == u.DONE:
-                # We call quit here, instead of proceed, because linux works way too good and always restarts after calling proceed
-                textbutton _("Proceed") action Quit(confirm=False)
-                textbutton _("Restart") action [Function(me.__del__), Function(u.proceed)]
+            # We call quit here instead of proceed, otherwise linux always restarts
+            # We also call quit when we get an ERROR, UPDATE_NOT_AVAILABLE or CANCELLED state, otherwise, proceed calls full_restart
+            # in this case, in windows we end up in the main menu and in linux everything breaks apart
+            if u.state in (u.ERROR, u.UPDATE_NOT_AVAILABLE, u.DONE, u.DONE_NO_RESTART, u.CANCELLED):
+                textbutton _("Quit") action Function(renpy.quit, relaunch=False)
+                textbutton _("Restart") action [Function(me.__del__), Function(renpy.quit, relaunch=True)]
 
             else:
                 if u.can_proceed:

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -2346,16 +2346,20 @@ screen updater:
         hbox:
             spacing gui._scale(25)
 
-            if u.can_proceed:
-                textbutton _("Proceed") action u.proceed
-                if u.state == u.DONE:
-                    textbutton _("Restart") action [me.__del__, u.proceed]
+            if u.state == u.DONE:
+                # We call quit here, instead of proceed, because linux works way too good and always restarts after calling proceed
+                textbutton _("Proceed") action Quit(confirm=False)
+                textbutton _("Restart") action [Function(me.__del__), Function(u.proceed)]
 
-            if u.can_cancel:
-                textbutton _("Cancel") action Return()
+            else:
+                if u.can_proceed:
+                    textbutton _("Proceed") action Function(u.proceed)
+
+                if u.can_cancel:
+                    textbutton _("Cancel") action Return()
 
     # Constantly update the screen to force the progress bar to update
-    timer 0.1 action renpy.restart_interaction repeat True
+    timer 0.1 action Function(renpy.restart_interaction) repeat True
 
 
 style updater_button is confirm_button

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -2361,7 +2361,7 @@ screen updater:
                     textbutton _("Cancel") action Return()
 
     # Constantly update the screen to force the progress bar to update
-    timer 0.1 action Function(renpy.restart_interaction) repeat True
+    timer 1.0 action Function(renpy.restart_interaction) repeat True
 
 
 style updater_button is confirm_button

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -2348,6 +2348,8 @@ screen updater:
 
             if u.can_proceed:
                 textbutton _("Proceed") action u.proceed
+                if u.state == u.DONE:
+                    textbutton _("Restart") action [me.__del__, u.proceed]
 
             if u.can_cancel:
                 textbutton _("Cancel") action Return()

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -2352,6 +2352,9 @@ screen updater:
             if u.can_cancel:
                 textbutton _("Cancel") action Return()
 
+    # Constantly update the screen to force the progress bar to update
+    timer 0.1 action renpy.restart_interaction repeat True
+
 
 style updater_button is confirm_button
 style updater_button_text is navigation_button_text


### PR DESCRIPTION
An attempt to fix the update bar and the updater's restart function refusing to work in windows.
## Testing:
- Verify the progress bar now works in all update stages (preparing, downloading and unpacking the update).
- Verify the `Quit` and `Restart` buttons appear when the update has finished, regardless if it's successful or not. The buttons should **not** appear during the update stages mentioned above, as long as in the `Checking for updates` and `Version x is available` screens.
- Verify the `Quit` and `Restart` buttons, at the end of the update, work as intended. (`Quit` should only close MAS while `Restart` should close the current MAS window and open a new one.)
- Verify no weird side effects by the constant call of `renpy.restart_interaction` every 0.1 secs (e.g. no lag, memory leaks, failed updates, pcs imploding etc.)
- Verify the progress bar and the restart function still works in Linux.