### PR TITLE
Dont apply outfit mode on selector launch

### DIFF
--- a/Monika After Story/game/zz_selector.rpy
+++ b/Monika After Story/game/zz_selector.rpy
@@ -3489,14 +3489,6 @@ label mas_selector_sidebar_select(items, select_type, preview_selections=True, o
             store.mas_selspr.SB_VIEWPORT_BOUNDS_BS
         )
 
-        # if in outfit mode, apply the outfit before launching
-        if mailbox.read_outfit_checkbox_checked():
-            monika_chr.change_clothes(
-                monika_chr.clothes,
-                by_user=True,
-                outfit_mode=True
-            )
-
     # sanity check to avoid crashes
     if len(items) < 1:
         return False


### PR DESCRIPTION
closes #7962 

# Key Changes
* clothing no longer changes to the exact outfit when opening clothes selector with outfit mode on

# Testing
1. Ensure outfit mode is selected.
2. Change clothes to one that has an outfit (like school uniform) and change an aspect of it so it no longer matches outfit mode. For example, change the hair style of the school uniform so it is not ponytail.
3. Open the clothes selector
4. Verify that no ACS/hair/etc changes when the selector is opened.
