### PR TITLE
Added a decorator for deprecation

### DIFF
--- a/Monika After Story/game/00utils.rpy
+++ b/Monika After Story/game/00utils.rpy
@@ -362,6 +362,8 @@ python early in mas_utils:
                     newline=newline
                 )
 
+                deprecated.__all_warnings__.add(msg)
+
                 if should_raise:
                     raise DeprecationWarning(msg)
 
@@ -374,3 +376,6 @@ python early in mas_utils:
             return wrapper
 
         return decorator
+
+    # Keep all warnings
+    deprecated.__all_warnings__ = set()

--- a/Monika After Story/game/00utils.rpy
+++ b/Monika After Story/game/00utils.rpy
@@ -354,20 +354,19 @@ python early in mas_utils:
                 else:
                     newline = ""
 
-                exc = DeprecationWarning(
-                    msg.format(
-                        module=module,
-                        name=name,
-                        use_instead_text=use_instead_text,
-                        newline=newline
-                    )
+                msg = msg.format(
+                    module=module,
+                    name=name,
+                    use_instead_text=use_instead_text,
+                    newline=newline
                 )
 
                 if should_raise:
-                    raise exc
+                    raise DeprecationWarning(msg)
 
                 else:
-                    writelog(str(exc))
+                    print(msg)
+                    writelog(msg)
 
                 return callable_(*args, **kwargs)
 

--- a/Monika After Story/game/00utils.rpy
+++ b/Monika After Story/game/00utils.rpy
@@ -1,6 +1,7 @@
 python early in mas_utils:
     import codecs
     import os
+    import sys
     import platform
     import shutil
     import store
@@ -365,7 +366,7 @@ python early in mas_utils:
                     raise DeprecationWarning(msg)
 
                 else:
-                    print(msg)
+                    print(msg, end="", file=sys.stderr)
                     writelog(msg)
 
                 return callable_(*args, **kwargs)

--- a/Monika After Story/game/00utils.rpy
+++ b/Monika After Story/game/00utils.rpy
@@ -316,8 +316,16 @@ python early in mas_utils:
         """
         Decorator that marks functions and classes as deprecated
 
+        During LINT every UNIQUE EXECUTION (during the init phase) of a deprecated object
+            will be reported to stdout using lint hooks
+        During RUNTIME every EXECUTION of a deprecated object
+            will be reported in the main log (mas_log.txt) and stderr
+        NOTE: if we were allowed to raise, we RAISE a DeprecationWarning intead
+
+        You can access all the reports via __all_warnings__
+
         IN:
-            use_instead - string with the nameof the function/class to use instead
+            use_instead - string with the name of the function/class to use instead
             should_raise - whether we raise an exception or just log the error
         """
         def decorator(callable_):

--- a/Monika After Story/game/00utils.rpy
+++ b/Monika After Story/game/00utils.rpy
@@ -336,7 +336,7 @@ python early in mas_utils:
                 """
                 Wrapper around the deprecated function/class
                 """
-                msg = "[WARNING]: '{module}{name}' is deprecated.{use_instead_text}{newline}"
+                msg = "[WARNING]: '{module}{name}' is deprecated.{use_instead_text}"
 
                 if hasattr(callable_, "__module__") and callable_.__module__:
                     module = callable_.__module__ + "."
@@ -350,16 +350,10 @@ python early in mas_utils:
                 else:
                     use_instead_text = " Use '{0}' instead.".format(use_instead)
 
-                if not should_raise:
-                    newline = "\n"
-                else:
-                    newline = ""
-
                 msg = msg.format(
                     module=module,
                     name=name,
-                    use_instead_text=use_instead_text,
-                    newline=newline
+                    use_instead_text=use_instead_text
                 )
 
                 deprecated.__all_warnings__.add(msg)
@@ -368,8 +362,8 @@ python early in mas_utils:
                     raise DeprecationWarning(msg)
 
                 else:
-                    print(msg, end="", file=sys.stderr)
-                    writelog(msg)
+                    print(msg, file=sys.stderr)
+                    writelog(msg + "\n")
 
                 return callable_(*args, **kwargs)
 

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -1582,6 +1582,7 @@ python early:
 
             return eventlabels
 
+        @store.mas_utils.deprecated(should_raise=True)
         @staticmethod
         def checkConditionals(events, rebuild_ev=False):
             # NOTE: DEPRECATED
@@ -1642,6 +1643,7 @@ python early:
 
             return events
 
+        @store.mas_utils.deprecated(should_raise=True)
         @staticmethod
         def checkCalendar(events):
             # NOTE: DEPRECATED
@@ -1789,7 +1791,7 @@ python early:
 
             return
 
-
+        @store.mas_utils.deprecated(should_raise=True)
         @staticmethod
         def _checkRepeatRule(ev, check_time, defval=True):
             """DEPRECATED
@@ -1825,7 +1827,7 @@ python early:
 
             return False
 
-
+        @store.mas_utils.deprecated(should_raise=True)
         @staticmethod
         def checkRepeatRules(events, check_time=None):
             """DEPRECATED
@@ -2981,7 +2983,7 @@ python early:
             ))
 
 # init -1 python:
