### PR TITLE
Windows geometry and mouse pos fixes

### DIFF
--- a/Monika After Story/game/zz_windowutils.rpy
+++ b/Monika After Story/game/zz_windowutils.rpy
@@ -401,9 +401,9 @@ init python in mas_windowutils:
 
         rv = win32gui.GetWindowRect(hwnd)
 
-        # win32gui may return incorrect geometry,
+        # win32gui may return incorrect geometry (-32k seems to be the limit),
         # in this case we return None
-        if rv[-1] < 0:
+        if rv[0] <= -32000 and rv[1] <= -32000:
             return None
 
         return rv

--- a/Monika After Story/game/zz_windowutils.rpy
+++ b/Monika After Story/game/zz_windowutils.rpy
@@ -399,7 +399,14 @@ init python in mas_windowutils:
         if hwnd is None:
             return None
 
-        return win32gui.GetWindowRect(hwnd)
+        rv = win32gui.GetWindowRect(hwnd)
+
+        # win32gui may return incorrect geometry,
+        # in this case we return None
+        if rv[-1] < 0:
+            return None
+
+        return rv
 
     def _getMASWindowPos_Linux():
         """
@@ -435,6 +442,8 @@ init python in mas_windowutils:
         left, top, right, bottom = pos_tuple
 
         curr_x, curr_y = getMousePos()
+        curr_x = max(curr_x, 1)
+        curr_y = max(curr_y, 1)
 
         half_mas_window_x = (right - left)/2
         half_mas_window_y = (bottom - top)/2


### PR DESCRIPTION
### Fixes:
 - `win32gui.GetWindowRect` may return incorrect geometry for windows. Now we catch it and return `None` instead of huge negative numbers.
 - `mas_windowutils.getMousePosRelative` is more consistent in fullscreen now (mouse will always be inside MAS window).

### Testing:
 - Verify `mas_windowutils.getMASWindowPos` always returns correct geometry or at least `None` **on Windows systems**.
 - Verify `mas_windowutils.getMousePosRelative` always returns `(0, 0)` when in fullscreen (check screen edges).