### PR TITLE
Override d25 gift protocol for devs

### DIFF
--- a/Monika After Story/game/dev/dev_d25_resets.rpy
+++ b/Monika After Story/game/dev/dev_d25_resets.rpy
@@ -1,6 +1,6 @@
 # just resetting the d25 events
 
-init python:
+init 999 python:
     if persistent._mas_override_d25_gift_react is None:
         persistent._mas_override_d25_gift_react = config.developer
 

--- a/Monika After Story/game/dev/dev_d25_resets.rpy
+++ b/Monika After Story/game/dev/dev_d25_resets.rpy
@@ -1,5 +1,9 @@
 # just resetting the d25 events
 
+init python:
+    if persistent._mas_override_d25_gift_react is None:
+        persistent._mas_override_d25_gift_react = config.developer
+
 init 998 python:
     def mas_reset_d25():
         """
@@ -44,5 +48,3 @@ init 998 python:
             "mas_nye_monika_nye",
             "mas_nye_monika_nyd"
         )
-
-        

--- a/Monika After Story/game/dev/dev_greetings.rpy
+++ b/Monika After Story/game/dev/dev_greetings.rpy
@@ -3,7 +3,7 @@
 # TODO Delete this *Insert Monika with a handgun*
 # Seriously this is for testing only
 
-init python:
+init 999 python:
     if persistent._mas_fastgreeting is None:
         persistent._mas_fastgreeting = config.developer
 

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -2020,6 +2020,7 @@ init -10 python in mas_d25_utils:
             store.mas_isD25Pre()
             and store.mas_isMoniNormal(higher=True)
             and store.persistent._mas_d25_deco_active
+            and not store.persistent._mas_override_d25_gift_react
         )
 
     def react_to_gifts(found_map):


### PR DESCRIPTION
Just adds a way to be able to not have Monika wait until Christmas to open gifts to make it easier for devs and SP creators to see their outfits in the mod.

Adds `persistent._mas_override_d25_gift_react` to `dev_d25_resets.rpy` and adds a check for it in `shouldUseD25ReactToGifts()`

## Testing
with `config.developer` set to True, gift a spritepack to Monika and ensure she opens it immediately while in the d25 gifting timeframe. also ensure if `config.developer` is False or None, gifting occurs as usual during this timeframe.