-
+    @store.mas_utils.deprecated(should_raise=True)
     class MASInteractable(renpy.Displayable):
         """DEPRECATED
 

--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -1781,7 +1781,7 @@ init python:
         # now this event has passsed checks, we can add it to the db
         eventdb.setdefault(event.eventlabel, event)
 
-
+    @store.mas_utils.deprecated("mas_hideEVL", should_raise=True)
     def hideEventLabel(
             eventlabel,
             lock=False,
@@ -1809,7 +1809,7 @@ init python:
         #       (DEfault: evhand.event_database)
         mas_hideEventLabel(eventlabel, lock, derandom, depool, decond, eventdb)
 
-
+    @store.mas_utils.deprecated("mas_hideEvent")
     def hideEvent(
             event,
             lock=False,
@@ -1957,7 +1957,7 @@ init python:
         """
         mas_showEvent(eventdb.get(ev_label, None), unlock, _random, _pool)
 
-
+    @store.mas_utils.deprecated("mas_lockEvent", should_raise=True)
     def lockEvent(ev):
         """
         NOTE: DEPRECATED
@@ -1968,7 +1968,7 @@ init python:
         """
         mas_lockEvent(ev)
 
-
+    @store.mas_utils.deprecated("mas_lockEventLabel", should_raise=True)
     def lockEventLabel(evlabel, eventdb=evhand.event_database):
         """
         NOTE: DEPRECATED
@@ -2041,7 +2041,7 @@ init python:
         persistent.event_list.insert(0, (event_label, notify))
         return
 
-
+    @store.mas_utils.deprecated("mas_unlockEvent", should_raise=True)
     def unlockEvent(ev):
         """
         NOTE: DEPRECATED
@@ -2052,7 +2052,7 @@ init python:
         """
         mas_unlockEvent(ev)
 
-
+    @store.mas_utils.deprecated("mas_unlockEventLabel")
     def unlockEventLabel(evlabel, eventdb=evhand.event_database):
         """
         NOTE: DEPRECATED

--- a/Monika After Story/game/event-rules.rpy
+++ b/Monika After Story/game/event-rules.rpy
@@ -611,6 +611,7 @@ init -1 python:
             # Evaluate randint with a chance of 1 in random_chance
             return renpy.random.randint(1,random_chance) == 1
 
+    @store.mas_utils.deprecated(use_instead="the aff_range property for Events", should_raise=True)
     class MASAffectionRule(object):
         """
         NOTE: DEPRECATED
@@ -622,6 +623,7 @@ init -1 python:
         to check against.
         """
 
+        @store.mas_utils.deprecated(use_instead="the aff_range property for Events", should_raise=True)
         @staticmethod
         def create_rule(min, max, ev=None):
             """
@@ -652,7 +654,7 @@ init -1 python:
 
             return rule
 
-
+        @store.mas_utils.deprecated(use_instead="the aff_range property for Events", should_raise=True)
         @staticmethod
         def evaluate_rule(event=None, rule=None, affection=None, noRuleReturn=False):
             """

--- a/Monika After Story/game/import_ddlc.rpy
+++ b/Monika After Story/game/import_ddlc.rpy
@@ -116,7 +116,7 @@ label import_ddlc_persistent:
             ddlc_persistent = updateTopicIDs("v031", ddlc_persistent)
             ddlc_persistent = updateTopicIDs("v032", ddlc_persistent)
             ddlc_persistent = updateTopicIDs("v033", ddlc_persistent)
-            clearUpdateStructs()
+            mas_versions.clear()
 
     if ddlc_persistent is None:
         menu:

--- a/Monika After Story/game/options.rpy
+++ b/Monika After Story/game/options.rpy
@@ -160,16 +160,26 @@ define config.label_overrides = {
     "_choose_renderer": "mas_choose_renderer_override"
 }
 #define config.gl_resize = False
