### PR TITLE
Update checkbox UI to be the fancy type

### DIFF
--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -1750,7 +1750,7 @@ screen notif_settings():
         default tooltip = Tooltip("")
 
         vbox:
-            style_prefix "check"
+            style_prefix "generic_fancy_check"
             hbox:
                 spacing 25
                 textbutton _("Use Notifications"):
@@ -1766,7 +1766,7 @@ screen notif_settings():
             label _("Alert Filters")
 
         hbox:
-            style_prefix "check"
+            style_prefix "generic_fancy_check"
             box_wrap True
             spacing 25
 

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -1350,7 +1350,7 @@ screen preferences():
                 if renpy.variant("pc"):
 
                     vbox:
-                        style_prefix "radio"
+                        style_prefix "generic_fancy_check"
                         label _("Display")
                         textbutton _("Window") action Preference("display", "window")
                         textbutton _("Fullscreen") action Preference("display", "fullscreen")
@@ -1364,7 +1364,7 @@ screen preferences():
 
                 #Disable/Enable space animation AND lens flair in room
                 vbox:
-                    style_prefix "check"
+                    style_prefix "generic_fancy_check"
                     label _("Graphics")
                     textbutton _("Disable Animation") action ToggleField(persistent, "_mas_disable_animations")
                     textbutton _("Change Renderer") action Function(renpy.call_in_new_context, "mas_gmenu_start")
@@ -1379,7 +1379,7 @@ screen preferences():
 
 
                 vbox:
-                    style_prefix "check"
+                    style_prefix "generic_fancy_check"
                     label _("Gameplay")
                     if not main_menu:
                         if persistent._mas_unstable_mode:
@@ -1400,7 +1400,7 @@ screen preferences():
                 ## Additional vboxes of type "radio_pref" or "check_pref" can be
                 ## added here, to add additional creator-defined preferences.
                 vbox:
-                    style_prefix "check"
+                    style_prefix "generic_fancy_check"
                     label _(" ")
 #                    textbutton _("Sensitive Mode"):
 #                        action ToggleField(persistent, "_mas_sensitive_mode", True, False)

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -1366,8 +1366,13 @@ screen preferences():
                 vbox:
                     style_prefix "generic_fancy_check"
                     label _("Graphics")
+
+                    # this is a normal button
+                    textbutton _("Change Renderer"):
+                        style "check_button"
+                        action Function(renpy.call_in_new_context, "mas_gmenu_start")
+
                     textbutton _("Disable Animation") action ToggleField(persistent, "_mas_disable_animations")
-                    textbutton _("Change Renderer") action Function(renpy.call_in_new_context, "mas_gmenu_start")
 
                     #Handle buttons
                     textbutton _("UI: Night Mode"):
@@ -1565,8 +1570,8 @@ screen preferences():
                         null height gui.pref_spacing
 
                         textbutton _("Mute All"):
+                            style "generic_fancy_check_button"
                             action Preference("all mute", "toggle")
-                            style "mute_all_button"
 
 
             hbox:

--- a/Monika After Story/game/styles.rpy
+++ b/Monika After Story/game/styles.rpy
@@ -299,13 +299,13 @@ style generic_button_text_dark is generic_button_text_base:
 style generic_fancy_check_button:
     properties gui.button_properties("check_button")
     foreground "mod_assets/buttons/checkbox/[prefix_]fancy_check.png"
-    hover_background Solid("#FFBDE1")
+    hover_background Solid("#ffe6f4")
     selected_background Solid("#FFBDE1")
 
 style generic_fancy_check_button_dark:
     properties gui.button_properties("check_button_dark")
     foreground "mod_assets/buttons/checkbox/[prefix_]fancy_check.png"
-    hover_background Solid("#CE4A7E")
+    hover_background Solid("#d9739c")
     selected_background Solid("#CE4A7E")
 
 style generic_fancy_check_button_text is gui_button_text:

--- a/Monika After Story/game/styles.rpy
+++ b/Monika After Story/game/styles.rpy
@@ -294,17 +294,22 @@ style generic_button_text_dark is generic_button_text_base:
     hover_color mas_ui.dark_button_text_hover_color
     insensitive_color mas_ui.dark_button_text_insensitive_color
 
+image generic_fancy_check_button_fg = Image("mod_assets/buttons/checkbox/fancy_check.png", yoffset=4)
+image generic_fancy_check_button_fg_selected = Image("mod_assets/buttons/checkbox/selected_fancy_check.png", yoffset=4)
+
 # fancy checkbox buttons lose the box when selected
 # and the entire frame gets colored
 style generic_fancy_check_button:
     properties gui.button_properties("check_button")
-    foreground "mod_assets/buttons/checkbox/[prefix_]fancy_check.png"
+    foreground "generic_fancy_check_button_fg"
+    selected_foreground "generic_fancy_check_button_fg_selected"
     hover_background Solid("#ffe6f4")
     selected_background Solid("#FFBDE1")
 
 style generic_fancy_check_button_dark:
     properties gui.button_properties("check_button_dark")
-    foreground "mod_assets/buttons/checkbox/[prefix_]fancy_check.png"
+    foreground "generic_fancy_check_button_fg"
+    selected_foreground "generic_fancy_check_button_fg_selected"
     hover_background Solid("#d9739c")
     selected_background Solid("#CE4A7E")
 
@@ -315,6 +320,7 @@ style generic_fancy_check_button_text is gui_button_text:
     hover_color "#000000"
     selected_color "#000000"
     outlines []
+    yoffset 3
 
 style generic_fancy_check_button_text_dark is gui_button_text_dark:
     properties gui.button_text_properties("generic_fancy_check_button_dark")
@@ -323,6 +329,7 @@ style generic_fancy_check_button_text_dark is gui_button_text_dark:
     hover_color "#FFAA99"
     selected_color "#FFAA99"
     outlines []
+    yoffset 3
 
 # START: image definitions
 image menu_bg:


### PR DESCRIPTION
closes #6262

# Key Changes
* Changes the checkbox UI in the settings screen so it uses the fancy, more user-friendly UI
* The `Change Renderer` option is moved up so it doesnt awkwardly break the checkbox line
* checkboxes are now centered with text

# Testing
* verify the UI looks good in the settings menu
* `Change Renderer` launches a menu, so it's not actually a toggle - it should not have the checkbox UI.