### PR TITLE
Cleanup pronouns

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -8157,42 +8157,9 @@ init 4 python:
     import store.mas_randchat as mas_randchat
 
 
-#Gender specific word replacement
-#Those are to be used like this "It is [his] pen." Output:
-#"It is his pen." (if the player's gender is declared as male)
-#"It is her pen." (if the player's gender is decalred as female)
-#"It is their pen." (if player's gender is not declared)
-#Variables (i.e. what you put in square brackets) so far: his, he, hes, heis, bf, man, boy,
-#Please remember to update the list if you add more gender exclusive words. ^
-define MAS_PRONOUN_GENDER_MAP = {
-    "his": {"M": "his", "G": "her", "X": "their"},
-    "he": {"M": "he", "G": "she", "X": "they"},
-    "hes": {"M": "he's", "G": "she's", "X": "they're"},
-    "heis": {"M": "he is", "G": "she is", "X": "they are"},
-    "bf": {"M": "boyfriend", "G": "girlfriend", "X": "partner"},
-    "man": {"M": "man", "G": "woman", "X": "person"},
-    "boy": {"M": "boy", "G": "girl", "X": "person"},
-    "guy": {"M": "guy", "G": "girl", "X": "person"},
-    "him": {"M": "him", "G": "her", "X": "them"},
-    "himself": {"M": "himself", "G": "herself", "X": "themselves"},
-    "hero": {"M": "hero", "G": "heroine", "X": "hero"}
-}
-# Deprecated
+# Deprecated, call mas_set_pronouns directly
 label mas_set_gender:
-    jump mas_set_pronouns
-
-label mas_set_pronouns(gender=None):
-    python hide:
-        if gender is None:
-            gender = persistent.gender
-
-        for word, sub_map in MAS_PRONOUN_GENDER_MAP.items():
-            if gender in sub_map:
-                value = sub_map[gender]
-            else:
-                value = sub_map["X"]
-            setattr(store, word, value)
-
+    $ mas_set_pronouns()
     return
 
 

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -8156,7 +8156,6 @@ init -1 python in mas_randchat:
 init 4 python:
     import store.mas_randchat as mas_randchat
 
-return
 
 #Gender specific word replacement
 #Those are to be used like this "It is [his] pen." Output:
@@ -8165,64 +8164,33 @@ return
 #"It is their pen." (if player's gender is not declared)
 #Variables (i.e. what you put in square brackets) so far: his, he, hes, heis, bf, man, boy,
 #Please remember to update the list if you add more gender exclusive words. ^
+define MAS_PRONOUN_GENDER_MAP = {
+    "his": {"M": "his", "G": "her", "X": "their"},
+    "he": {"M": "he", "G": "she", "X": "they"},
+    "hes": {"M": "he's", "G": "she's", "X": "they're"},
+    "heis": {"M": "he is", "G": "she is", "X": "they are"},
+    "bf": {"M": "boyfriend", "G": "girlfriend", "X": "partner"},
+    "man": {"M": "man", "G": "woman", "X": "person"},
+    "boy": {"M": "boy", "G": "girl", "X": "person"},
+    "guy": {"M": "guy", "G": "girl", "X": "person"},
+    "him": {"M": "him", "G": "her", "X": "them"},
+    "himself": {"M": "himself", "G": "herself", "X": "themselves"},
+    "hero": {"M": "hero", "G": "heroine", "X": "hero"}
+}
+# Deprecated
 label mas_set_gender:
-    python:
-        pronoun_gender_map = {
-            "M": {
-                "his": "his",
-                "he": "he",
-                "hes": "he's",
-                "heis": "he is",
-                "bf": "boyfriend",
-                "man": "man",
-                "boy": "boy",
-                "guy": "guy",
-                "him": "him",
-                "himself": "himself",
-                "hero": "hero"
-            },
-            "F": {
-                "his": "her",
-                "he": "she",
-                "hes": "she's",
-                "heis": "she is",
-                "bf": "girlfriend",
-                "man": "woman",
-                "boy": "girl",
-                "guy": "girl",
-                "him": "her",
-                "himself": "herself",
-                "hero": "heroine"
-            },
-            "X": {
-                "his": "their",
-                "he": "they",
-                "hes": "they're",
-                "heis": "they are",
-                "bf": "partner",
-                "man": "person",
-                "boy": "person",
-                "guy": "person",
-                "him": "them",
-                "himself": "themselves",
-                "hero": "hero"
-            }
-        }
+    jump mas_set_pronouns
 
-        pronouns = pronoun_gender_map[persistent.gender]
+label mas_set_pronouns:
+    python hide:
+        gender = persistent.gender
 
