### PR TITLE
Hangman sensitive mode alignment fix

### DIFF
--- a/Monika After Story/game/zz_hangman.rpy
+++ b/Monika After Story/game/zz_hangman.rpy
@@ -94,7 +94,8 @@ transform hangman_display_word:
     xcenter 975 yanchor 0 ypos 475
 
 transform hangman_hangman:
-    xanchor 0 yanchor 0 xpos 880 ypos 125
+    xanchor 0 yanchor 0 ypos 125
+    xpos (880 if not persistent._mas_sensitive_mode else 836)
 
 # window sayori
 # left in


### PR DESCRIPTION
Trivial fix for **Remaining guesses: n** image alignment.
Non-sensitive mode is not affected.

---
<table>
  <tr>
    <th></th>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <th>Sensitive</th>
    <td><img src="https://user-images.githubusercontent.com/5585984/120096414-09b13280-c134-11eb-81f2-aab6c86c49ec.png"></td>
    <td><img src="https://user-images.githubusercontent.com/5585984/120096416-0e75e680-c134-11eb-8ab4-64ddc451937b.png"></td>
  </tr>
  <tr>
    <th>Normal</th>
    <td><img src="https://user-images.githubusercontent.com/5585984/120096419-146bc780-c134-11eb-84d4-f9bee38e1db8.png"></td>
    <td><img src="https://user-images.githubusercontent.com/5585984/120096421-15045e00-c134-11eb-9cf8-0101458b9dbe.png"></td>
  </tr>
</table>