### PR TITLE
O31 bug fixes

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -57,10 +57,10 @@ init -1 python in mas_globals:
     # True means show lightning, False means do not
 
     lightning_chance = 16
-    lightning_s_chance = 10
+    sayori_lightning_chance = 10
     # lightning chances
 
-    show_s_light = False
+    show_sayori_lightning = False
     # set to True to show s easter egg.
 
     text_speed_enabled = False
@@ -1526,16 +1526,16 @@ label ch30_post_mid_loop_eval:
 
         # Thunder / lightning if enabled
         if (
-                store.mas_globals.show_lightning
-                and renpy.random.randint(1, store.mas_globals.lightning_chance) == 1
-            ):
+            store.mas_globals.show_lightning
+            and renpy.random.randint(1, store.mas_globals.lightning_chance) == 1
+        ):
             $ light_zorder = MAS_BACKGROUND_Z - 1
             if (
-                    store.mas_globals.show_s_light
-                    and renpy.random.randint(
-                        1, store.mas_globals.lightning_s_chance
-                    ) == 1
-                ):
+                store.mas_globals.show_sayori_lightning
+                and persistent._mas_pm_cares_about_dokis
+                and mas_current_background.background_id == store.mas_background.MBG_DEF
+                and renpy.random.randint(1, store.mas_globals.sayori_lightning_chance) == 1
+            ):
                 $ renpy.show("mas_lightning_s", zorder=light_zorder)
             else:
                 $ renpy.show("mas_lightning", zorder=light_zorder)
@@ -1814,8 +1814,8 @@ label ch30_reset:
 
     python:
         # name eggs
-        if mas_egg_manager.sayori_enabled() or (mas_isO31() and not persistent._mas_pm_cares_about_dokis):
-            store.mas_globals.show_s_light = True
+        if mas_egg_manager.sayori_enabled() or mas_isO31():
+            store.mas_globals.show_sayori_lightning = True
 
     python:
         # apply ACS defaults

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1532,7 +1532,7 @@ label ch30_post_mid_loop_eval:
             $ light_zorder = MAS_BACKGROUND_Z - 1
             if (
                 store.mas_globals.show_sayori_lightning
-                and persistent._mas_pm_cares_about_dokis
+                and not persistent._mas_pm_cares_about_dokis
                 and mas_current_background.background_id == store.mas_background.MBG_DEF
                 and renpy.random.randint(1, store.mas_globals.sayori_lightning_chance) == 1
             ):

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1531,8 +1531,7 @@ label ch30_post_mid_loop_eval:
         ):
             $ light_zorder = MAS_BACKGROUND_Z - 1
             if (
-                store.mas_globals.show_sayori_lightning
-                and not persistent._mas_pm_cares_about_dokis
+                (mas_egg_manager.sayori_enabled() or (store.mas_globals.show_sayori_lightning and not persistent._mas_pm_cares_about_dokis))
                 and mas_current_background.background_id == store.mas_background.MBG_DEF
                 and renpy.random.randint(1, store.mas_globals.sayori_lightning_chance) == 1
             ):

--- a/Monika After Story/game/script-easter-eggs.rpy
+++ b/Monika After Story/game/script-easter-eggs.rpy
@@ -9,7 +9,7 @@ label sayori_name_scare:
         from store.songs import FP_SAYO_NARA, initMusicChoices
         initMusicChoices(sayori=True)
         play_song(FP_SAYO_NARA, set_per=True)
-        store.mas_globals.show_s_light = True
+        store.mas_globals.show_sayori_lightning = True
     return
 
 # yuri scare
@@ -290,7 +290,7 @@ init -1 python in mas_egg_manager:
         """
         return not store.persistent._mas_disable_eggs
 
-    
+
     def natsuki_enabled():
         """
         Checks if the natsuki egg should be enabled

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -401,9 +401,6 @@ init -10 python:
         for _tag in MAS_O31_DECO_TAGS:
             mas_hideDecoTag(_tag, hide_now=True)
 
