### PR TITLE
Implement augmented jump

### DIFF
--- a/Monika After Story/game/0statements.rpy
+++ b/Monika After Story/game/0statements.rpy
@@ -1,0 +1,109 @@
+python early in mas_statements:
+    from collections import namedtuple
+
+    __AugJumpParseData = namedtuple("__AugJumpParseData", ("label", "is_expression", "arg_info"))
+
+    def __get_label(parsed_data):
+        """
+        Returns label from the parsed data
+        NOTE: may raise exceptions
+
+        IN:
+            parsed_data - __AugJumpParseData for this statement
+
+        OUT:
+            str
+        """
+        label_ = parsed_data.label
+        if parsed_data.is_expression:
+            label_ = eval(label_)
+        return label_
+
+    def __parse_augmented_jump(lex):
+        """
+        Parses the aug_jump statement
+
+        IN:
+            lex - the Lexer object
+
+        OUT:
+            __AugJumpParseData
+        """
+        lex.expect_noblock("aug_jump")
+
+        if lex.keyword("expression"):
+            is_expression = True
+            label_ = lex.require(lex.simple_expression)
+            lex.keyword("pass")
+
+        else:
+            is_expression = False
+            label_ = lex.require(lex.label_name)
+
+        arg_info = renpy.parser.parse_arguments(lex)
+
+        lex.expect_eol()
+        lex.advance()
+
+        return __AugJumpParseData(label_, is_expression, arg_info)
+
+    def __execute_augmented_jump(parsed_data):
+        """
+        Executes the aug_jump statement
+
+        IN:
+            parsed_data - __AugJumpParseData for this statement
+        """
+        label_ = __get_label(parsed_data)
+
+        arg_info = parsed_data.arg_info
+        if arg_info:
+            args, kwargs = arg_info.evaluate()
+            renpy.store._args = args
+            renpy.store._kwargs = kwargs
+
+        else:
+            renpy.store._args = None
+            renpy.store._kwargs = None
+
+        renpy.jump(label_)
+
+    def __predict_augmented_jump(parsed_data):
+        """
+        Predicts the aug_jump statement
+
+        IN:
+            parsed_data - __AugJumpParseData for this statement
+        """
+        try:
+            label_ = __get_label(parsed_data)
+        except Exception:
+            return
+
+        if not renpy.has_label(label_):
+            return
+
+        return [renpy.game.script.lookup(label)]
+
+    def __lint_augmented_jump(parsed_data):
+        """
+        A lint function for the aug_jump statement
+
+        IN:
+            parsed_data - __AugJumpParseData for this statement
+        """
+        try:
+            label_ = __get_label(parsed_data)
+        except Exception:
+            return
+
+        if not renpy.has_label(label_):
+            raise Exception("aug_jump is being used with unknown label: '{}'", label_)
+
+    renpy.register_statement(
+        "aug_jump",
+        parse=__parse_augmented_jump,
+        execute=__execute_augmented_jump,
+        predict=__predict_augmented_jump,
+        lint=__lint_augmented_jump
+    )

--- a/Monika After Story/game/0statements.rpy
+++ b/Monika After Story/game/0statements.rpy
@@ -3,6 +3,34 @@ python early in mas_statements:
 
     __AugJumpParseData = namedtuple("__AugJumpParseData", ("label", "is_expression", "arg_info"))
 