-init python:
-    # Print all deprecation warnings
-    def __print_deprecation_warnings():
-        print("Total deprecation warnings: {0}".format(len(store.mas_utils.deprecated.__all_warnings__)))
-        for msg in store.mas_utils.deprecated.__all_warnings__:
-            print(msg)
+init 50 python:
+    # For some reason it's not inported yet, so we do it now /shrug
+    from __future__ import print_function
 
-    config.lint_hooks.append(
-        __print_deprecation_warnings
-    )
+    config.lint_hooks = [
+        lambda: print(),
+        lambda: print("#"*5, "START MAS LINT HOOKS", "#"*5),
+        # Print all deprecation warnings after lint
+        lambda: print(
+            "Known uses of deprecated functions/classes in initialisation:",
+            (
+                "\n".join([msg.rjust(len(msg) + 4) for msg in store.mas_utils.deprecated.__all_warnings__])
+                if store.mas_utils.deprecated.__all_warnings__
+                else "    None"
+            ),
+            "",
+            sep="\n"
+        ),
+        lambda: print("#"*5, "END MAS LINT HOOKS", "#"*5)
+    ]
 
 init python:
     if len(renpy.loadsave.location.locations) > 1: del(renpy.loadsave.location.locations[1])

--- a/Monika After Story/game/options.rpy
+++ b/Monika After Story/game/options.rpy
@@ -160,6 +160,15 @@ define config.label_overrides = {
     "_choose_renderer": "mas_choose_renderer_override"
 }
 #define config.gl_resize = False
+init python:
+    # Print all deprecation warnings
+    def __print_deprecation_warnings():
+        for msg in store.mas_utils.deprecated.__all_warnings__:
+            print(msg)
+
+    config.lint_hooks.append(
+        __print_deprecation_warnings
+    )
 
 init python:
     if len(renpy.loadsave.location.locations) > 1: del(renpy.loadsave.location.locations[1])

--- a/Monika After Story/game/options.rpy
+++ b/Monika After Story/game/options.rpy
@@ -163,6 +163,7 @@ define config.label_overrides = {
 init python:
     # Print all deprecation warnings
     def __print_deprecation_warnings():
+        print("Total deprecation warnings: {0}".format(len(store.mas_utils.deprecated.__all_warnings__)))
         for msg in store.mas_utils.deprecated.__all_warnings__:
             print(msg)
 

--- a/Monika After Story/game/progression.rpy
+++ b/Monika After Story/game/progression.rpy
@@ -319,7 +319,7 @@ init python in mas_xp:
 
 
 init python:
-
+    @store.mas_utils.deprecated(should_raise=True)
     def grant_xp(experience):
         """DEPRECATED
         This does not do anything anymore. Around for compatibility
@@ -327,7 +327,7 @@ init python:
         """
         pass
 
-
+    @store.mas_utils.deprecated(should_raise=True)
     def get_level():
         """DEPRECATED
         This does not do anything anymore. Around for compatibility purposes

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -508,7 +508,7 @@ init python:
 #            config.keymap['dismiss'] = dismiss_keys
 #            renpy.display.behavior.clear_keymap_cache()
 
-
+    @store.mas_utils.deprecated(use_instead="mas_isDayNow", should_raise=True)
     def mas_isMorning():
         """DEPRECATED
         Checks if it is day or night via suntimes
@@ -535,7 +535,7 @@ init python:
 
         return curr_flt != new_flt
 
-
+    @store.mas_utils.deprecated(should_raise=True)
     def mas_shouldChangeTime():
         """DEPRECATED
         This no longer makes sense with the filtering system.

--- a/Monika After Story/game/sprite-chart-matrix.rpy
+++ b/Monika After Story/game/sprite-chart-matrix.rpy
@@ -812,7 +812,7 @@ init -99 python in mas_sprites:
 
         FILTERS[flt_enum] = imx
 
-
+    @store.mas_utils.deprecated(use_instead="get_filter", should_raise=True)
     def _decide_filter():
         """DEPRECATED
         Please use get_filter

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -3790,7 +3790,7 @@ init -3 python:
                     acs_layer
                 )
 
-        @store.mas_utils.deprecated()
+        @store.mas_utils.deprecated("wear_acs_in")
         def wear_acs_pre(self, acs):
             """DEPRECATED
             Wears the given accessory in the pre body accessory mode
@@ -3800,7 +3800,7 @@ init -3 python:
             """
             self.wear_acs_in(acs, self.PRE_ACS)
 
-        @store.mas_utils.deprecated()
+        @store.mas_utils.deprecated("wear_acs_in")
         def wear_acs_bbh(self, acs):
             """DEPRECATED
             Wears the given accessory in the post back hair accessory loc
@@ -3810,7 +3810,7 @@ init -3 python:
             """
             self.wear_acs_in(acs, self.BBH_ACS)
 
