### PR TITLE
Linux support for `is_running()`

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -5510,16 +5510,16 @@ init -1 python:
                     # 1: Did not find
                     if output == 0:
                         return True
-                except:
-                    pass
-        
-        running_procs = get_procs()
-        if len(running_procs) == 0:
-            return False
-
-        for proc in proc_list:
-            if proc in running_procs:
-                return True
+                except Exception:
+                    return False # If it didn't work here, it probably won't work again, so lets bail here.
+        elif renpy.windows:        
+            running_procs = get_procs()
+            if len(running_procs) == 0:
+                return False
+    
+            for proc in proc_list:
+                if proc in running_procs:
+                    return True
 
         # otherwise, not found
         return False

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -5500,6 +5500,19 @@ init -1 python:
 
         RETURNS: True if a proccess in proc_list is running, False otherwise
         """
+        if renpy.linux:
+            for proc in proc_list:
+                import subprocess
+                try:
+                    output = subprocess.call(["pidof", proc])
+
+                    # 0: Success
+                    # 1: Did not find
+                    if output == 0:
+                        return True
+                except:
+                    pass
+        
         running_procs = get_procs()
         if len(running_procs) == 0:
             return False

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -5500,7 +5500,15 @@ init -1 python:
 
         RETURNS: True if a proccess in proc_list is running, False otherwise
         """
-        if renpy.linux:
+        if renpy.windows:        
+            running_procs = get_procs()
+            if len(running_procs) == 0:
+                return False
+    
+            for proc in proc_list:
+                if proc in running_procs:
+                    return True
+        elif renpy.linux:
             for proc in proc_list:
                 try:
                     output = subprocess.call(["pidof", proc])
@@ -5511,14 +5519,6 @@ init -1 python:
                         return True
                 except Exception:
                     return False # If it didn't work here, it probably won't work again, so lets bail here.
-        elif renpy.windows:        
-            running_procs = get_procs()
-            if len(running_procs) == 0:
-                return False
-    
-            for proc in proc_list:
-                if proc in running_procs:
-                    return True
 
         # otherwise, not found
         return False


### PR DESCRIPTION
I briefly went over this change in #9008, but for clarity's sake I'll explain it again here in a little bit more detail:

This works a bit differently than Windows, as in it won't check a list of all running process, rather it will use the error code output of `pidof [program_name]`. 

I did look into getting Linux support for `get_procs()` but it didn't seem like there would be a way to get it in a clean way since `ps`, the only definitely-on-the-system-by-default utility I can think of shows full paths and arguments no matter what, so I left it. This could be problematic in the future if you or a submod decides to use `get_procs()`, however I don't see any other usages of it other than the one in `is_running()`.

If this command is available on Mac by default on a fresh installation let me know, and I can go ahead and enable that branch for Mac. Right now I don't have access to a Mac that doesn't have stuff like Homebrew on it, though, so I wouldn't be able to tell.