### PR TITLE
Adjust screen props for r7.4

### DIFF
--- a/Monika After Story/game/zz_poemgame.rpy
+++ b/Monika After Story/game/zz_poemgame.rpy
@@ -377,9 +377,11 @@ init -2 python in mas_poemgame_fun:
 #       (Default: None - 0)
 #   _style_prefix - style prefix to use for this screen
 #       (Default: None)
-#   _layer - layer to show this screen on
-#       (Default: None)
+#   _layer - IGNORED - no longer in use - just specify layer when u call the screen
 screen mas_pg_textbutton_grid(words, row_info, col_info, xywh, bg_image=None, is_modal=False, _zorder=None, _style_prefix=None, _layer=None):
+    modal is_modal
+    zorder _zorder
+    style_prefix _style_prefix
 
     # precalc setup for rows/cols
     python:
@@ -389,16 +391,6 @@ screen mas_pg_textbutton_grid(words, row_info, col_info, xywh, bg_image=None, is
             row_spacing = int(xywh[3] / row_info[0])
         if col_spacing is None:
             col_spacing = int(xywh[2] / col_info[0])
-
-    # start with screen props
-    if is_modal:
-        modal True
-    if _zorder:
-        zorder _zorder
-    if _style_prefix:
-        style_prefix _style_prefix
-    if _layer:
-        layer _layer
 
     # fixed area
     fixed:


### PR DESCRIPTION
Adjusts screen props in the poemgame textbutton grid screen so they organized in line with renpy 7.4's stricter screen requirements.

**NOTE:** I'm making this pull req for r6, so we avoid having a codebase that differs too much between versions. Generally speaking, this should be the way forward with r7 changes that we can backport to current without causing issues.

# Key Change
* the key props `modal`, `zorder`, and `style_prefix` are now always set in the screen instead of conditionally set
* the screen prop `layer` has been removed since it requires a string layer and cannot be variablized - this is not a big deal since you can specify the layer when showing/calling a screen.

# Testing
* 7.4 is where this is actually a problem, so just verify in r6 that this does not crash