### PR TITLE
Piano fixes

### DIFF
--- a/Monika After Story/game/zz_pianokeys.rpy
+++ b/Monika After Story/game/zz_pianokeys.rpy
@@ -186,7 +186,6 @@ label mas_piano_setupstart:
     $ enable_esc()
     $ mas_startup_song()
     $ pnmlSaveTuples()
-    $ del piano_displayable_obj
 
     show monika 1hua at t11
 

--- a/Monika After Story/game/zz_pianokeys.rpy
+++ b/Monika After Story/game/zz_pianokeys.rpy
@@ -134,7 +134,7 @@ label mas_piano_songchoice:
                 $ pnml = _return
 
                 # song selected
-                if pnml is not None:
+                if pnml:
 
                     # reaction in picking a song
                     m 1hua "I'm so excited to hear you play, [player]!"
@@ -1976,7 +1976,7 @@ init 800 python in mas_piano_keys:
             if (pnml.name not in STOCK_SONG_NAMES or pnml.wins > 0)
         ]
 
-        last_item = ("Nevermind", None, False, False, 10)
+        last_item = ("Nevermind", False, False, False, 10)
 
         return song_list, last_item
 

--- a/Monika After Story/game/zz_pianokeys.rpy
+++ b/Monika After Story/game/zz_pianokeys.rpy
@@ -126,7 +126,7 @@ label mas_piano_songchoice:
         menu:
             m "Did you want to play a song or play on your own, [player]?{fast}"
             "Play a song.":
-                m "Which song?" nointeract
+                m "Which song would you like to play?" nointeract
                 show monika at t21
                 call screen mas_gen_scrollable_menu(song_list, mas_piano_keys.MENU_AREA, mas_piano_keys.MENU_XALIGN, final_item)
                 show monika at t11
@@ -368,7 +368,7 @@ label mas_piano_yr_fail:
 label mas_piano_yr_prac:
     m 1hua "That was really cool, [player]!"
     m 3eua "With some more practice, you'll be able to play my song perfectly."
-    m 1eka "Make sure to practice everyday for me, okay?~"
+    m 1eka "Make sure to practice every day for me, okay?~"
     return
 
 


### PR DESCRIPTION
When we added dynamic sprite generation, we got an issue with piano. Since we generate those on the fly, there might be quite noticeable lag during the game, nonideal. Also @multimokia suggested that the player should be able to select songs from the get go w/o the need play them first, but as discussed, we do that only for custom songs.

### Changes:
 - We generate sprites before starting the game
    - For the free mode we generate sprites for all available songs*
    - For the song mode we generate sprites only for the current song*
    - We always generate the default sprites (like for when you miss a note)*
 - Custom songs are available for selection from the start

*unless those are already in the cache.

### Bug fixes:
 - Fixed the dlg which didn't autoprogress to the menu
 - Replaced `"None"` with `False`

### Testing:
 - Verify piano still works
 - Verify piano doesn't lag when you play a song for the first time in sesh
 - Verify you can select custom songs from the menu w/o having to play them first
