### PR TITLE
Fix IO Thread Crash

### DIFF
--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -192,7 +192,7 @@ init -998 python in mas_ev_data_ver:
         valid_times = True
     except:
         valid_times = False
-        renpy.log("failed to verify mtimes")
+        renpy.exports.log("failed to verify mtimes")
 
 init -950 python in mas_ev_data_ver:
     import store

--- a/Monika After Story/game/zz_dockingstation.rpy
+++ b/Monika After Story/game/zz_dockingstation.rpy
@@ -1866,7 +1866,7 @@ init 200 python in mas_dockstat:
                 # no data found, assume a missing monika
                 return (MAS_PKG_NF, None)
 
-            real_data = parseMoniData(real_data)
+            real_data = parseMoniData(real_data, rd_log)
             ret_code = MAS_PKG_DL
 
         else:


### PR DESCRIPTION
Was looking thru dockstat, noticed this func didn't get a logfile passed in, this will crash the thread and brick the promise.

Added the rd_log to the func call and it should work as intended now