### PR TITLE
Some fixes for PauseDispalyable

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -3629,7 +3629,7 @@ init 25 python:
         """
         Class to represent events for PauseDisplayableWithEvents
         """
-        def __init__(self, timedelta, functions, repeatable=False, invoke_in_new_context=False):
+        def __init__(self, timedelta, functions, repeatable=False, invoke_in_new_context=False, restart_interaction=False):
             """
             Constructor for events
 
@@ -3641,6 +3641,9 @@ init 25 python:
                     (Default: False)
                 invoke_in_new_context - whether or not we'll invoke the functions
                     to avoid interaction issues
+                    (Default: False)
+                restart_interaction - whether or not we'll also call renpy.restart_interaction
+                    to update the screen
                     (Default: False)
             """
             self.timedelta = timedelta
@@ -3655,6 +3658,7 @@ init 25 python:
             self.functions = functions
             self.repeatable = repeatable
             self.invoke_in_new_context = invoke_in_new_context
+            self.restart_interaction = restart_interaction
 
             self.end_datetime = None
 
@@ -3683,6 +3687,9 @@ init 25 python:
 
                 else:
                     func()
+
+                if self.restart_interaction:
+                    renpy.restart_interaction()
 
     class PauseDisplayableWithEvents(renpy.Displayable):
         """
@@ -3721,55 +3728,80 @@ init 25 python:
             """
             super(renpy.Displayable, self).__init__()
 
-            if events is None:
-                events = [PauseDisplayableWithEvents.CRUTCH_EVENT]
+            # This will set remaining_events and all_events props
+            self.set_events(events)
 
-            elif isinstance(events, tuple):
-                events = list(events)
-                events.append(PauseDisplayableWithEvents.CRUTCH_EVENT)
-
-            elif isinstance(events, list):
-                events.append(PauseDisplayableWithEvents.CRUTCH_EVENT)
-
-            # Assuming it's a single PauseDisplayableEvent
-            else:
-                events = [events, PauseDisplayableWithEvents.CRUTCH_EVENT]
-
-            events.sort(key=PauseDisplayableWithEvents.__sort_key_td)
-
-            self.events = events
-            self.__events = list(events)
             self.respected_keysims = respected_keysims or PauseDisplayableWithEvents._RESPECTED_KEYSIMS
             self.__abort_events = False
-            self.should_enable_afm = None
+            self.__should_enable_afm = None
 
         def __repr__(self):
             """
             Representation of this obj
             """
-            return "<PauseDisplayableWithEvents ({0})>".format(self.events)
+            return "<PauseDisplayableWithEvents ({0})>".format(self.__remaining_events)
+
+        @classmethod
+        def __handle_events(cls, events):
+            """
+            Takes events and sorts them before passing further
+
+            IN:
+                events - PauseDisplayableEvent or a list of PauseDisplayableEvent's
+
+            OUT:
+                sorted list
+            """
+            if events is None:
+                events = [cls.CRUTCH_EVENT]
+
+            elif isinstance(events, tuple):
+                events = list(events)
+                events.append(cls.CRUTCH_EVENT)
+
+            elif isinstance(events, list):
+                events.append(cls.CRUTCH_EVENT)
+
+            # Assuming it's a single PauseDisplayableEvent
+            else:
+                events = [events, cls.CRUTCH_EVENT]
+
+            events.sort(key=cls.__sort_key_td)
+
+            return events
+
+        def set_events(self, events):
+            """
+            Sets new events for this PauseDisplayable
+
+            IN:
+                events - PauseDisplayableEvent or a list of PauseDisplayableEvent's
+            """
+            events = self.__handle_events(events)
+            self.__remaining_events = events
+            self.__all_events = list(events)
 
         def __set_end_datetimes(self):
             """
             Sets end datetimes for events using current time
             """
             _now = datetime.datetime.now()
