### PR TITLE
NYE data fix

### DIFF
--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -377,9 +377,8 @@ label v0_3_1(version=version): # 0.3.1
 # 0.12.5
 label v0_12_5(version="v0_12_5"):
     python hide:
-        local_now = mas_utils.utc_to_local(datetime.datetime.utcnow())
 
-        if local_now.date() < datetime.date(2021, 12, 31) and persistent._mas_nye_spent_nye:
+        if datetime.date.today() < datetime.date(2021, 12, 31) and persistent._mas_nye_spent_nye:
             persistent._mas_nye_spent_nye = False
             mas_history._store(True, "nye.actions.spent_nye", 2020)
 

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -381,15 +381,15 @@ label v0_12_5(version="v0_12_5"):
 
         if local_now.date() < datetime.date(2021, 12, 31) and persistent._mas_nye_spent_nye:
             persistent._mas_nye_spent_nye = False
-            if mas_HistLookup("nye.actions.spent_nye", 2020)[1] is not None:
-                mas_history._store(True, "nye.actions.spent_nye", 2020)
+            mas_history._store(True, "nye.actions.spent_nye", 2020)
 
             date_count = persistent._mas_nye_nye_date_count
             persistent._mas_nye_nye_date_count = 0
             old_date_count = mas_HistLookup("nye.actions.went_out_nye", 2020)[1]
             if old_date_count is not None:
                 date_count += old_date_count
-                mas_history._store(date_count, "nye.actions.went_out_nye", 2020)
+
+            mas_history._store(date_count, "nye.actions.went_out_nye", 2020)
 
     return
 

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -377,7 +377,20 @@ label v0_3_1(version=version): # 0.3.1
 # 0.12.5
 label v0_12_5(version="v0_12_5"):
     python hide:
-        pass
+        local_now = mas_utils.utc_to_local(datetime.datetime.utcnow())
+
+        if local_now.date() < datetime.date(2021, 12, 31) and persistent._mas_nye_spent_nye:
+            persistent._mas_nye_spent_nye = False
+            if mas_HistLookup("nye.actions.spent_nye", 2020)[1] is not None:
+                mas_history._store(True, "nye.actions.spent_nye", 2020)
+
+            date_count = persistent._mas_nye_nye_date_count
+            persistent._mas_nye_nye_date_count = 0
+            old_date_count = mas_HistLookup("nye.actions.went_out_nye", 2020)[1]
+            if old_date_count is not None:
+                date_count += old_date_count
+                mas_history._store(date_count, "nye.actions.went_out_nye", 2020)
+
     return
 
 # 0.12.4


### PR DESCRIPTION
An issue arose last year due to the wrong year being used and a check that extended past the reset trigger date that allowed `mas_gone_over_nye_check` to set data for the following year. The issue itself was fixed in https://github.com/jmwall24/MonikaModDev/commit/de4eb6dc549e23ebab18f8cca03636b52b0263cc and now we are fixing the bad data by resetting `persistent._mas_nye_spent_nye` and `persistent._mas_nye_nye_date_count` and amending 2020 historical data.

## Testing

- on a persistent with historical data from 2020, set `persistent._mas_nye_spent_nye` to True and `persistent._mas_nye_nye_date_count` to any non-zero integer and then run the update script. Verify the vars are `False` and `0` respectively (defaults) and that historical data has been updated accordingly.
- on a persistent with no historical data from 2020 (fresh persist is easiest) repeat the above test and verify there were no crashes.