### PR TITLE
Update old links in README and FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -62,7 +62,7 @@ If the traceback includes a line like the following:
 The label chara_monika_scare is defined twice, at
 ```
 
-Then it is likely that developer files have been installed, instead of the release distribution. Ensure that the game files downloaded were from the latest release, found on our [Release Page](https://github.com/Backdash/MonikaModDev/releases), and that the file downloaded was the mod zip file and *not* the Source Code.
+Then it is likely that developer files have been installed, instead of the release distribution. Ensure that the game files downloaded were from the latest release, found on our [Release Page](https://github.com/Monika-After-Story/MonikaModDev/releases), and that the file downloaded was the mod zip file and *not* the Source Code.
 
 ### Where are the minigames (chess, hangman, piano...)?
 
@@ -73,7 +73,7 @@ topics with her or keeping her running in the background.
 
 ### I have an idea on how to improve Monika After Story, where do I suggest it?
 
-We're always happy to hear new ideas! Suggestions can be made on our issues page. Please preface all suggestions with [Suggestion], or follow [this link](https://github.com/Backdash/MonikaModDev/issues/new?labels=suggestion&body=Your%20suggestion%20goes%20here&title=%5BSuggestion%5D%20-%20) which will automatically populate your suggestion with the appropriate tags.
+We're always happy to hear new ideas! Suggestions can be made on our issues page. Please preface all suggestions with [Suggestion], or follow [this link](https://github.com/Monika-After-Story/MonikaModDev/issues/new?labels=suggestion&body=Your%20suggestion%20goes%20here&title=%5BSuggestion%5D%20-%20) which will automatically populate your suggestion with the appropriate tags.
 
 ### I would like to contribute, but I don't know how to code. Is there any way I can help?
 
@@ -81,7 +81,7 @@ We are always looking for new dialogue and art. Please see our [Contributing Gui
 
 ### Where can I find things to help with?
 
-Our issues page will show a list of technical issues, new features, and requests that are available. Anything with the [Help Wanted](https://github.com/Backdash/MonikaModDev/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) tag is a good place to start if you would like to help add something to the game!
+Our issues page will show a list of technical issues, new features, and requests that are available. Anything with the [Help Wanted](https://github.com/Monika-After-Story/MonikaModDev/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) tag is a good place to start if you would like to help add something to the game!
 
 ### How can I get in touch with the development staff?
 
@@ -145,4 +145,4 @@ To add the Sprite Previewer to your MAS, copy [this file](https://github.com/Mon
 
 ## Other help
 
-Don't see the answer that you're looking for here? Please [create an issue](https://github.com/Backdash/MonikaModDev/issues) to ask a tech-support question or file a bug report. You can also get help from members of our community on the [tech-support channel on discord](https://discordapp.com/invite/K2KuJeX).
+Don't see the answer that you're looking for here? Please [create an issue](https://github.com/Monika-After-Story/MonikaModDev/issues) to ask a tech-support question or file a bug report. You can also get help from members of our community on the [tech-support channel on discord](https://discordapp.com/invite/K2KuJeX).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Monika After Story](https://github.com/Backdash/MonikaModDev/blob/master/Monika%20After%20Story/game/mod_assets/menu_new.png?raw=True)
+![Monika After Story](https://github.com/Monika-After-Story/MonikaModDev/blob/master/Monika%20After%20Story/game/mod_assets/menu_new.png?raw=True)
 
 # Monika After Story (MAS)
 Monika After Story is a mod for the free game [Doki Doki Literature Club](https://www.ddlc.moe) from [Team Salvato](http://teamsalvato.com/). MAS builds on Act 3 to create a simulator of your eternal life with Monika, featuring new events, handlers, and metacommentary!
@@ -19,7 +19,7 @@ Video tutorial on install MAS: https://youtu.be/eH5Q4Xdlg6Y
 
 * Running DDLC will now load the Monika After Story Mod.
 
-*NOTE: Source files and files downloaded directed from the repository are for development purposes and may not behave as expected if used to mod the game. Please only use one of our [Release Versions](https://github.com/Backdash/MonikaModDev/releases).*
+*NOTE: Source files and files downloaded directed from the repository are for development purposes and may not behave as expected if used to mod the game. Please only use one of our [Release Versions](https://github.com/Monika-After-Story/MonikaModDev/releases).*
 
 For more help with installation, please see our [Frequently Asked Questions](https://github.com/Monika-After-Story/MonikaModDev/wiki/FAQ)
 
@@ -41,14 +41,14 @@ For more help with installation, please see our [Frequently Asked Questions](htt
 ## Contributing to Monika After Story
 
 ### Bugs & Suggestions
-If there are issues with MAS, please file a [bug report](https://github.com/Backdash/MonikaModDev/issues/new?labels=bug&body=Describe%20bug%20and%20steps%20for%20reproduction%20here&title=%5BBug%5D%20-%20).
+If there are issues with MAS, please file a [bug report](https://github.com/Monika-After-Story/MonikaModDev/issues/new?labels=bug&body=Describe%20bug%20and%20steps%20for%20reproduction%20here&title=%5BBug%5D%20-%20).
 
-To add a suggestion, visit [this link](https://github.com/Backdash/MonikaModDev/issues/new?labels=suggestion&body=Your%20suggestion%20goes%20here&title=%5BSuggestion%5D%20-%20)
+To add a suggestion, visit [this link](https://github.com/Monika-After-Story/MonikaModDev/issues/new?labels=suggestion&body=Your%20suggestion%20goes%20here&title=%5BSuggestion%5D%20-%20)
 
  ### Other Help
- Want to help with MAS? Navigate to the [issues page](https://github.com/Backdash/MonikaModDev/issues) to find current bugs or suggestions to work on.
+ Want to help with MAS? Navigate to the [issues page](https://github.com/Monika-After-Story/MonikaModDev/issues) to find current bugs or suggestions to work on.
 
-If you have a change you'd like to submit, open a [pull request](https://github.com/Backdash/MonikaModDev/pulls). Any changes made will be reviewed by contributors & fixed/added on to as needed.
+If you have a change you'd like to submit, open a [pull request](https://github.com/Monika-After-Story/MonikaModDev/pulls). Any changes made will be reviewed by contributors & fixed/added on to as needed.
 
 #### Adding Content
 Want to add some content to MAS? Here's a list of important .RPY files the game uses.
@@ -92,12 +92,12 @@ For things more complicated than simple dialogue, consult the Ren'Py documentati
 [More info is available in our Contributing Guide](https://github.com/Monika-After-Story/MonikaModDev/wiki/Contributing-Guidelines)
 
  ### Join the conversation
-You can [follow us on twitter](https://twitter.com/MonikaAfterMod) for game updates. 
+You can [follow us on twitter](https://twitter.com/MonikaAfterMod) for game updates.
 
 Or if you're more Discord-ly inclined, for a constant stream of our favorite Monika-related content from around the web, and if you're interested in contributing to/building this mod, feel free to join our discord server:
- 
+
  [![Discord](https://discordapp.com/api/guilds/372766620977725441/widget.png?style=banner1)](https://discord.gg/K2KuJeX)
- 
+
  Please be sure to follow our [Code of Conduct](https://github.com/Monika-After-Story/MonikaModDev/wiki/Code-of-Conduct), which is essentially to be courteous and respectful.
 
 ## Frequently Asked Questions

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ You can [follow us on twitter](https://twitter.com/MonikaAfterMod) for game upda
 
 Or if you're more Discord-ly inclined, for a constant stream of our favorite Monika-related content from around the web, and if you're interested in contributing to/building this mod, feel free to join our discord server:
 
- [![Discord](https://discordapp.com/api/guilds/372766620977725441/widget.png?style=banner1)](https://discord.gg/K2KuJeX)
+ [![Discord](https://discordapp.com/api/guilds/372766620977725441/widget.png?style=banner1)](https://discord.gg/monika-after-story)
 
  Please be sure to follow our [Code of Conduct](https://github.com/Monika-After-Story/MonikaModDev/wiki/Code-of-Conduct), which is essentially to be courteous and respectful.
 


### PR DESCRIPTION
These are working *perfectly fine* thanks to GitHub redirects being active, but these will be invalid when a new repository is created at their path... Thought I'd fix this.