-        #Also, if we're hiding visuals, we're no longer in o31 mode
-        store.persistent._mas_o31_in_o31_mode = False
-
         #unlock hairdown greet if we don't have hairdown unlocked
         hair = store.mas_selspr.get_sel_hair(store.mas_hair_down)
         if hair is not None and not hair.unlocked:
@@ -607,6 +604,9 @@ init -10 python:
 
         #Hide visuals
         mas_o31HideVisuals()
+
+        #o31 is now over. Reset the o31 mode flag
+        store.persistent._mas_o31_in_o31_mode = False
 
         #rmall for safety
         mas_rmallEVL("mas_o31_cleanup")
@@ -5808,6 +5808,8 @@ label return_home_post_player_bday:
             #If we returned from a date post pbday but have O31 deco
             if not mas_isO31() and persistent._mas_o31_in_o31_mode:
                 $ mas_o31HideVisuals()
+                # Make sure no o31 mode
+                $ store.persistent._mas_o31_in_o31_mode = False
 
             m 3eua "There we go!"
             if not persistent._mas_f14_gone_over_f14:

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -29,11 +29,6 @@ init 10 python:
         if clothes is None:
             return
 
-        #If this is a spritepack outfit that has been gifted, we should ignore it
-        for sel_clothes in mas_selspr.filter_clothes(unlocked=True):
-            if sel_clothes.get_sprobj() == clothes:
-                return
-
         if key is None:
             key = datetime.date.today()
 

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -29,6 +29,11 @@ init 10 python:
         if clothes is None:
             return
 
+        #If this is a spritepack outfit that has been gifted, we should ignore it
+        spritepack_gifted_clothes = [ x.get_sprobj() for x in mas_selspr.filter_clothes(unlocked=True)]
+        if clothes in spritepack_gifted_clothes:
+            return
+
         if key is None:
             key = datetime.date.today()
 

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -30,9 +30,9 @@ init 10 python:
             return
 
         #If this is a spritepack outfit that has been gifted, we should ignore it
-        spritepack_gifted_clothes = [ x.get_sprobj() for x in mas_selspr.filter_clothes(unlocked=True)]
-        if clothes in spritepack_gifted_clothes:
-            return
+        for sel_clothes in mas_selspr.filter_clothes(unlocked=True):
+            if sel_clothes.get_sprobj() == clothes:
+                return
 
         if key is None:
             key = datetime.date.today()

--- a/Monika After Story/game/script-stories.rpy
+++ b/Monika After Story/game/script-stories.rpy
@@ -51,7 +51,10 @@ init -1 python in mas_stories:
 
     #Override maps to have special conditionals for specific story types
     NEW_STORY_CONDITIONAL_OVERRIDE = {
-        TYPE_SCARY: "mas_isO31() or mas_stories.check_can_unlock_new_story(mas_stories.TYPE_SCARY)",
+        TYPE_SCARY: (
+            "(mas_isO31() and mas_stories.has_new_stories_for_type(mas_stories.TYPE_SCARY)) "
+            "or mas_stories.check_can_unlock_new_story(mas_stories.TYPE_SCARY)"
+        ),
     }
 
     def check_can_unlock_new_story(story_type=TYPE_NORMAL):
@@ -77,16 +80,7 @@ init -1 python in mas_stories:
                 store.seen_event(first_story) if new_story_ls is None
                 else store.mas_timePastSince(new_story_ls, datetime.timedelta(hours=TIME_BETWEEN_UNLOCKS))
             )
-            and len(
-                store.Event.filterEvents(
-                    story_database,
-                    pool=False,
-                    aff=store.mas_curr_affection,
-                    unlocked=False,
-                    flag_ban=store.EV_FLAG_HFM,
-                    category=(True, [story_type])
-                )
-            ) > 0
+            and has_new_stories_for_type(story_type)
         )
 
         #If we're showing a new story, randomize the time between unlocks again
@@ -94,6 +88,24 @@ init -1 python in mas_stories:
             TIME_BETWEEN_UNLOCKS = renpy.random.randint(20, 28)
 
         return can_show_new_story
