### PR TITLE
Update zz_windowituls.rpy to allow window reacts on Linux

### DIFF
--- a/Monika After Story/game/zz_windowutils.rpy
+++ b/Monika After Story/game/zz_windowutils.rpy
@@ -299,10 +299,7 @@ init python in mas_windowutils:
             active_winname_prop = active_winobj.get_full_property(NET_WM_NAME, 0)
 
             if active_winname_prop is not None:
-                active_winname = unicode(active_winname_prop.value, encoding = "utf-8")
-                reversed_winname = active_winname[::-1]
-                terminating_index_buffer = len(active_winname) - reversed_winname.index("—")
-                active_winname = active_winname[:terminating_index_buffer - 2]
+                active_winname = unicode(active_winname_prop.value, encoding = "utf-8")    
                 return active_winname.replace("\n", "")
 
             else:

--- a/Monika After Story/game/zz_windowutils.rpy
+++ b/Monika After Story/game/zz_windowutils.rpy
@@ -300,7 +300,9 @@ init python in mas_windowutils:
 
             if active_winname_prop is not None:
                 active_winname = unicode(active_winname_prop.value, encoding = "utf-8")
-                active_winname = active_winname.replace("—","\b\0")
+                reversed_winname = active_winname[::-1]
+                terminating_index_buffer = len(active_winname) - reversed_winname.index("—")
+                active_winname = active_winname[:terminating_index_buffer - 2]
                 return active_winname.replace("\n", "")
 
             else:

--- a/Monika After Story/game/zz_windowutils.rpy
+++ b/Monika After Story/game/zz_windowutils.rpy
@@ -299,7 +299,8 @@ init python in mas_windowutils:
             active_winname_prop = active_winobj.get_full_property(NET_WM_NAME, 0)
 
             if active_winname_prop is not None:
-                active_winname = unicode(active_winname_prop.value)
+                active_winname = unicode(active_winname_prop.value, encoding = "utf-8")
+                active_winname = active_winname.replace("—","\b\0")
                 return active_winname.replace("\n", "")
 
             else:


### PR DESCRIPTION
Window reacts now work on Linux!

```
                active_winname = unicode(active_winname_prop.value, encoding = "utf-8")
                active_winname = active_winname.replace("—","\b\0")
```

Line 302 was changed and another line was added right after it. Tested on Linux, and the feature now works! No exceptions occurring, nothing of that sort. No delays either as far as I can tell! Not sure why GitHub says there's a delay.