-        his = pronouns["his"]
-        he = pronouns["he"]
-        hes = pronouns["hes"]
-        heis = pronouns["heis"]
-        bf = pronouns["bf"]
-        man = pronouns["man"]
-        boy = pronouns["boy"]
-        guy = pronouns["guy"]
-        him = pronouns["him"]
-        himself = pronouns["himself"]
-        hero = pronouns["hero"]
+        for word, sub_map in MAS_PRONOUN_GENDER_MAP.items():
+            value = sub_map[gender]
+            setattr(store, word, value)
+
     return
+
 
 style jpn_text:
     font "mod_assets/font/mplus-2p-regular.ttf"

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -8181,12 +8181,16 @@ define MAS_PRONOUN_GENDER_MAP = {
 label mas_set_gender:
     jump mas_set_pronouns
 
-label mas_set_pronouns:
+label mas_set_pronouns(gender=None):
     python hide:
-        gender = persistent.gender
+        if gender is None:
+            gender = persistent.gender
 
         for word, sub_map in MAS_PRONOUN_GENDER_MAP.items():
-            value = sub_map[gender]
+            if gender in sub_map:
+                value = sub_map[gender]
+            else:
+                value = sub_map["X"]
             setattr(store, word, value)
 
     return

--- a/Monika After Story/game/dev/dev_unittest.rpy
+++ b/Monika After Story/game/dev/dev_unittest.rpy
@@ -2743,18 +2743,28 @@ label dev_unit_test_mas_set_pronouns:
 
     python hide:
         pronouns_tester.prepareTest("Validate map size and keys")
-        map_size = None
-        for sub_map in store.MAS_PRONOUN_GENDER_MAP.values():
+        expected_map_size = None
+        for key, sub_map in store.MAS_PRONOUN_GENDER_MAP.items():
             sub_map = dict(sub_map)
 
-            if map_size is None:
-                map_size = len(sub_map)
+            if expected_map_size is None:
+                expected_map_size = len(sub_map)
             else:
-                pronouns_tester.assertTrue(map_size == len(sub_map))
+                sub_map_size = len(sub_map)
+                pronouns_tester.prepareTest(
+                    "Validating map size for key {}, expected {}, got {}".format(
+                        key,
+                        expected_map_size,
+                        sub_map_size
+                    )
+                )
+                pronouns_tester.assertEqual(expected_map_size, sub_map_size)
 
-            pronouns_tester.assertTrue("M" in sub_map)
-            pronouns_tester.assertTrue("G" in sub_map)
-            pronouns_tester.assertTrue("X" in sub_map)
+            for k in ("M", "G", "X"):
+                pronouns_tester.prepareTest(
+                    "Validating the key {} is in the map".format(k)
+                )
+                pronouns_tester.assertTrue(k in sub_map)
 
         pronouns_tester.prepareTest("Check global pronouns variables")
         for gender in ("M", "G", "X"):
@@ -2766,6 +2776,13 @@ label dev_unit_test_mas_set_pronouns:
                 # Verify the func set correct values
                 global_value = getattr(store, word, fallback)
                 map_value = sub_map[gender]
+                pronouns_tester.prepareTest(
+                    "Check global pronouns variable match: {}, expected {}, got {}".format(
+                        word,
+                        map_value,
+                        global_value
+                    )
+                )
                 pronouns_tester.assertEqual(global_value, map_value)
 
         # This is just to reset pronouns

--- a/Monika After Story/game/dev/dev_unittest.rpy
+++ b/Monika After Story/game/dev/dev_unittest.rpy
@@ -12,6 +12,7 @@ init -1 python in mas_dev_unit_tests:
         ("UTC APIs", "dev_unit_test_utc_api", False, False),
         ("WRS REGEXP Tests", "dev_unit_test_wrs_regexpchecks", False, False),
         ("strict_can_pickle", "dev_unit_test_strict_can_pickle", False, False),
+        ("mas_set_pronouns", "dev_unit_test_mas_set_pronouns", False, False)
     ]
 
     class MASUnitTest(object):
@@ -2619,7 +2620,7 @@ label dev_unit_test_strict_can_pickle:
         recur_dict[10] = recur_list
 
         class FakeTzInfo(datetime.tzinfo):
-            
+
             def utcoffset(self, dt):
                 return datetime.timedelta()
 
@@ -2732,5 +2733,46 @@ label dev_unit_test_strict_can_pickle:
         scp_tester.assertEqual(recur_error, scp(recur_dict))
 
     call dev_unit_tests_finish_test(scp_tester)
