### PR TITLE
Fix for followed sprites

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -5465,6 +5465,15 @@ init -985 python:
         """
         return store.mas_globals.tt_detected
 
+    def mas_getWindowTitle():
+        """
+        Returns current windows title set by RenPy
+
+        OUT:
+            str
+        """
+        return renpy.game.interface.window_caption
+
 init -101 python:
     def is_file_present(filename):
         """DEPRECIATED

--- a/Monika After Story/game/options.rpy
+++ b/Monika After Story/game/options.rpy
@@ -12,6 +12,9 @@ init -999:
     ##
     ## The _() surrounding the string marks it as eligible for translation.
     define config.name = "Monika After Story"
+    # Add an invisible 0-width char to the title so we know it's unique
+    define config.menu_window_subtitle = "\u200b"
+    define _window_subtitle = "\u200b"
 
     ## The version of the game.
     define config.version = "0.12.2.4"

--- a/Monika After Story/game/zz_windowutils.rpy
+++ b/Monika After Story/game/zz_windowutils.rpy
@@ -177,8 +177,7 @@ init python in mas_windowutils:
                 transient_for = win.get_wm_transient_for()
                 winname = win.get_wm_name()
 
-                #NOTE: This must be config.name as we call this during init time, where config.name is None
-                if transient_for is None and winname and renpy.config.window_title == winname:
+                if transient_for is None and winname and store.mas_getWindowTitle() == winname:
                     return win
 
         except BadWindow:
@@ -201,7 +200,7 @@ init python in mas_windowutils:
             """
             Internal function to identify the MAS window. Raises an exception when found to allow the main func to return
             """
-            if renpy.config.window_title == win32gui.GetWindowText(hwnd):
+            if store.mas_getWindowTitle() == win32gui.GetWindowText(hwnd):
                 raise MASWindowFoundException(hwnd)
 
         try:
@@ -666,7 +665,7 @@ init python:
         Checks if MAS is the focused window
         """
         #TODO: Mac vers (if possible)
-        return store.mas_windowreacts.can_show_notifs and mas_getActiveWindowHandle() == config.window_title
+        return store.mas_windowreacts.can_show_notifs and mas_getActiveWindowHandle() == store.mas_getWindowTitle()
 
     def mas_isInActiveWindow(regexp, active_window_handle=None):
         """


### PR DESCRIPTION
Fixes #7050, this time for real!

### Changes:
- implemented `mas_getWindowTitle`, returns current title set by RenPy Including all possible prefixes/suffixes it adds
- `_window_subtitle` and `config.menu_window_subtitle` are set to a 0-width char to make the title more unique as an attempt to remove false-positives