### PR TITLE
Mirror stdout + stderr to file

### DIFF
--- a/.github/workflows/mas_check.yml
+++ b/.github/workflows/mas_check.yml
@@ -65,7 +65,7 @@ jobs:
       - name: rpy lint
         run: |
           cd renpy
-          ./renpy.sh "../mas0105/" lint | grep -E -v "^$|Could not find image \(monika [0-9][^[:space:]]+ corresponding to attributes on say statement\.|'monika [0-9][^[:space:]]' is not an image\.|The image named 'monika [0-9][^[:space:]]+ was not declared\."
+          ./renpy.sh "../mas0105/" lint | grep -E -v "^$|Could not find image \(monika [0-9][^[:space:]]+ corresponding to attributes on say statement\.|'monika [0-9][^[:space:]]+' is not an image\.|The image named 'monika [0-9][^[:space:]]+ was not declared\."
 
       # distribute
       - name: rpy distribute

--- a/.github/workflows/mas_check.yml
+++ b/.github/workflows/mas_check.yml
@@ -65,7 +65,7 @@ jobs:
       - name: rpy lint
         run: |
           cd renpy
-          ./renpy.sh "../mas0105/" lint | grep -v "^$\|Could not find image\|is not an image\|The image named"
+          ./renpy.sh "../mas0105/" lint | grep -E -v "^$|Could not find image \(monika [0-9][^[:space:]]+ corresponding to attributes on say statement\.|'monika [0-9][^[:space:]]' is not an image\.|The image named 'monika [0-9][^[:space:]]+ was not declared\."
 
       # distribute
       - name: rpy distribute

--- a/.github/workflows/mas_check.yml
+++ b/.github/workflows/mas_check.yml
@@ -2,7 +2,7 @@
 
 name: CI
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
@@ -18,10 +18,10 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     name: ci_build
-    
+
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    
+
     env:
       SDL_AUDIODRIVER: dummy # handles ALSA issues
 
@@ -43,7 +43,7 @@ jobs:
           tar xf renpy-6.99.12.4-sdk.tar.bz2
           rm renpy-6.99.12.4-sdk.tar.bz2
           mv renpy-6.99.12.4-sdk renpy
-          
+
       # download base mas
       - name: Download base MAS + copy files over
         run: |
@@ -56,7 +56,7 @@ jobs:
       - name: exception skip for unstable
         run: touch mas0105/trb
         if: github.ref == 'refs/heads/unstable'
-        
+
       # run sprite checkers
       - name: check sprites
         run: python tools/ghactions.py
@@ -65,7 +65,7 @@ jobs:
       - name: rpy lint
         run: |
           cd renpy
-          ./renpy.sh "../mas0105/" lint &> renpy_output
+          ./renpy.sh "../mas0105/" lint &> >(tee renpy_output)
           python ../tools/renpy_lint_parser.py
           cat renpy_output_clean
 
@@ -74,4 +74,3 @@ jobs:
         run: |
           cd renpy
           ./renpy.sh launcher distribute "../mas0105/" --package Mod
-        

--- a/.github/workflows/mas_check.yml
+++ b/.github/workflows/mas_check.yml
@@ -65,9 +65,7 @@ jobs:
       - name: rpy lint
         run: |
           cd renpy
-          ./renpy.sh "../mas0105/" lint &> >(tee renpy_output)
-          python ../tools/renpy_lint_parser.py
-          cat renpy_output_clean
+          ./renpy.sh "../mas0105/" lint | grep -v "^$\|Could not find image\|is not an image"
 
       # distribute
       - name: rpy distribute

--- a/.github/workflows/mas_check.yml
+++ b/.github/workflows/mas_check.yml
@@ -65,7 +65,7 @@ jobs:
       - name: rpy lint
         run: |
           cd renpy
-          ./renpy.sh "../mas0105/" lint | grep -v "^$\|Could not find image\|is not an image"
+          ./renpy.sh "../mas0105/" lint | grep -v "^$\|Could not find image\|is not an image\|The image named"
 
       # distribute
       - name: rpy distribute


### PR DESCRIPTION
Even with [`0e848db`](https://github.com/Monika-After-Story/MonikaModDev/blob/0e848dbdaace268e8e381b2521c557f4f414a255/.github/workflows/mas_check.yml), we still didn't properly report errors in the GHActions script

~~using `tee` I mirrored the output from lint to stdout and to file so it's reported properly.~~

I modified the script to no longer use the lint parser, but instead run through `grep` with an inverted match criteria to find the lines referring to images