### PR TITLE
Fix `extend` jarring

### DIFF
--- a/Monika After Story/game/screens.rpy
+++ b/Monika After Story/game/screens.rpy
@@ -219,7 +219,8 @@ style edited is default:
     xanchor gui.text_xalign
     xsize gui.text_width
     text_align gui.text_xalign
-    layout ("subtitle" if gui.text_xalign else "tex")
+    # layout ("subtitle" if gui.text_xalign else "tex")
+    layout "greedy"
 
 style edited_dark is default:
     font "gui/font/VerilySerifMono.otf"
@@ -229,14 +230,18 @@ style edited_dark is default:
     xanchor gui.text_xalign
     xsize gui.text_width
     text_align gui.text_xalign
-    layout ("subtitle" if gui.text_xalign else "tex")
+    # layout ("subtitle" if gui.text_xalign else "tex")
+    layout "greedy"
 
 style normal is default:
     pos (gui.text_xpos, gui.text_ypos)
     xanchor gui.text_xalign
     xsize gui.text_width
     text_align gui.text_xalign
-    layout ("subtitle" if gui.text_xalign else "tex")
+    # layout ("subtitle" if gui.text_xalign else "tex")
+    layout "greedy"
+    justify False
+    adjust_spacing False
 
 style input:
     color gui.accent_color
@@ -495,7 +500,10 @@ style say_dialogue is default:
     xsize gui.text_width
     ypos gui.text_ypos
     text_align gui.text_xalign
-    layout ("subtitle" if gui.text_xalign else "tex")
+    # layout ("subtitle" if gui.text_xalign else "tex")
+    layout "greedy"
+    justify False
+    adjust_spacing False
 
 style say_thought is say_dialogue
 


### PR DESCRIPTION
A very old issue with the `extend` character...

### Changes:
- Basically `adjust_spacing` can't be used with `extend`, it's so bad that Tom even disabled it for the `say` screen in the latest versions
- `justify` causes similar issues, but it's not even needed, so disable it explicitly
- `layout "greedy"` is the only layout that works well with `extend`s

### Testing:
- I tried to change only the styles that relevant to dialogues (the `say` screen), but test overall UI (especially inputs) and see if anything is wrong
- Test different topics, especially those that use a lot of `extend`s, verify text doesn't change size/position

A simple test example, copy paste into console:
```renpy
m 2tsd "Not so long ago, people looked down on playing video games like it was a waste of time, {w=0.1}{nw}"
extend 7hub "but now some of these players are making millions of dollars playing some of their favorite games!"
```