### PR TITLE
Fix safe mod issues

### DIFF
--- a/Monika After Story/game/0config.rpy
+++ b/Monika After Story/game/0config.rpy
@@ -124,3 +124,8 @@ define config.main_menu_music = audio.t1
 
 define config.window_show_transition = dissolve_textbox
 define config.window_hide_transition = dissolve_textbox
+
+# RenPain enables gl tests by default
+# which users might accidentally start by holding shift on startup
+# We don't want this to happen
+define config.performance_test = False

--- a/Monika After Story/game/splash.rpy
+++ b/Monika After Story/game/splash.rpy
@@ -328,12 +328,12 @@ label before_main_menu:
     return
 
 label quit:
-    python:
+    python hide:
         store.mas_calendar.saveCalendarDatabase(CustomEncoder)
         persistent.sessions['last_session_end']=datetime.datetime.now()
         today_time = (
-            persistent.sessions["last_session_end"]
-            - persistent.sessions["current_session_start"]
+            mas_getLastSeshEnd()
+            - mas_getCurrSeshStart()
         )
         new_time = today_time + persistent.sessions["total_playtime"]
 

--- a/Monika After Story/game/zz_graphicsmenu.rpy
+++ b/Monika After Story/game/zz_graphicsmenu.rpy
@@ -388,5 +388,8 @@ label mas_gmenu_start:
     return
 
 label mas_choose_renderer_override:
-    # if we do this somehow, just quit immediately.
-    jump _quit
+    # This label can be called by renpy when launched in safe mod
+    # (holding shift on windows)
+    # We provide our own renderer menu
+    # and this one should be disabled, so we just return
+    return


### PR DESCRIPTION
## We still need to figure out do we want `mas_choose_renderer_override` to return or crash. I propose just returning

Fixes:
- fixed issue where there was a possibility of doing `datetime.datetime() - None` 
- moved `quit` label code into the `hide` namespace because there's no reason not to encapsulate
- set `config.performance_test` to `False` to disable GL testing done by renpy
- `mas_choose_renderer_override` now just `return`s instead of silently closing the game (because that had a chance to cause the first issue)