### PR TITLE
Add shields when changing background

### DIFF
--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -3216,7 +3216,13 @@ label monika_change_background_loop:
         skip_transition = mas_background.EXP_SKIP_TRANSITION in sel_background.ex_props
         skip_outro = mas_background.EXP_SKIP_OUTRO in sel_background.ex_props
 
+    # UI shields
+    $ mas_RaiseShield_core()
+
     call mas_background_change(sel_background, skip_leadin=skip_leadin, skip_outro=skip_outro, set_persistent=True)
+
+    $ mas_DropShield_core()
+
     return
 
 #Generic background changing label, can be used if we wanted a sort of story related change

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -3216,11 +3216,15 @@ label monika_change_background_loop:
         skip_transition = mas_background.EXP_SKIP_TRANSITION in sel_background.ex_props
         skip_outro = mas_background.EXP_SKIP_OUTRO in sel_background.ex_props
 
-    # UI shields
+    # UI shields + buttons
+    # NOTE: buttons are in here since there is no consistency if placed in 
+    # the bg change label.
     $ mas_RaiseShield_core()
+    $ HKBHideButtons()
 
     call mas_background_change(sel_background, skip_leadin=skip_leadin, skip_outro=skip_outro, set_persistent=True)
 
+    $ HKBShowButtons()
     $ mas_DropShield_core()
 
     return
@@ -3240,6 +3244,7 @@ label mas_background_change(new_bg, skip_leadin=False, skip_transition=False, sk
         pause 2.0
 
     python:
+
         #Set persistent
         if set_persistent:
             persistent._mas_current_background = new_bg.background_id

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -3222,7 +3222,7 @@ label monika_change_background_loop:
     $ mas_RaiseShield_core()
     $ HKBHideButtons()
 
-    call mas_background_change(sel_background, skip_leadin=skip_leadin, skip_outro=skip_outro, set_persistent=True)
+    call mas_background_change(sel_background, skip_leadin=skip_leadin, skip_transition=skip_transition, skip_outro=skip_outro, set_persistent=True)
 
     $ HKBShowButtons()
     $ mas_DropShield_core()


### PR DESCRIPTION
#6358 

# Key Changes
* UI elements are disabled when background is changed
* hotkey buttons are hidden as well

# Testing
* Verify that the hotkey buttons/escape menu/calendar/etc is disabled when the background is changed via `Hey Monika > Location > Can we go somewhere else?`  
    * the buttons are only disabled once Monika says "Alright!"