### PR TITLE
Fix settings menu

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -8087,7 +8087,7 @@ init -1 python in mas_randchat:
         """
         Reduces the randchat setting if we're too high for the current affection level
         """
-        max_setting_for_level = store.mas_affection.RANDCHAT_RANGE_MAP[aff_level]
+        max_setting_for_level = store.mas_affection.RANDCHAT_RANGE_MAP.get(aff_level, RARELY)
 
         if store.persistent._mas_randchat_freq > max_setting_for_level:
             adjustRandFreq(max_setting_for_level)
@@ -8126,12 +8126,7 @@ init -1 python in mas_randchat:
             displayable string that reprsents the current random chatter
             setting
         """
-        randchat_disp = SLIDER_MAP_DISP.get(slider_value, None)
-
-        if slider_value is None:
-            return "Never"
-
-        return randchat_disp
+        return SLIDER_MAP_DISP.get(slider_value, "UNKNOWN")
 
 
     def setWaitingTime():

--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -1421,6 +1421,7 @@ screen preferences():
                 style_prefix "slider"
                 box_wrap True
 
+                # TODO: clean this up, we should not exucute py code in screens
                 python:
                     ### random chatter preprocessing
                     if mas_randchat_prev != persistent._mas_randchat_freq:

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -122,17 +122,6 @@ init -900 python in mas_affection:
         LOVE: "monika 1hua_static",
     }
 
-    RANDCHAT_RANGE_MAP = {
-        BROKEN: 1,
-        DISTRESSED: 2,
-        UPSET: 3,
-        NORMAL: 4,
-        HAPPY: 4,
-        AFFECTIONATE: 5,
-        ENAMORED: 6,
-        LOVE: 6
-    }
-
     # compare functions for affection / group
     def _compareAff(aff_1, aff_2):
         """
@@ -418,6 +407,20 @@ init -1 python in mas_affection:
             return "monika 1esc_static"
 
         return FORCE_EXP_MAP.get(curr_aff, "monika idle")
+
+# This needs to be defined a bit later
+init 5 python in mas_affection:
+    # Rand chatter settings map
+    RANDCHAT_RANGE_MAP = {
+        BROKEN: store.mas_randchat.RARELY,
+        DISTRESSED: store.mas_randchat.OCCASIONALLY,
+        UPSET: store.mas_randchat.LESS_OFTEN,
+        NORMAL: store.mas_randchat.NORMAL,
+        HAPPY: store.mas_randchat.NORMAL,
+        AFFECTIONATE: store.mas_randchat.OFTEN,
+        ENAMORED: store.mas_randchat.VERY_OFTEN,
+        LOVE: store.mas_randchat.VERY_OFTEN
+    }
 
 
 # need these utility functiosn post event_handler


### PR DESCRIPTION
Fixed the issue with returning `None` and coercing it to `str`ings. Also safer access to the other map + using the defined constants for it instead of raw literals.

### Testing:
 - verify the chatter still works
 - set `persistent._mas_randchat_freq` to `-99` or `99` and verify you can still open the menu