-        @store.mas_utils.deprecated()
+        @store.mas_utils.deprecated("wear_acs_in")
         def wear_acs_bfh(self, acs):
             """DEPRECATED
             Wears the given accessory in the pre front hair accesory log
@@ -3820,7 +3820,7 @@ init -3 python:
             """
             self.wear_acs_in(acs, self.BFH_ACS)
 
-        @store.mas_utils.deprecated()
+        @store.mas_utils.deprecated("wear_acs_in")
         def wear_acs_afh(self, acs):
             """DEPRECATED
             Wears the given accessory in the between front hair and arms
@@ -3831,7 +3831,7 @@ init -3 python:
             """
             self.wear_acs_in(acs, self.AFH_ACS)
 
-        @store.mas_utils.deprecated()
+        @store.mas_utils.deprecated("wear_acs_in")
         def wear_acs_mid(self, acs):
             """DEPRECATED
             Wears the given accessory in the mid body acessory mode
@@ -3841,7 +3841,7 @@ init -3 python:
             """
             self.wear_acs_in(acs, self.MID_ACS)
 
-        @store.mas_utils.deprecated()
+        @store.mas_utils.deprecated("wear_acs_in")
         def wear_acs_pst(self, acs):
             """DEPRECATED
             Wears the given accessory in the post body accessory mode

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -354,7 +354,7 @@ init -100 python in mas_sprites:
 
     EXP_C_C_DTS = "compat-downtiedstrand"
     # v: ignored
-    # compatibilty exprop saying that these clothes work with the 
+    # compatibilty exprop saying that these clothes work with the
     # downtiedstrand hair style
     # NOTE: THIS IS AN EXCEPTION. We should not be doing exprops like this.
 
@@ -1056,7 +1056,7 @@ init -5 python in mas_sprites:
             return allow_none
         return _verify_uprightpose(val) or _verify_leaningpose(val)
 
-
+    @store.mas_utils.deprecated(should_raise=True)
     def acs_lean_mode(sprite_list, lean):
         """
         NOTE: DEPRECATED
@@ -3790,6 +3790,7 @@ init -3 python:
                     acs_layer
                 )
 
+        @store.mas_utils.deprecated()
         def wear_acs_pre(self, acs):
             """DEPRECATED
             Wears the given accessory in the pre body accessory mode
@@ -3799,7 +3800,7 @@ init -3 python:
             """
             self.wear_acs_in(acs, self.PRE_ACS)
 
-
+        @store.mas_utils.deprecated()
         def wear_acs_bbh(self, acs):
             """DEPRECATED
             Wears the given accessory in the post back hair accessory loc
@@ -3809,7 +3810,7 @@ init -3 python:
             """
             self.wear_acs_in(acs, self.BBH_ACS)
 
-
+        @store.mas_utils.deprecated()
         def wear_acs_bfh(self, acs):
             """DEPRECATED
             Wears the given accessory in the pre front hair accesory log
@@ -3819,7 +3820,7 @@ init -3 python:
             """
             self.wear_acs_in(acs, self.BFH_ACS)
 
-
+        @store.mas_utils.deprecated()
         def wear_acs_afh(self, acs):
             """DEPRECATED
             Wears the given accessory in the between front hair and arms
@@ -3830,7 +3831,7 @@ init -3 python:
             """
             self.wear_acs_in(acs, self.AFH_ACS)
 
-
+        @store.mas_utils.deprecated()
         def wear_acs_mid(self, acs):
             """DEPRECATED
             Wears the given accessory in the mid body acessory mode
@@ -3840,7 +3841,7 @@ init -3 python:
             """
             self.wear_acs_in(acs, self.MID_ACS)
 
-
+        @store.mas_utils.deprecated()
         def wear_acs_pst(self, acs):
             """DEPRECATED
             Wears the given accessory in the post body accessory mode
@@ -5777,6 +5778,7 @@ init -3 python:
             """
             return acs.priority
 
+        @store.mas_utils.deprecated()
         def get_arm_split_code(self, poseid):
             """DEPRECATED
             NOTE: we are keeping this around for compatiblity purposes
@@ -6531,7 +6533,7 @@ init -3 python:
                 split=None,
                 ex_props=None,
                 hl_data=None,
-                mpm_mid=None 
+                mpm_mid=None
             ):
             """
             MASHair constructor

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -301,7 +301,7 @@ init 10 python:
         persistent.version_number = config.version
 
         # and clear update data
-        clearUpdateStructs()
+        mas_versions.clear()
 
     elif persistent.version_number != config.version:
         # parse this version number into something we can use
