### PR TITLE
92221 fixes

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -962,8 +962,6 @@ label spaceroom(start_bg=None, hide_mask=None, hide_monika=False, dissolve_all=F
     if persistent._mas_bday_visuals:
         #We only want cake on a non-reacted sbp (i.e. returning home with MAS open)
         $ store.mas_surpriseBdayShowVisuals(cake=not persistent._mas_bday_sbp_reacted)
-    else:
-        $ store.mas_surpriseBdayHideVisuals(cake=True)
 
     # ----------- Grouping date-based events since they can never overlap:
     #O31 stuff
@@ -977,7 +975,9 @@ label spaceroom(start_bg=None, hide_mask=None, hide_monika=False, dissolve_all=F
     # TODO: move this to bday autoload
     if persistent._mas_player_bday_decor:
         $ store.mas_surpriseBdayShowVisuals()
-    else:
+
+    # both 922 and pbday share the same visual funcs, so need to check both before hiding
+    if not persistent._mas_bday_visuals and not persistent._mas_player_bday_decor:
         $ store.mas_surpriseBdayHideVisuals(cake=True)
 
     if datetime.date.today() == persistent._date_last_given_roses:

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -6888,11 +6888,11 @@ label mas_bday_surprise_party_reacton_cake:
     show screen mas_background_timed_jump(5, "mas_bday_surprise_party_reaction_no_make_wish")
     menu:
         "Make a wish, [m_name]...":
+            hide screen mas_background_timed_jump
             $ made_wish = True
             show monika 6hua
             if mas_isplayer_bday():
                 m "Make sure you make one too, [player]!"
-            hide screen mas_background_timed_jump
             #+10 for wishes
             $ mas_gainAffection(10, bypass=True)
             pause 2.0
@@ -6900,8 +6900,8 @@ label mas_bday_surprise_party_reacton_cake:
             jump mas_bday_surprise_party_reaction_post_make_wish
 
 label mas_bday_surprise_party_reaction_no_make_wish:
-    $ made_wish = False
     hide screen mas_background_timed_jump
+    $ made_wish = False
     show monika 6dsc
     pause 2.0
     show monika 6hft

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -6907,6 +6907,7 @@ label mas_bday_surprise_party_reaction_no_make_wish:
     show monika 6hft
 
 label mas_bday_surprise_party_reaction_post_make_wish:
+    pause 0.1
     $ mas_bday_cake_lit = False
     window auto
     if mas_isMoniNormal(higher=True):


### PR DESCRIPTION
This PR is going to be a catchall for any 922 related stuff that needs to be addressed. Please update the description as stuff is added

## Fixes

- no pause after the candle blowout animation causing it to not show
- 922 decor disappearing at any spaceroom call due to 922 and pbday sharing the same decor funcs. the pbday check in spaceroom would nuke the 922 decor provided it wasn't also pbday. the 922 check could also nuke pbday decor, which would then be readded by the pbday check, but this was not optimal so instead we can add a separate if statement to check for both bday scenarios before nuking decor