### PR TITLE
Persistent analysis module + progression data dump

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -360,6 +360,30 @@ python early:
         def __str__(self):
             return self.msg
 
+
+    # event data class - use for data grouping - no behaviors allowed
+    class EventDBData(object):
+        """
+        Speciality class that can hold data from data tuples (events)
+        Read-only (for now)
+        """
+
+        def __init__(self, data_tup):
+            """
+            IN:
+                data_tup - the data to store
+            """
+            self.data_tup = data_tup
+
+        def __getattr__(self, name):
+            attr_loc = Event.T_EVENT_NAMES.get(name, None)
+
+            if attr_loc:
+                return self.data_tup[attr_loc]
+
+            return None
+
+
     # event class for chatbot replacement
     # NOTE: effectively a wrapper for dict of tuples
     # NOTE: Events are TIED to the database they are found in. Moving databases

--- a/Monika After Story/game/zz_dump.rpy
+++ b/Monika After Story/game/zz_dump.rpy
@@ -32,15 +32,19 @@ init 999 python:
             # setup lines
             _ev_finalstatline = (
                 "\n---ST ({12}) ---\n" +
-                "EV:{0}\n" +
-                "PC:{1}\n" +
-                "RC:{2}\n" +
-                "UC:{3}\n" +
-                "LC:{4}\n" +
-                "SC:{5}\n" +
-                "SSC:{6} - AVG:{7}\n" +
-                "PSC:{8} - AVG:{9}\n" +
-                "RSC:{10} - AVG:{11}\n"
+                "EV:{0}\n" + # total events
+                "PC:{1}\n" + # number of pool events
+                "PUC:{12}\n" + # number of unlocked pools
+                "PLC:{13}\n" + # number of locked pools
+                "RC:{2}\n" + # number of random events
+                "RUC:{14}\n" + # number of unlokced randoms
+                "RLC:{15}\n" + # number of locked randoms
+                "UC:{3}\n" + # number of unlocked events
+                "LC:{4}\n" + # number of locked events
+                "SC:{5}\n" + # number of seen events
+                "SSC:{6} - AVG:{7}\n" + # number of shown events - avg
+                "PSC:{8} - AVG:{9}\n" + # number of pool showns - avg
+                "RSC:{10} - AVG:{11}\n" # number of random showns - avg
             )
             _ev_statline = "{0} - p:{1} - r:{2} - u:{3} - s:{4} - sc:{5}\n"
 
@@ -53,7 +57,11 @@ init 999 python:
                 """
                 self.ev_count = 0
                 self.pool_count = 0
+                self.pool_unlo_count = 0
+                self.pool_lock_count = 0
                 self.rand_count = 0
+                self.rand_unlo_count = 0
+                self.rand_lock_count = 0
                 self.unlo_count = 0
                 self.lock_count = 0
                 self.seen_count = 0
@@ -126,9 +134,19 @@ init 999 python:
                     self.pool_count += 1
                     self.pshow_count += ev.shown_count
 
+                    if ev.unlocked:
+                        self.pool_unlo_count += 1
+                    else:
+                        self.pool_lock_count += 1
+
                 if ev.random:
                     self.rand_count += 1
                     self.rshow_count += ev.shown_count
+
+                    if ev.unlocked:
+                        self.rand_unlo_count += 1
+                    else:
+                        self.rand_lock_count += 1
 
                 if ev.unlocked:
                     self.unlo_count += 1
@@ -161,7 +179,11 @@ init 999 python:
                         psc_avg,
                         self.rshow_count,
                         rsc_avg,
-                        self.name
+                        self.name,
+                        self.pool_unlo_count,
+                        self.pool_lock_count,
+                        self.rand_unlo_count,
+                        self.rand_lock_count,
                     ) + "\n[MOST]: " +
                     self._ev_statline.format(
                         self.most_seen_ev.eventlabel,
@@ -207,6 +229,8 @@ init 999 python:
 
             _ev_stats_file.write(config.version + "\n\n")
             _ev_stats_file.write(mas_sessionDataDump())
+            _ev_stats_file.write("\n\n")
+            _ev_stats_file.write(mas_progressionDataDump())
 
             # gather data
             for ev in mas_all_ev_db.values():
@@ -239,6 +263,25 @@ init 999 python:
         mas_eventDataDump()
         mas_varDataDump()
 
+    def mas_progressionDataDump():
+        """
+        Dumps progression data as a string
+        """
+        return (
+            "Last XP rate reset: {0}\n"
+            "Hours spent today: {1}\n"
+            "XP to next level: {2}\n"
+            "Current level: {3}\n"
+            "Current xp rate: {4}\n"
+            "XP last granted: {5}\n"
+        ).format(
+            persistent._mas_xp_rst,
+            persistent._mas_xp_hrx,
+            persistent._mas_xp_tnl,
+            persistent._mas_xp_lvl,
+            mas_xp.xp_rate,
+            mas_xp.prev_grant,
+        )
 
     def mas_sessionDataDump():
         """

--- a/Monika After Story/game/zz_dump.rpy
+++ b/Monika After Story/game/zz_dump.rpy
@@ -34,11 +34,11 @@ init 999 python:
                 "\n---ST ({12}) ---\n" +
                 "EV:{0}\n" + # total events
                 "PC:{1}\n" + # number of pool events
-                "PUC:{12}\n" + # number of unlocked pools
-                "PLC:{13}\n" + # number of locked pools
+                "PUC:{13}\n" + # number of unlocked pools
+                "PLC:{14}\n" + # number of locked pools
                 "RC:{2}\n" + # number of random events
-                "RUC:{14}\n" + # number of unlokced randoms
-                "RLC:{15}\n" + # number of locked randoms
+                "RUC:{15}\n" + # number of unlokced randoms
+                "RLC:{16}\n" + # number of locked randoms
                 "UC:{3}\n" + # number of unlocked events
                 "LC:{4}\n" + # number of locked events
                 "SC:{5}\n" + # number of seen events

--- a/Monika After Story/game/zz_dump.rpy
+++ b/Monika After Story/game/zz_dump.rpy
@@ -229,7 +229,6 @@ init 999 python:
 
             _ev_stats_file.write(config.version + "\n\n")
             _ev_stats_file.write(mas_sessionDataDump())
-            _ev_stats_file.write("\n\n")
             _ev_stats_file.write(mas_progressionDataDump())
 
             # gather data
@@ -273,7 +272,7 @@ init 999 python:
             "XP to next level: {2}\n"
             "Current level: {3}\n"
             "Current xp rate: {4}\n"
-            "XP last granted: {5}\n"
+            "XP last granted: {5}\n\n"
         ).format(
             persistent._mas_xp_rst,
             persistent._mas_xp_hrx,


### PR DESCRIPTION
# Key Changes
* Adds a new class for helping analyze persistents `MASPersistentAnalyzer`
    * it basically indexes persistent data by value and property, so you can run searches on persistent data (including external user data if the persistent is dropped in characters). 
    * For some examples, see the `report_on_unlocked_pools` and `report_on_unlocked_randoms` - used to determine if the unlocking mechanism was glitching for a user.
* Adds progression info to the data dumps `mas_progressionDataDump`
* Adds unlocked/locked counts for pool and random topics in the data dump

# Testing
* No testing for the analyzer debug tool - unless you want to try it. I recommend running `dev_mas_shared.MASPersistentAnalyzer.analyze_and_report` to get all the event data in separate files.
* Verify that progression info is dumped in the `ev_dumps.log`
* Verify that unlocked/locked counts for pool and random topics are in the topic summary in `ev_dumps.log`. (This is after the giant list of topics).