+
+    return
+
+label dev_unit_test_mas_set_pronouns:
+    m "Running tests..."
+
+    $ pronouns_tester = store.mas_dev_unit_tests.MASUnitTester()
+
+    python hide:
+        pronouns_tester.prepareTest("Validate map size and keys")
+        map_size = None
+        for sub_map in store.MAS_PRONOUN_GENDER_MAP.values():
+            sub_map = dict(sub_map)
+
+            if map_size is None:
+                map_size = len(sub_map)
+            else:
+                pronouns_tester.assertTrue(map_size == len(sub_map))
+
+            pronouns_tester.assertTrue("M" in sub_map)
+            pronouns_tester.assertTrue("G" in sub_map)
+            pronouns_tester.assertTrue("X" in sub_map)
+
+        pronouns_tester.prepareTest("Check global pronouns variables")
+        all_vars = store.MAS_PRONOUN_GENDER_MAP.keys()
+        for gender in ("M", "G", "X"):
+            # Verify the func works
+            mas_set_pronouns(gender)
+
+            fallback = object()
+            for word, sub_map in store.MAS_PRONOUN_GENDER_MAP.items():
+                # Verify the func set correct values
+                global_value = getattr(store, word, fallback)
+                map_value = sub_map[gender]
+                pronouns_tester.assertEqual(global_value, map_value)
+
+        # This is just to reset pronouns
+        mas_set_pronouns()
+
+    call dev_unit_tests_finish_test(pronouns_tester)
+    $ del pronouns_tester
 
     return

--- a/Monika After Story/game/dev/dev_unittest.rpy
+++ b/Monika After Story/game/dev/dev_unittest.rpy
@@ -2757,7 +2757,6 @@ label dev_unit_test_mas_set_pronouns:
             pronouns_tester.assertTrue("X" in sub_map)
 
         pronouns_tester.prepareTest("Check global pronouns variables")
-        all_vars = store.MAS_PRONOUN_GENDER_MAP.keys()
         for gender in ("M", "G", "X"):
             # Verify the func works
             mas_set_pronouns(gender)

--- a/Monika After Story/game/dev/dev_unittest.rpy
+++ b/Monika After Story/game/dev/dev_unittest.rpy
@@ -2760,14 +2760,14 @@ label dev_unit_test_mas_set_pronouns:
                 )
                 pronouns_tester.assertEqual(expected_map_size, sub_map_size)
 
-            for k in ("M", "G", "X"):
+            for k in ("M", "F", "X"):
                 pronouns_tester.prepareTest(
                     "Validating the key {} is in the map".format(k)
                 )
                 pronouns_tester.assertTrue(k in sub_map)
 
         pronouns_tester.prepareTest("Check global pronouns variables")
-        for gender in ("M", "G", "X"):
+        for gender in ("M", "F", "X"):
             # Verify the func works
             mas_set_pronouns(gender)
 

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -818,7 +818,7 @@ init python:
         if gender is None:
             gender = store.persistent.gender
 
-        for word, sub_map in MAS_PRONOUN_GENDER_MAP.items():
+        for word, sub_map in store.MAS_PRONOUN_GENDER_MAP.items():
             if gender in sub_map:
                 value = sub_map[gender]
             else:

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -798,7 +798,7 @@ init python:
         """
         return store.persistent._mas_pm_cares_about_dokis is False
 
-    def mas_set_pronouns(gender=None):
+    def mas_set_pronouns(key=None):
         """
         Sets gender specific word replacements
 
@@ -810,17 +810,17 @@ init python:
         For all available pronouns/words check the keys in MAS_PRONOUN_GENDER_MAP
 
         IN:
