### PR TITLE
Check consumables topic

### DIFF
--- a/Monika After Story/game/zz_consumables.rpy
+++ b/Monika After Story/game/zz_consumables.rpy
@@ -1845,7 +1845,7 @@ label monika_consumables_check:
 
         else:
             $ items_running_out_of = low_cons[0].disp_name
-            m 3rusdlb "Oh{w=0.1}, good you asked!"
+            m 3rusdlb "Oh{w=0.1}, glad you asked!"
             m 1rksdla "I've been running out of [items_running_out_of]."
             m 1eka "I'd appreciate if you could get some for me~"
 

--- a/Monika After Story/game/zz_consumables.rpy
+++ b/Monika After Story/game/zz_consumables.rpy
@@ -1823,8 +1823,8 @@ init 5 python:
         Event(
             persistent.event_database,
             eventlabel="monika_consumables_check",
-            category=['consumables'],
-            prompt="Can you check if you are running out of any consumables?",
+            category=['supplies'],
+            prompt="Are you running out of anything?",
             conditional="MASConsumable._getEnabledConsumables()",
             pool=True,
             unlocked=False,
@@ -1837,8 +1837,8 @@ label monika_consumables_check:
     #Firstly, let's get what we're low on.
     $ low_cons = MASConsumable._getLowCons()
 
-    m 1hua "Sure!"
-    m 3eub "Give me a moment to check.{w=0.2}.{w=0.2}.{w=0.2}{nw}"
+    m 1rtd "Umm...{w=0.3}{nw}"
+    extend 3eua "let me check.{w=0.2}.{w=0.2}.{w=0.2}{nw}"
 
     #Monika goes off screen
     call mas_transition_to_emptydesk
@@ -1847,12 +1847,12 @@ label monika_consumables_check:
 
     call mas_transition_from_emptydesk("monika 1eua")
 
-    m 1hua "Back!"
+    m 1hub "Back!"
 
     if len(low_cons) > 2:
         $ mas_generateShoppingList(low_cons)
-        m 3rksdla "I've been running out of a few things in here..."
-        m 3eua "So I hope you don't mind, but I left you a list of things in the characters folder."
+        m 3rksdla "I'm actually running out of a few things..."
+        m 3eua "I hope you don't mind, but I left you a list of things in the characters folder."
         m 1eka "You wouldn't mind getting them for me, would you?"
 
     elif len(low_cons) > 0:
@@ -1867,7 +1867,7 @@ label monika_consumables_check:
         m 1eka "You wouldn't mind getting some more for me, would you?"
 
     else:
-        m 3eub "I'm not running out of anything at the moment."
-        m 3eua "But if I run out of something, I'll let you know."
+        m 3eua "I'm not running out of anything at the moment, [player]...{w=0.3}{nw}"
+        extend 3hua "but I'll be sure to let you know if I do~"
 
     return

--- a/Monika After Story/game/zz_consumables.rpy
+++ b/Monika After Story/game/zz_consumables.rpy
@@ -1817,3 +1817,57 @@ label mas_consumables_candycane_finish_having:
         else:
             m 1eua "Okay, what else should we do today?"
     return
+
+init 5 python:
+    addEvent(
+        Event(
+            persistent.event_database,
+            eventlabel="monika_consumables_check",
+            category=['consumables'],
+            prompt="Can you check if you are running out of any consumables?",
+            conditional="MASConsumable._getEnabledConsumables()",
+            pool=True,
+            unlocked=False,
+            action=EV_ACT_UNLOCK,
+            rules={"no_unlock": None},
+        )
+    )
+
+label monika_consumables_check:
+    #Firstly, let's get what we're low on.
+    $ low_cons = MASConsumable._getLowCons()
+
+    m 1hua "Sure!"
+    m 3eub "Give me a moment to check.{w=0.2}.{w=0.2}.{w=0.2}{nw}"
+
+    #Monika goes off screen
+    call mas_transition_to_emptydesk
+
+    pause 5.0
+
+    call mas_transition_from_emptydesk("monika 1eua")
+
+    m 1hua "Back!"
+
+    if len(low_cons) > 2:
+        $ mas_generateShoppingList(low_cons)
+        m 3rksdla "I've been running out of a few things in here..."
+        m 3eua "So I hope you don't mind, but I left you a list of things in the characters folder."
+        m 1eka "You wouldn't mind getting them for me, would you?"
+
+    elif len(low_cons) > 0:
+        python:
+            items_running_out_of = ""
+            if len(low_cons) == 2:
+                items_running_out_of = "{0} and {1}".format(low_cons[0].disp_name, low_cons[1].disp_name)
+            else:
+                items_running_out_of = low_cons[0].disp_name
+
+        m 3rksdla "I'm running out of [items_running_out_of]."
+        m 1eka "You wouldn't mind getting some more for me, would you?"
+
+    else:
+        m 3eub "I'm not running out of anything at the moment."
+        m 3eua "But if I run out of something, I'll let you know."
+
+    return

--- a/Monika After Story/game/zz_consumables.rpy
+++ b/Monika After Story/game/zz_consumables.rpy
@@ -1837,6 +1837,20 @@ label monika_consumables_check:
     #Firstly, let's get what we're low on.
     $ low_cons = MASConsumable._getLowCons()
 
+    # Quick path if Monika needs 1 or none of consumables
+    if len(low_cons) < 2 and random.random() > 0.5:
+        if not low_cons:
+            m 3eua "Oh{w=0.1}, I'm not running out of anything at the moment, [player]...{w=0.3}{nw}"
+            extend 3hua "but I'll be sure to let you know if I do~"
+
+        else:
+            $ items_running_out_of = low_cons[0].disp_name
+            m 3rusdlb "Oh{w=0.1}, good you asked!"
+            m 1rksdla "I've been running out of [items_running_out_of]."
+            m 1eka "I'd appreciate if you could get some for me~"
+
+        return
+
     m 1rtd "Umm...{w=0.3}{nw}"
     extend 3eua "let me check.{w=0.2}.{w=0.2}.{w=0.2}{nw}"
 


### PR DESCRIPTION
Adds a new pool topic where you can ask Monika to check the stock of all her enabled warnable consumables.

### Testing:
- While having no enabled consumables and with the topic locked, confirm that the topic stays locked.
- After enabling any consumable confirm that the topic gets unlocked. (Note: The topic remains unlocked even if all the consumables are disabled after its initial unlocking.)
- Confirm the topic doesn't randomly gets unlocked by any rogue sentient xp systems.
- Confirm that Monika only informs you about enabled warnable consumables.
- Confirm no crashes and random spaceroom fires.