@@ -316,7 +316,7 @@ init 10 python:
         persistent.version_number = config.version
 
         # and clear update data
-        clearUpdateStructs()
+        mas_versions.clear()
 
 
     ### special function for resetting versions

--- a/Monika After Story/game/updates_topics.rpy
+++ b/Monika After Story/game/updates_topics.rpy
@@ -31,6 +31,7 @@ init -1 python in mas_db_merging:
 
 # preeerything
 init -1 python:
+    @store.mas_utils.deprecated(use_instead="mas_versions.clear", should_raise=True)
     def clearUpdateStructs():
         """DEPRECATED
         Use mas_versions.clear instead

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -1795,7 +1795,7 @@ init -10 python:
             self._sr_ss.verify()
             self._ss_mn.verify()
 
-
+    @store.mas_utils.deprecated(use_instead="MASFilterableBackground")
     def MASBackground(
             background_id,
             prompt,
@@ -2296,6 +2296,7 @@ init -10 python:
             """
             return self.getRoom(self._flt_man.current())
 
+        @store.mas_utils.deprecated(use_instead="getDayRooms", should_raise=True)
         def getDayRoom(self, weather=None):
             """DEPRECATED
             Can't use this anymore since there's no single image that defines
@@ -2345,6 +2346,7 @@ init -10 python:
                 return None
             return m_w_m.get(precip_type)
 
+        @store.mas_utils.deprecated(use_instead="getNightRooms", should_raise=True)
         def getNightRoom(self, weather=None):
             """DEPRECATED
             Can't use this anymore since there's no single image that defines
@@ -3217,7 +3219,7 @@ label monika_change_background_loop:
         skip_outro = mas_background.EXP_SKIP_OUTRO in sel_background.ex_props
 
     # UI shields + buttons
-    # NOTE: buttons are in here since there is no consistency if placed in 
+    # NOTE: buttons are in here since there is no consistency if placed in
     # the bg change label.
     $ mas_RaiseShield_core()
     $ HKBHideButtons()

--- a/Monika After Story/game/zz_calendar.rpy
+++ b/Monika After Story/game/zz_calendar.rpy
@@ -1081,6 +1081,7 @@ init -1 python in mas_calendar:
     import datetime
     import json
     import renpy
+    import store
 
     ### Calendar database stores events for repeating / processing and more.
     #
@@ -1156,7 +1157,7 @@ init -1 python in mas_calendar:
 
         return str(years) + " years ago"
 
-
+    @store.mas_utils.deprecated(use_instead="genFriendlyDispDate_d")
     def genFriendlyDispDate(_datetime):
         """
         NOTE: DEPRECATED

--- a/Monika After Story/game/zz_selector.rpy
+++ b/Monika After Story/game/zz_selector.rpy
@@ -1589,7 +1589,7 @@ init -10 python in mas_selspr:
         """
         _unlock_item(hair, SELECT_HAIR)
 
-
+    @store.mas_utils.deprecated(use_instead="unlock_prompt", should_raise=True)
     def unlock_selector(group):
         """DEPRECATED - Use unlock_prompt instead
         Unlocks the selector of the given group.

--- a/Monika After Story/game/zz_weather.rpy
+++ b/Monika After Story/game/zz_weather.rpy
@@ -476,7 +476,7 @@ init -20 python in mas_weather:
 
 
 init -10 python:
-
+    @store.mas_utils.deprecated(use_instead="MASFilterableWeather")
     def MASWeather(
             weather_id,
             prompt,
@@ -674,6 +674,7 @@ init -10 python:
             """
             self.unlocked = data_tuple[0]
 
+        @store.mas_utils.deprecated(use_instead="get_mask", should_raise=True)
         def sp_window(self, day):
             """DEPRECATED
             Use get_mask instead.
@@ -681,6 +682,7 @@ init -10 python:
             """
             return self.get_mask()
 
+        @store.mas_utils.deprecated(should_raise=True)
         def isbg_window(self, day, no_frame):
             """DEPRECATED
             Islands are now separate images. See script-islands-event.


### PR DESCRIPTION
Now we have a proper way to deprecate functions/classes

### Changes:
- added `mas_utils.deprecated`. Accepts 2 parameters: `use_instead` - the name of the new function to use, `should_raise` - boolean whether or not we should raise a deprecation warning.
- added the new decorator to deprecated functions and classes in our code.

### Testing:
- verify we log/raise deprecation warnings for all our deprecated functions and classes.
- **verify we don't raise exceptions for the things still in use.** I checked that, but just in case.
- verify we provide the new alternatives where it's possible (via `use_instead`).