### PR TITLE
Removed dashes from hangman

### DIFF
--- a/Monika After Story/game/zz_hangman.rpy
+++ b/Monika After Story/game/zz_hangman.rpy
@@ -5,7 +5,7 @@
 
 # hangman stuff only
 default persistent._mas_hangman_playername = False
-define hm_ltrs_only = "abcdefghijklmnopqrstuvwxyz?!-"
+define hm_ltrs_only = "abcdefghijklmnopqrstuvwxyz?!"
 
 # IMAGES-----------
 # hangman
@@ -353,6 +353,23 @@ init -1 python in mas_hangman:
         return words.pop(random.randint(0, len(words)-1))
 
 
+    def wordToDisplay(word):
+        """
+        Formats a word so it can be displayed in hangman
+
+        IN:
+            word - word to format (string)
+
+        RETURNS: display word
+        """
+        dash_tokens = word.split("-")
+
+        return list("-".join([
+            "_" * len(token)
+            for token in dash_tokens
+        ]))
+
+
 # post processing
 init 10 python:
 
@@ -454,7 +471,7 @@ label mas_hangman_game_loop:
                 and persistent.playername.isalpha()
                 and len(persistent.playername) <= 15
             ):
-            display_word = list("_" * len(persistent.playername.lower()))
+            display_word = mas_hmg.wordToDisplay(persistent.playername.lower())
             hm_hint = mas_hmg.HM_HINT.format("I")
             word = persistent.playername.lower()
             player_word = True
@@ -464,7 +481,7 @@ label mas_hangman_game_loop:
             if word == -1:
                 word = mas_hmg.randomSelect(hangman_mode)
 
-            display_word = list("_" * len(word[0]))
+            display_word = mas_hmg.wordToDisplay(word[0])
             hm_hint = mas_hmg.HM_HINT.format(word[1])
 
             word = word[0]

--- a/Monika After Story/game/zz_hangman.rpy
+++ b/Monika After Story/game/zz_hangman.rpy
@@ -362,12 +362,7 @@ init -1 python in mas_hangman:
 
         RETURNS: display word
         """
-        dash_tokens = word.split("-")
-
-        return list("-".join([
-            "_" * len(token)
-            for token in dash_tokens
-        ]))
+        return ["_" if c != "-" else "-" for c in word]
 
 
 # post processing


### PR DESCRIPTION
#7329 

Dashes are an acceptable input in hangman, but this isn't obvious nor intuitive. Players are likely to guess letters when a word with dashes is used.

# Key Changes
* dashes are no longer acceptable hangman inputs, and words with dashes will have the dashes prefilled.

# Testing
* verify words with dashes (doki-doki, life-changing) have the dashes filled 
    * best way to force words is hardcode the word on line 466 of `zz_hangman`. format is like `word = ("word", "hint")`
* verify normal words still work as expected