### PR TITLE
Prevent d25 gift react function from duplicating react labels

### DIFF
--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -2379,8 +2379,9 @@ label mas_d25_gift_starter:
 
     m 1suo "Let's see what we have here.{w=0.5}.{w=0.5}.{nw}"
 
-    #Pop the last index so we remove gifts from under the tree as we go
-    $ persistent._mas_d25_gifts_given.pop()
+    #Safe-pop the last index so we remove gifts from under the tree as we go
+    if persistent._mas_d25_gifts_given:
+        $ persistent._mas_d25_gifts_given.pop()
     return
 
 label mas_d25_gift_connector:
@@ -2397,8 +2398,9 @@ label mas_d25_gift_connector:
     m 1hub "[picked_quip]"
     m 1suo "And here we have.{w=0.5}.{w=0.5}.{nw}"
 
-    #Pop here too for the tree gifts
-    $ persistent._mas_d25_gifts_given.pop()
+    #Safe-pop here too for the tree gifts
+    if persistent._mas_d25_gifts_given:
+        $ persistent._mas_d25_gifts_given.pop()
     return
 
 label mas_d25_gift_end:

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -1912,7 +1912,9 @@ init -10 python:
         # queue the reacts
         if len(react_labels) > 0:
             for react_label in react_labels:
-                mas_rmallEVL(react_label) # TODO - this is a patch, revalute when #8545 (gift logging) and #8546 (gift registering) are addressed
+                mas_rmEVL(react_label) # TODO - this is a patch, revalute when #8545 (gift logging) and #8546 (gift registering) are addressed
+
+            for react_label in react_labels:
                 pushEvent(react_label,skipeval=True)
 
     def mas_d25SilentReactToGifts():

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -1912,7 +1912,7 @@ init -10 python:
         # queue the reacts
         if len(react_labels) > 0:
             for react_label in react_labels:
-                mas_rmEVL(react_label) # TODO - this is a patch, revalute when #8545 (gift logging) and #8546 (gift registering) are addressed
+                mas_rmallEVL(react_label) # TODO - this is a patch, revalute when #8545 (gift logging) and #8546 (gift registering) are addressed
 
             for react_label in react_labels:
                 pushEvent(react_label,skipeval=True)

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -1912,7 +1912,7 @@ init -10 python:
         # queue the reacts
         if len(react_labels) > 0:
             for react_label in react_labels:
-                mas_rmallEVL(react_label)
+                mas_rmallEVL(react_label) # TODO - this is a patch, revalute when #8545 (gift logging) and #8546 (gift registering) are addressed
                 pushEvent(react_label,skipeval=True)
 
     def mas_d25SilentReactToGifts():
@@ -2380,6 +2380,7 @@ label mas_d25_gift_starter:
     m 1suo "Let's see what we have here.{w=0.5}.{w=0.5}.{nw}"
 
     #Safe-pop the last index so we remove gifts from under the tree as we go
+    # TODO - add logging if there is a mismatch here
     if persistent._mas_d25_gifts_given:
         $ persistent._mas_d25_gifts_given.pop()
     return
@@ -2399,6 +2400,7 @@ label mas_d25_gift_connector:
     m 1suo "And here we have.{w=0.5}.{w=0.5}.{nw}"
 
     #Safe-pop here too for the tree gifts
+    # TODO - add logging if there is a mismatch here
     if persistent._mas_d25_gifts_given:
         $ persistent._mas_d25_gifts_given.pop()
     return

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -1912,6 +1912,7 @@ init -10 python:
         # queue the reacts
         if len(react_labels) > 0:
             for react_label in react_labels:
+                mas_rmallEVL(react_label)
                 pushEvent(react_label,skipeval=True)
 
     def mas_d25SilentReactToGifts():


### PR DESCRIPTION
Fixes #8508 

# Key Changes
* removes react labels as they are being added at the end of the `mas_d25ReactToGifts` function
* guards `_mas_d25_gifts_given` so it doesnt pop when empty
* marked some TODOs for #8545 and #8546

# Testing

## Console-based
1. Fill `persistent._mas_d25_gifts_given` with a list of lowercase giftnames, no extensions.
2. Run `mas_d25ReactToGifts()`
3. Verify that `persistent.event_list` is filled out as appropriate (you should see gift reaction labels)
4. Run `mas_d25ReactToGifts()` again
5. Verify that the gift reaction labels are **not** duplicated