+
+    def has_new_stories_for_type(story_type):
+        """
+        Checks if we have a new story of the given type
+
+        IN:
+            story_type - story type to check if we have more to unlock
+        """
+        return len(
+            store.Event.filterEvents(
+                story_database,
+                pool=False,
+                aff=store.mas_curr_affection,
+                unlocked=False,
+                flag_ban=store.EV_FLAG_HFM,
+                category=(True, [story_type])
+            )
+        ) > 0
 
     def get_and_unlock_random_story(story_type=TYPE_NORMAL):
         """

--- a/Monika After Story/game/script-stories.rpy
+++ b/Monika After Story/game/script-stories.rpy
@@ -95,13 +95,13 @@ init -1 python in mas_stories:
 
     def get_new_stories_for_type(story_type):
         """
-        Checks if we have a new story of the given type
+        Gets all new (unseen) stories of the given ype
 
         IN:
-            story_type - story type to check if we have more to unlock
+            story_type - story type to get
 
         OUT:
-            list of unlocked stories for the given story type
+            list of locked stories for the given story type
         """
         return store.Event.filterEvents(
             story_database,

--- a/Monika After Story/game/script-stories.rpy
+++ b/Monika After Story/game/script-stories.rpy
@@ -77,12 +77,11 @@ init -1 python in mas_stories:
         if not first_story:
             return False
 
-        can_show_new_story = ((
-                store.seen_event(first_story)
-                and (
-                    ignore_cooldown
-                    or store.mas_timePastSince(new_story_ls, datetime.timedelta(hours=TIME_BETWEEN_UNLOCKS))
-                )
+        can_show_new_story = (
+            store.seen_event(first_story)
+            and (
+                ignore_cooldown
+                or store.mas_timePastSince(new_story_ls, datetime.timedelta(hours=TIME_BETWEEN_UNLOCKS))
             )
             and len(get_new_stories_for_type(story_type)) > 0
         )
@@ -108,7 +107,7 @@ init -1 python in mas_stories:
             pool=False,
             aff=store.mas_curr_affection,
             unlocked=False,
-            flag_ban=store.EV_FLAG_HFM,
+            flag_ban=store.EV_FLAG_HFNAS,
             category=(True, [story_type])
         )
 

--- a/Monika After Story/game/script-stories.rpy
+++ b/Monika After Story/game/script-stories.rpy
@@ -52,7 +52,7 @@ init -1 python in mas_stories:
     #Override maps to have special conditionals for specific story types
     NEW_STORY_CONDITIONAL_OVERRIDE = {
         TYPE_SCARY: (
-            "mas_stories.has_new_stories_for_type(mas_stories.TYPE_SCARY, ignore_cooldown=store.mas_isO31())"
+            "mas_stories.check_can_unlock_new_story(mas_stories.TYPE_SCARY, ignore_cooldown=store.mas_isO31())"
         ),
     }
 

--- a/Monika After Story/game/script-stories.rpy
+++ b/Monika After Story/game/script-stories.rpy
@@ -80,8 +80,8 @@ init -1 python in mas_stories:
         can_show_new_story = ((
                 store.seen_event(first_story)
                 and (
-                    ignore_cooldown or
-                    (not ignore_cooldown and store.mas_timePastSince(new_story_ls, datetime.timedelta(hours=TIME_BETWEEN_UNLOCKS)))
+                    ignore_cooldown
+                    or store.mas_timePastSince(new_story_ls, datetime.timedelta(hours=TIME_BETWEEN_UNLOCKS))
                 )
             )
             and len(get_new_stories_for_type(story_type)) > 0

--- a/Monika After Story/game/script-stories.rpy
+++ b/Monika After Story/game/script-stories.rpy
@@ -78,8 +78,8 @@ init -1 python in mas_stories:
             return False
 
         can_show_new_story = ((
-                new_story_ls is None and store.seen_event(first_story)
-                or (
+                store.seen_event(first_story)
+                and (
                     ignore_cooldown or
                     (not ignore_cooldown and store.mas_timePastSince(new_story_ls, datetime.timedelta(hours=TIME_BETWEEN_UNLOCKS)))
                 )

--- a/Monika After Story/game/zz_pianokeys.rpy
+++ b/Monika After Story/game/zz_pianokeys.rpy
@@ -1372,7 +1372,7 @@ init -3 python in mas_piano_keys:
 
                 # log warnings
                 for _warn in _msg:
-                    log.warn("    " + _warn)
+                    log.warning("    " + _warn)
 
                 # verse check
                 if real_pnm.verse < 0 or real_pnm.verse >= len(_pnm_list):

--- a/Monika After Story/game/zz_selector.rpy
+++ b/Monika After Story/game/zz_selector.rpy
@@ -3940,30 +3940,28 @@ label monika_clothes_select:
             # need to get a list of clothes that have been gifted
             # so we will get a list of all clothes and then remove the event_clothes
             gifted_clothes = mas_selspr.filter_clothes(True)
-            ev_outfits = persistent._mas_event_clothes_map.get(datetime.date.today(), ())
+            clothes_id_to_add = persistent._mas_event_clothes_map.get(datetime.date.today(), None)
 
             for index in range(len(gifted_clothes)-1, -1, -1):
                 spr_obj = gifted_clothes[index].get_sprobj()
                 if (
-                        spr_obj.name in ev_outfits
-                        or (
-                                not spr_obj.is_custom
-                                and spr_obj != mas_clothes_def
-                                and spr_obj != mas_clothes_blazerless
-                        )
+                    spr_obj.name == clothes_id_to_add
+                    or (
+                        not spr_obj.is_custom
+                        and spr_obj != mas_clothes_def
+                        and spr_obj != mas_clothes_blazerless
+                    )
                 ):
                     gifted_clothes.pop(index)
 
-            #Now we handle holiday clothes
-            clothes_to_add = ev_outfits
 
             #If there's something for today, then we'll add it to be unlocked
-            if clothes_to_add:
+            if clothes_id_to_add:
                 #Get the outfit selector and add it
                 gifted_clothes.append(mas_selspr.get_sel_clothes(
                     mas_sprites.get_sprite(
                         mas_sprites.SP_CLOTHES,
-                        clothes_to_add
+                        clothes_id_to_add
                     )
                 ))
                 gifted_clothes.sort(key=mas_selspr.selectable_key)

--- a/Monika After Story/game/zz_selector.rpy
+++ b/Monika After Story/game/zz_selector.rpy
@@ -3940,18 +3940,22 @@ label monika_clothes_select:
             # need to get a list of clothes that have been gifted
             # so we will get a list of all clothes and then remove the event_clothes
             gifted_clothes = mas_selspr.filter_clothes(True)
+            ev_outfits = persistent._mas_event_clothes_map.get(datetime.date.today(), ())
 
             for index in range(len(gifted_clothes)-1, -1, -1):
                 spr_obj = gifted_clothes[index].get_sprobj()
                 if (
-                        not spr_obj.is_custom
-                        and spr_obj != mas_clothes_def
-                        and spr_obj != mas_clothes_blazerless
+                        spr_obj.name in ev_outfits
+                        or (
+                                not spr_obj.is_custom
+                                and spr_obj != mas_clothes_def
+                                and spr_obj != mas_clothes_blazerless
+                        )
                 ):
                     gifted_clothes.pop(index)
 
             #Now we handle holiday clothes
-            clothes_to_add = persistent._mas_event_clothes_map.get(datetime.date.today())
+            clothes_to_add = ev_outfits
 
             #If there's something for today, then we'll add it to be unlocked
             if clothes_to_add:


### PR DESCRIPTION
Bugfix PR, handles issues seen during the o31 event and some other ones. May be added onto in future.

Fixes: #8140, #8116, #8121, #8124, #8133

Renames our `s_lightning` vars to more glance-readable names, background locks it to just spaceroom due to the lack of a guarantee it'll work with other BGs, as well as embeds the doki cares check into the lighting chance for sayori lightning.

Also addresses an issue where outfits were duplicated in the event clothes selector for users with < 1000 affection due to spritepack outfits being added (and then duplicated in the event clothes map)
    - This change forbids spritepacks from being added to that map (no reason they should be in there in the first place)