-            for event in self.events:
-                event.set_end_datetime(_now + event.timedelta)
+            for ev in self.__remaining_events:
+                ev.end_datetime = _now + ev.timedelta
 
         def __reset_events(self):
             """
             Resets events state
             """
-            self.events = self.__events[:]
-            for ev in self.events:
-                ev.set_end_datetime(None)
+            self.__remaining_events = self.__all_events[:]
+            for ev in self.__remaining_events:
+                ev.end_datetime = None
 
         def start(self):
             """
             Starts this displayable
             """
-            self.should_enable_afm = store._preferences.afm_enable
+            self.__should_enable_afm = store._preferences.afm_enable
             self.__set_end_datetimes()
             ui.implicit_add(self)
             ui.interact()
@@ -3780,7 +3812,7 @@ init 25 python:
             """
             ui.remove(self)
             self.__abort_events = True
-            self.should_enable_afm = None
+            self.__should_enable_afm = None
 
             if renpy.game.context().interacting:
                 renpy.end_interaction(False)
@@ -3792,7 +3824,7 @@ init 25 python:
             ui.remove(self)
             self.__reset_events()
             self.__abort_events = False
-            self.should_enable_afm = None
+            self.__should_enable_afm = None
 
             if renpy.game.context().interacting:
                 renpy.end_interaction(False)
@@ -3810,9 +3842,9 @@ init 25 python:
             """
             _now = datetime.datetime.now()
 
-            for event in self.events[:]:
+            for event in self.__remaining_events[:]:
                 if _now >= event.end_datetime:
-                    self.events.remove(event)
+                    self.__remaining_events.remove(event)
                     yield event
 
                 # no need to keep iter, we can return at this point