+
+    def __aug_jump(label, args, kwargs):
+        """
+        Jumps to the given label and passes the provided args and kwargs
+        You're probably looking for mas_aug_jump which
+            utilises Python's * and ** starred syntax
+
+        IN:
+            label - the label to jump to
+            args - the positional arguments for the label
+            kwargs - the named arguments forthe label
+        """
+        renpy.store._args = args
+        renpy.store._kwargs = kwargs
+        renpy.jump(label)
+
+    def mas_aug_jump(label, *args, **kwargs):
+        """
+        Jumps to the given label and passes the provided args and kwargs
+
+        IN:
+            label - the label to jump to
+            *args - the positional arguments for the label
+            **kwargs - the named arguments forthe label
+        """
+        __aug_jump(label, args, kwargs)
+
+
     def __get_label(parsed_data):
         """
         Returns label from the parsed data
@@ -59,14 +87,10 @@ python early in mas_statements:
         arg_info = parsed_data.arg_info
         if arg_info:
             args, kwargs = arg_info.evaluate()
-            renpy.store._args = args
-            renpy.store._kwargs = kwargs
+            __aug_jump(label_, args, kwargs)
 
         else:
-            renpy.store._args = None
-            renpy.store._kwargs = None
-
-        renpy.jump(label_)
+            __aug_jump(label_, None, None)
 
     def __predict_augmented_jump(parsed_data):
         """
@@ -100,6 +124,8 @@ python early in mas_statements:
         if not renpy.has_label(label_):
             raise Exception("aug_jump is being used with unknown label: '{}'", label_)
 
+
+    # Define the new statement
     renpy.register_statement(
         "aug_jump",
         parse=__parse_augmented_jump,
@@ -107,3 +133,5 @@ python early in mas_statements:
         predict=__predict_augmented_jump,
         lint=__lint_augmented_jump
     )
+    # Expose to the global namespace
+    renpy.store.mas_aug_jump = mas_aug_jump

--- a/Monika After Story/game/0statements.rpy
+++ b/Monika After Story/game/0statements.rpy
@@ -1,13 +1,13 @@
 python early in mas_statements:
     from collections import namedtuple
 
-    __AugJumpParseData = namedtuple("__AugJumpParseData", ("label", "is_expression", "arg_info"))
+    __JumpWithArgsParseData = namedtuple("__JumpWithArgsParseData", ("label", "is_expression", "arg_info"))
 
 
-    def __aug_jump(label, args, kwargs):
+    def __jump_with_args(label, args, kwargs):
         """
         Jumps to the given label and passes the provided args and kwargs
-        You're probably looking for mas_aug_jump which
+        You're probably looking for mas_jump_with_args which
             utilises Python's * and ** starred syntax
 
         IN:
@@ -19,7 +19,7 @@ python early in mas_statements:
         renpy.store._kwargs = kwargs
         renpy.jump(label)
 
-    def mas_aug_jump(label, *args, **kwargs):
+    def mas_jump_with_args(label, *args, **kwargs):
         """
         Jumps to the given label and passes the provided args and kwargs
 
@@ -28,7 +28,7 @@ python early in mas_statements:
             *args - the positional arguments for the label
             **kwargs - the named arguments forthe label
         """
-        __aug_jump(label, args, kwargs)
+        __jump_with_args(label, args, kwargs)
 
 
     def __get_label(parsed_data):
@@ -37,7 +37,7 @@ python early in mas_statements:
         NOTE: may raise exceptions
 
         IN:
-            parsed_data - __AugJumpParseData for this statement
+            parsed_data - __JumpWithArgsParseData for this statement
 
         OUT:
             str
@@ -47,17 +47,17 @@ python early in mas_statements:
             label_ = eval(label_)
         return label_
 
-    def __parse_augmented_jump(lex):
+    def __parse_jump_with_args(lex):
         """
-        Parses the aug_jump statement
+        Parses the jump_with_args statement
 
         IN:
             lex - the Lexer object
 
         OUT:
-            __AugJumpParseData
+            __JumpWithArgsParseData
         """
-        lex.expect_noblock("aug_jump")
+        lex.expect_noblock("jarg")
 
         if lex.keyword("expression"):
             is_expression = True
@@ -73,31 +73,31 @@ python early in mas_statements:
         lex.expect_eol()
         lex.advance()
 
-        return __AugJumpParseData(label_, is_expression, arg_info)
+        return __JumpWithArgsParseData(label_, is_expression, arg_info)
 
-    def __execute_augmented_jump(parsed_data):
+    def __execute_jump_with_args(parsed_data):
         """
-        Executes the aug_jump statement
+        Executes the jump_with_args statement
 
         IN:
