### PR TITLE
Remove zero width char

### DIFF
--- a/Monika After Story/game/0config.rpy
+++ b/Monika After Story/game/0config.rpy
@@ -16,8 +16,8 @@ python early:
     ## The version of the game.
     renpy.config.version = "0.12.3"
 
-    # NOTE: This is an undocumented internal renpy variable
-    _window_subtitle = "\u200b"
+    #Triple space suffix to avoid potential issues with same names in window title
+    config.window_title = "Monika After Story   "
 
     ## Save directory ##############################################################
     ##
@@ -124,6 +124,3 @@ define config.main_menu_music = audio.t1
 
 define config.window_show_transition = dissolve_textbox
 define config.window_hide_transition = dissolve_textbox
-
-# Add an invisible 0-width char to the title so we know it's unique
-define config.menu_window_subtitle = "\u200b"


### PR DESCRIPTION
The zero width chars caused significant lag on some systems for an unknown reason, but were necessary for window detection to make sure finding the MAS window is accurate on windows.

As such this PR compromises by removing them and applies 3 spaces to the end of the window title to ideally be able to properly identify the MAS window.

## Testing:
- Verify no lag
- Verify window detection still works on Windows