@@ -3824,17 +3856,17 @@ init 25 python:
             Sets a timeout for event generator
             """
             # No need to do anything if we have no pending events
-            if not self.events:
+            if not self.__remaining_events:
                 return
 
             _now = datetime.datetime.now()
-            _end_dt = self.events[0].end_datetime
+            _end_dt = self.__remaining_events[0].end_datetime
 
             if _end_dt >= _now:
-                timeout = (_end_dt - _now).total_seconds() + 0.1
+                timeout = (_end_dt - _now).total_seconds()
 
             else:
-                timeout = 0.1
+                timeout = 0.0
 
             renpy.timeout(timeout)
 
@@ -3871,7 +3903,7 @@ init 25 python:
                         event()
                         if event.repeatable:
                             event.set_end_datetime(datetime.datetime.now() + event.timedelta)
-                            store.mas_utils.insert_sort(self.events, event, PauseDisplayableWithEvents.__sort_key_dt)
+                            store.mas_utils.insert_sort(self.__remaining_events, event, PauseDisplayableWithEvents.__sort_key_dt)
 
                     # If we aborted, we need to quit asap
                     else:
@@ -3884,8 +3916,8 @@ init 25 python:
             elif ev.type == pygame.MOUSEBUTTONDOWN and ev.button == 1:
                 self.__abort_events = True
                 ui.remove(self)
-                if self.should_enable_afm:
-                    self.should_enable_afm = None
+                if self.__should_enable_afm:
+                    self.__should_enable_afm = None
                     store._preferences.afm_enable = True
                 return True
 

--- a/Monika After Story/game/dev/dev_pausedisplayable_test.rpy
+++ b/Monika After Story/game/dev/dev_pausedisplayable_test.rpy
@@ -1,0 +1,49 @@
+init 5 python:
+    addEvent(
+        Event(
+            persistent.event_database,
+            eventlabel="dev_pausedisplayable_test",
+            category=["dev"],
+            prompt="TEST PAUSEDISPLAYABLE",
+            pool=True,
+            unlocked=True
+        )
+    )
+
+label dev_pausedisplayable_test:
+    m 1eua "I'll start the pause and queue multiple events with different parameters.{w=0.5}.{w=0.5}.{nw}"
+
+    python hide:
+        events = (
+            PauseDisplayableEvent(
+                datetime.timedelta(seconds=5),
+                renpy.partial(renpy.invoke_in_new_context, renpy.say, store.m, "5 SECONDS. REPEATABLE."),
+                repeatable=True
+            ),
+            PauseDisplayableEvent(
+                datetime.timedelta(seconds=10),
+                renpy.partial(renpy.say, store.m, "10 SECONDS. INVOKED."),# This would crash w/o invoke_in_new_context
+                invoke_in_new_context=True
+            ),
+            PauseDisplayableEvent(
+                datetime.timedelta(seconds=3),
+                renpy.partial(renpy.say, store.m, "3 SECONDS. INVOKED."),
+                invoke_in_new_context=True
+            ),
+            PauseDisplayableEvent(
+                datetime.timedelta(seconds=15),
+                (
+                    renpy.partial(renpy.invoke_in_new_context, renpy.say, store.m, "15 SECONDS. REPEATABLE. RESTARTS INTERACTION."),
+                    renpy.partial(renpy.show, "monika 2eua")# The screen wouldn't update w/o restart_interaction
+                ),
+                repeatable=True,
+                restart_interaction=True
+            )
+        )
+        disp = PauseDisplayableWithEvents()
+        disp.set_events(events)
+        disp.start()
+
+    m 1eua "We're done.{w=1}{nw}"
+
+    return

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -4349,15 +4349,16 @@ label greeting_spacing_out:
         spacing_out_pause = PauseDisplayableWithEvents()
         events = list()
         next_event_time = 0
-        right_smug = (renpy.partial(renpy.show, "monika 1gsbsu"), renpy.restart_interaction)
-        left_smug = (renpy.partial(renpy.show, "monika 1msbsu"), renpy.restart_interaction)
+        right_smug = renpy.partial(renpy.show, "monika 1gsbsu")
+        left_smug = renpy.partial(renpy.show, "monika 1msbsu")
 
         # Make the events which will change exps
         for i in range(random.randint(4, 6)):
             events.append(
                 PauseDisplayableEvent(
                     datetime.timedelta(seconds=next_event_time),
-                    right_smug if use_right_smug else left_smug
+                    right_smug if use_right_smug else left_smug,
+                    restart_interaction=True
                 )
             )
             next_event_time += random.uniform(0.9, 1.8)
@@ -4366,7 +4367,8 @@ label greeting_spacing_out:
         events.append(
             PauseDisplayableEvent(
                 datetime.timedelta(seconds=next_event_time),
-                (renpy.partial(renpy.show, "monika 1tsbsu"), renpy.restart_interaction)
+                renpy.partial(renpy.show, "monika 1tsbsu"),
+                restart_interaction=True
             )
         )
         next_event_time += 0.7
@@ -4377,8 +4379,8 @@ label greeting_spacing_out:
                 spacing_out_pause.stop
             )
         )
-        spacing_out_pause.events[:] = events
 
+        spacing_out_pause.set_events(events)
         spacing_out_pause.start()
 
     # Small pause so people don't skip this line


### PR DESCRIPTION
This fixes some potential bugs + makes changes required for things like #7359.

### Changes:
 - new prop `restart_interaction`. Since I want events to be wrappers (they already handle `invoke_in_new_context`), I wrap `renpy.restart_interaction` in them for convenience. Those 2 funcs will be used the most, so it makes sense to have them in the API.
 - new method `set_events` - setter to set events for `PauseDisplayable`. There was a bug before when I directly accessed `events`. Not only there was a potential issue because of that, it's just a bad practice. Using a setter is better.
 - props with events are now private, because you shouldn't access those directly.
 - updated code in `greeting_spacing_out` to use the new method and fix that issue.
 - removed the delay (`0.1` sec) from the timeout event. It was redundant.
 - added small test for `PauseDisplayable`.

### Testing:
- verify general stability, there's only minor code changes, but still.
- push `greeting_spacing_out` and see if it looks the same.
- can also give the new test a try.