-            parsed_data - __AugJumpParseData for this statement
+            parsed_data - __JumpWithArgsParseData for this statement
         """
         label_ = __get_label(parsed_data)
 
         arg_info = parsed_data.arg_info
         if arg_info:
             args, kwargs = arg_info.evaluate()
-            __aug_jump(label_, args, kwargs)
+            __jump_with_args(label_, args, kwargs)
 
         else:
-            __aug_jump(label_, None, None)
+            __jump_with_args(label_, None, None)
 
-    def __predict_augmented_jump(parsed_data):
+    def __predict_jump_with_args(parsed_data):
         """
-        Predicts the aug_jump statement
+        Predicts the jump_with_args statement
 
         IN:
-            parsed_data - __AugJumpParseData for this statement
+            parsed_data - __JumpWithArgsParseData for this statement
         """
         try:
             label_ = __get_label(parsed_data)
@@ -109,12 +109,12 @@ python early in mas_statements:
 
         return [renpy.game.script.lookup(label)]
 
-    def __lint_augmented_jump(parsed_data):
+    def __lint_jump_with_args(parsed_data):
         """
-        A lint function for the aug_jump statement
+        A lint function for the jump_with_args statement
 
         IN:
-            parsed_data - __AugJumpParseData for this statement
+            parsed_data - __JumpWithArgsParseData for this statement
         """
         try:
             label_ = __get_label(parsed_data)
@@ -122,16 +122,17 @@ python early in mas_statements:
             return
 
         if not renpy.has_label(label_):
-            raise Exception("aug_jump is being used with unknown label: '{}'", label_)
+            raise Exception("jarg is being used with unknown label: '{}'", label_)
 
 
     # Define the new statement
     renpy.register_statement(
-        "aug_jump",
-        parse=__parse_augmented_jump,
-        execute=__execute_augmented_jump,
-        predict=__predict_augmented_jump,
-        lint=__lint_augmented_jump
+        "jarg", 
+        parse=__parse_jump_with_args,
+        execute=__execute_jump_with_args,
+        predict=__predict_jump_with_args,
+        lint=__lint_jump_with_args
     )
+
     # Expose to the global namespace
-    renpy.store.mas_aug_jump = mas_aug_jump
+    renpy.store.mas_jump_with_args = mas_jump_with_args

--- a/Monika After Story/game/dev/dev_unittest.rpy
+++ b/Monika After Story/game/dev/dev_unittest.rpy
@@ -13,7 +13,7 @@ init -1 python in mas_dev_unit_tests:
         ("WRS REGEXP Tests", "dev_unit_test_wrs_regexpchecks", False, False),
         ("strict_can_pickle", "dev_unit_test_strict_can_pickle", False, False),
         ("mas_set_pronouns", "dev_unit_test_mas_set_pronouns", False, False),
-        ("Augmented jump", "dev_unit_test_aug_jump", False, False)
+        ("Jump with args", "dev_unit_test_jump_with_args", False, False)
     ]
 
     class MASUnitTest(object):
@@ -2795,7 +2795,7 @@ label dev_unit_test_mas_set_pronouns:
     return
 
 
-label dev_unit_test_aug_jump:
+label dev_unit_test_jump_with_args:
     m "Running tests..."
 
     $ jump_tester = store.mas_dev_unit_tests.MASUnitTester()
@@ -2806,39 +2806,39 @@ label dev_unit_test_aug_jump:
     $ e = None
     python:
         try:
-            mas_aug_jump("dev_unit_test_aug_jump_crash_no_args", "crash", "aboom")
+            mas_jump_with_args("dev_unit_test_jump_with_args_crash_no_args", "crash", "aboom")
         except Exception as e:
             pass
     $ jump_tester.assertIsNotNone(e)
 
-    call dev_unit_test_aug_jump_no_test_vars_in_store
+    call dev_unit_test_jump_with_args_no_test_vars_in_store
 
     $ jump_tester.prepareTest("Validate no test vars in store after jumping without args")
-    call dev_unit_test_aug_jump_redirector("dev_unit_test_aug_jump_no_args")
+    call dev_unit_test_jump_with_args_redirector("dev_unit_test_jump_with_args_no_args")
 
     $ jump_tester.prepareTest("Validate 'foo' is in store after jumping with args")
-    call dev_unit_test_aug_jump_redirector("dev_unit_test_aug_jump_foo", "foo_value")
+    call dev_unit_test_jump_with_args_redirector("dev_unit_test_jump_with_args_foo", "foo_value")
 
     $ jump_tester.prepareTest("Validate 'foo' is in store and 'bar' kept default value")
-    call dev_unit_test_aug_jump_redirector("dev_unit_test_aug_jump_foo_bar", "another_foo_value")
+    call dev_unit_test_jump_with_args_redirector("dev_unit_test_jump_with_args_foo_bar", "another_foo_value")
 
-    call dev_unit_test_aug_jump_no_test_vars_in_store
+    call dev_unit_test_jump_with_args_no_test_vars_in_store
 
     $ jump_tester.prepareTest("Validate nested calls/jumps work as intended")
-    call dev_unit_test_aug_jump_redirector("dev_unit_test_aug_jump_depth_0", foo="foo_value", bar="bar_value")
+    call dev_unit_test_jump_with_args_redirector("dev_unit_test_jump_with_args_depth_0", foo="foo_value", bar="bar_value")
 
-    call dev_unit_test_aug_jump_no_test_vars_in_store
+    call dev_unit_test_jump_with_args_no_test_vars_in_store
 
     call dev_unit_tests_finish_test(jump_tester)
     $ del jump_tester, TEST_VARS, e
 
     return
 
-label dev_unit_test_aug_jump_redirector(label, *args, **kwargs):
-    $ mas_aug_jump(label, *args, **kwargs)
+label dev_unit_test_jump_with_args_redirector(label, *args, **kwargs):
+    $ mas_jump_with_args(label, *args, **kwargs)
     return
 
-label dev_unit_test_aug_jump_no_test_vars_in_store:
+label dev_unit_test_jump_with_args_no_test_vars_in_store:
     $ jump_tester.prepareTest("Validate no test vars in store")
     python:
         for i in TEST_VARS:
@@ -2846,16 +2846,16 @@ label dev_unit_test_aug_jump_no_test_vars_in_store:
             jump_tester.assertFalse(hasattr(store, i))
     return
 
-label dev_unit_test_aug_jump_crash_no_args:
+label dev_unit_test_jump_with_args_crash_no_args:
     # We should crash before reaching this
     $ raise Exception("YOU SHOULDN'T GET HERE")
     return
 
-label dev_unit_test_aug_jump_no_args():
-    call dev_unit_test_aug_jump_no_test_vars_in_store
+label dev_unit_test_jump_with_args_no_args():
+    call dev_unit_test_jump_with_args_no_test_vars_in_store
     return
 
-label dev_unit_test_aug_jump_foo(foo):
+label dev_unit_test_jump_with_args_foo(foo):
     python:
         jump_tester.prepareTest("Validating 'foo' is in store")
         jump_tester.assertEqual(getattr(store, "foo", None), "foo_value")
@@ -2864,7 +2864,7 @@ label dev_unit_test_aug_jump_foo(foo):
         jump_tester.assertFalse(hasattr(store, "bar"))
     return
 
-label dev_unit_test_aug_jump_foo_bar(foo, bar="bar_default"):
+label dev_unit_test_jump_with_args_foo_bar(foo, bar="bar_default"):
     python:
         jump_tester.prepareTest("Validating 'foo' is in store")
         jump_tester.assertEqual(getattr(store, "foo", None), "another_foo_value")
@@ -2873,26 +2873,26 @@ label dev_unit_test_aug_jump_foo_bar(foo, bar="bar_default"):
         jump_tester.assertEqual(getattr(store, "bar", None), "bar_default")
     return
 
-label dev_unit_test_aug_jump_depth_0(foo, bar):
+label dev_unit_test_jump_with_args_depth_0(foo, bar):
     python:
         for name in TEST_VARS:
             jump_tester.prepareTest("Validating '{}' is in store".format(name))
             jump_tester.assertEqual(getattr(store, name, None), "{}_value".format(name))
 
-    call dev_unit_test_aug_jump_depth_1("wow a egg")
+    call dev_unit_test_jump_with_args_depth_1("wow a egg")
 
-    aug_jump expression "dev_unit_test_aug_jump_depth_2" pass ("brand_new_foo_value", "brand_new_bar_value")
+    jarg expression "dev_unit_test_jump_with_args_depth_2" pass ("brand_new_foo_value", "brand_new_bar_value")
 
     return
 
-label dev_unit_test_aug_jump_depth_1(egg):
+label dev_unit_test_jump_with_args_depth_1(egg):
     python:
         for name in TEST_VARS:
             jump_tester.prepareTest("Validating '{}' is still in store".format(name))
             jump_tester.assertEqual(getattr(store, name, None), "{}_value".format(name))
     return
 
-label dev_unit_test_aug_jump_depth_2(foo, bar):
+label dev_unit_test_jump_with_args_depth_2(foo, bar):
     python:
         for name in TEST_VARS:
             jump_tester.prepareTest("Validating '{}' got a new value".format(name))

--- a/Monika After Story/game/dev/dev_unittest.rpy
+++ b/Monika After Story/game/dev/dev_unittest.rpy
@@ -12,7 +12,8 @@ init -1 python in mas_dev_unit_tests:
         ("UTC APIs", "dev_unit_test_utc_api", False, False),
         ("WRS REGEXP Tests", "dev_unit_test_wrs_regexpchecks", False, False),
         ("strict_can_pickle", "dev_unit_test_strict_can_pickle", False, False),
-        ("mas_set_pronouns", "dev_unit_test_mas_set_pronouns", False, False)
+        ("mas_set_pronouns", "dev_unit_test_mas_set_pronouns", False, False),
+        ("Augmented jump", "dev_unit_test_aug_jump", False, False)
     ]
 
     class MASUnitTest(object):
@@ -2791,4 +2792,112 @@ label dev_unit_test_mas_set_pronouns:
     call dev_unit_tests_finish_test(pronouns_tester)
     $ del pronouns_tester
 
+    return
+
+
+label dev_unit_test_aug_jump:
+    m "Running tests..."
+
+    $ jump_tester = store.mas_dev_unit_tests.MASUnitTester()
+    $ TEST_VARS = ("foo", "bar")
+
+    $ jump_tester.prepareTest("Expecting a crash if jumped and gave args to a label without args")
+    # This is janky...
+    $ e = None
+    python:
+        try:
+            mas_aug_jump("dev_unit_test_aug_jump_crash_no_args", "crash", "aboom")
+        except Exception as e:
+            pass
+    $ jump_tester.assertIsNotNone(e)
+
+    call dev_unit_test_aug_jump_no_test_vars_in_store
+
+    $ jump_tester.prepareTest("Validate no test vars in store after jumping without args")
+    call dev_unit_test_aug_jump_redirector("dev_unit_test_aug_jump_no_args")
+
+    $ jump_tester.prepareTest("Validate 'foo' is in store after jumping with args")
+    call dev_unit_test_aug_jump_redirector("dev_unit_test_aug_jump_foo", "foo_value")
+
+    $ jump_tester.prepareTest("Validate 'foo' is in store and 'bar' kept default value")
+    call dev_unit_test_aug_jump_redirector("dev_unit_test_aug_jump_foo_bar", "another_foo_value")
+
+    call dev_unit_test_aug_jump_no_test_vars_in_store
+
+    $ jump_tester.prepareTest("Validate nested calls/jumps work as intended")
+    call dev_unit_test_aug_jump_redirector("dev_unit_test_aug_jump_depth_0", foo="foo_value", bar="bar_value")
+
+    call dev_unit_test_aug_jump_no_test_vars_in_store
+
+    call dev_unit_tests_finish_test(jump_tester)
+    $ del jump_tester, TEST_VARS, e
+
+    return
+
+label dev_unit_test_aug_jump_redirector(label, *args, **kwargs):
+    $ mas_aug_jump(label, *args, **kwargs)
+    return
+
+label dev_unit_test_aug_jump_no_test_vars_in_store:
+    $ jump_tester.prepareTest("Validate no test vars in store")
+    python:
+        for i in TEST_VARS:
+            jump_tester.prepareTest("Validating '{}' is not in store".format(i))
+            jump_tester.assertFalse(hasattr(store, i))
+    return
+
+label dev_unit_test_aug_jump_crash_no_args:
+    # We should crash before reaching this
+    $ raise Exception("YOU SHOULDN'T GET HERE")
+    return
+
+label dev_unit_test_aug_jump_no_args():
+    call dev_unit_test_aug_jump_no_test_vars_in_store
+    return
+
+label dev_unit_test_aug_jump_foo(foo):
+    python:
+        jump_tester.prepareTest("Validating 'foo' is in store")
+        jump_tester.assertEqual(getattr(store, "foo", None), "foo_value")
+
+        jump_tester.prepareTest("Validating 'bar' is not in store")
+        jump_tester.assertFalse(hasattr(store, "bar"))
+    return
+
+label dev_unit_test_aug_jump_foo_bar(foo, bar="bar_default"):
+    python:
+        jump_tester.prepareTest("Validating 'foo' is in store")
+        jump_tester.assertEqual(getattr(store, "foo", None), "another_foo_value")
+
+        jump_tester.prepareTest("Validating 'bar' is in store by default")
+        jump_tester.assertEqual(getattr(store, "bar", None), "bar_default")
+    return
+
+label dev_unit_test_aug_jump_depth_0(foo, bar):
+    python:
+        for name in TEST_VARS:
+            jump_tester.prepareTest("Validating '{}' is in store".format(name))
+            jump_tester.assertEqual(getattr(store, name, None), "{}_value".format(name))
+
+    call dev_unit_test_aug_jump_depth_1("wow a egg")
+
+    aug_jump expression "dev_unit_test_aug_jump_depth_2" pass ("brand_new_foo_value", "brand_new_bar_value")
+
+    return
+
+label dev_unit_test_aug_jump_depth_1(egg):
+    python:
+        for name in TEST_VARS:
+            jump_tester.prepareTest("Validating '{}' is still in store".format(name))
+            jump_tester.assertEqual(getattr(store, name, None), "{}_value".format(name))
+    return
+
+label dev_unit_test_aug_jump_depth_2(foo, bar):
+    python:
+        for name in TEST_VARS:
+            jump_tester.prepareTest("Validating '{}' got a new value".format(name))
+            jump_tester.assertEqual(getattr(store, name, None), "brand_new_{}_value".format(name))
+
+        jump_tester.prepareTest("Validating 'egg' is not in store")
+        jump_tester.assertFalse(hasattr(store, "egg"))
     return


### PR DESCRIPTION
Jump and take your arguments with you!

Allows to `jump` and pass arguments to the label. Example code:
```renpy
label test_start:
    m "We're starting"
    call test_1
    return

label test_1(a=0):
    m "a=[a], expected 0"
    aug_jump test_2(1)

label test_2(a, b=2):
    m "a=[a], b=[b]; expected 1 and 2"
    jump test_3

label test_3(c=3):
    m "a=[a], b=[b], c=[c]; expected 1, 2, and 3"

label test_4(a=-1):
    m "a=[a], b=[b], c=[c]; expected -1, 2, and 3"
    return
```
This is a noninvasive addition since its our own custom statement, I tried to use ""documented"" public API, so even with future updates we wouldn't need to change anything. This allows us to clean up docstat and some menu flows. The new statement has the exact same syntax like the default `jump` and `call`:
- `aug_jump expression "label_name" pass (arg1=1, arg2="2")`
- `aug_jump some_label`
- `aug_jump another_label(foo="bar")`
- lint support included
- unittests included