-            gender - Optional[Literal["M", "G", "X"]] - gender to set the pronouns for
+            key - Optional[Literal["M", "G", "X"]] - key (perhaps current gender) to set the pronouns for
                 If None, uses persistent.gender
         """
         store = renpy.store
 
-        if gender is None:
-            gender = store.persistent.gender
+        if key is None:
+            key = store.persistent.gender
 
         for word, sub_map in store.MAS_PRONOUN_GENDER_MAP.items():
-            if gender in sub_map:
-                value = sub_map[gender]
+            if key in sub_map:
+                value = sub_map[key]
             else:
                 value = sub_map["X"]
             setattr(store, word, value)

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -295,17 +295,17 @@ image room_glitch = "images/cg/monika/monika_bg_glitch.png"
 
 # Gender specific word replacement
 define MAS_PRONOUN_GENDER_MAP = {
-    "his": {"M": "his", "G": "her", "X": "their"},
-    "he": {"M": "he", "G": "she", "X": "they"},
-    "hes": {"M": "he's", "G": "she's", "X": "they're"},
-    "heis": {"M": "he is", "G": "she is", "X": "they are"},
-    "bf": {"M": "boyfriend", "G": "girlfriend", "X": "partner"},
-    "man": {"M": "man", "G": "woman", "X": "person"},
-    "boy": {"M": "boy", "G": "girl", "X": "person"},
-    "guy": {"M": "guy", "G": "girl", "X": "person"},
-    "him": {"M": "him", "G": "her", "X": "them"},
-    "himself": {"M": "himself", "G": "herself", "X": "themselves"},
-    "hero": {"M": "hero", "G": "heroine", "X": "hero"}
+    "his": {"M": "his", "F": "her", "X": "their"},
+    "he": {"M": "he", "F": "she", "X": "they"},
+    "hes": {"M": "he's", "F": "she's", "X": "they're"},
+    "heis": {"M": "he is", "F": "she is", "X": "they are"},
+    "bf": {"M": "boyfriend", "F": "girlfriend", "X": "partner"},
+    "man": {"M": "man", "F": "woman", "X": "person"},
+    "boy": {"M": "boy", "F": "girl", "X": "person"},
+    "guy": {"M": "guy", "F": "girl", "X": "person"},
+    "him": {"M": "him", "F": "her", "X": "them"},
+    "himself": {"M": "himself", "F": "herself", "X": "themselves"},
+    "hero": {"M": "hero", "F": "heroine", "X": "hero"}
 }
 
 init python:
@@ -810,7 +810,7 @@ init python:
         For all available pronouns/words check the keys in MAS_PRONOUN_GENDER_MAP
 
         IN:
-            key - Optional[Literal["M", "G", "X"]] - key (perhaps current gender) to set the pronouns for
+            key - Optional[Literal["M", "F", "X"]] - key (perhaps current gender) to set the pronouns for
                 If None, uses persistent.gender
         """
         store = renpy.store

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -246,6 +246,7 @@ init -10 python:
 
     mas_idle_mailbox = MASIdleMailbox()
 
+
 image monika_room_highlight:
     "images/cg/monika/monika_room_highlight.png"
     function monika_alpha
@@ -289,12 +290,25 @@ image monika_body_glitch2:
     0.15
     "images/cg/monika/monika_glitch4.png"
 
-
-
 image room_glitch = "images/cg/monika/monika_bg_glitch.png"
 
-init python:
 
+# Gender specific word replacement
+define MAS_PRONOUN_GENDER_MAP = {
+    "his": {"M": "his", "G": "her", "X": "their"},
+    "he": {"M": "he", "G": "she", "X": "they"},
+    "hes": {"M": "he's", "G": "she's", "X": "they're"},
+    "heis": {"M": "he is", "G": "she is", "X": "they are"},
+    "bf": {"M": "boyfriend", "G": "girlfriend", "X": "partner"},
+    "man": {"M": "man", "G": "woman", "X": "person"},
+    "boy": {"M": "boy", "G": "girl", "X": "person"},
+    "guy": {"M": "guy", "G": "girl", "X": "person"},
+    "him": {"M": "him", "G": "her", "X": "them"},
+    "himself": {"M": "himself", "G": "herself", "X": "themselves"},
+    "hero": {"M": "hero", "G": "heroine", "X": "hero"}
+}
+
+init python:
     import subprocess
     import os
     import eliza      # mod specific
@@ -783,6 +797,33 @@ init python:
         RETURNS: True if safe to reference dokis
         """
         return store.persistent._mas_pm_cares_about_dokis is False
+
+    def mas_set_pronouns(gender=None):
+        """
+        Sets gender specific word replacements
+
+        Few examples:
+            "It is his pen." (if the player's gender is declared as male)
+            "It is her pen." (if the player's gender is declared as female)
+            "It is their pen." (if player's gender is not declared)
+
+        For all available pronouns/words check the keys in MAS_PRONOUN_GENDER_MAP
+
+        IN:
+            gender - Optional[Literal["M", "G", "X"]] - gender to set the pronouns for
+                If None, uses persistent.gender
+        """
+        store = renpy.store
+
+        if gender is None:
+            gender = store.persistent.gender
+
+        for word, sub_map in MAS_PRONOUN_GENDER_MAP.items():
+            if gender in sub_map:
+                value = sub_map[gender]
+            else:
+                value = sub_map["X"]
+            setattr(store, word, value)
 
 
 # IN:


### PR DESCRIPTION
### Changes:
- the pronouns map is global now
- don't duplicate the keys anymore (I think this way it's cleaner, but I can revert that change)
- use `setattr` to dynamically add new words from the map (easier to maintain)
- `mas_set_gender` is deprecated, we don't set gender, we set pronouns. Now the old label calls new new function - `mas_set_pronouns`
- New function: `mas_set_pronouns` accepts the `key` param, by default `None`. if `None`, uses the `persistent.gender` to access the pronouns map
- New unittest to test this

### Testing:
- run test, verify it works
