### PR TITLE
WR cleanup + guardrail

### DIFF
--- a/Monika After Story/game/zz_windowutils.rpy
+++ b/Monika After Story/game/zz_windowutils.rpy
@@ -38,7 +38,9 @@ init -10 python in mas_windowreacts:
 
 init python in mas_windowutils:
     import os
+
     import store
+    import mas_utils
     #The initial setup
 
     # The window object, used on Linux systems, otherwise always None
@@ -69,13 +71,15 @@ init python in mas_windowutils:
             #Now we set the hwnd of this temporarily
             __tip.hwnd = None
 
-        except:
+        except Exception as e:
             #If we fail to import, then we're going to have to make sure nothing can run.
             store.mas_windowreacts.can_show_notifs = False
             store.mas_windowreacts.can_do_windowreacts = False
 
             #Log this
-            store.mas_utils.mas_log.warning("win32api/win32gui failed to be imported, disabling notifications.")
+            store.mas_utils.mas_log.warning(
+                "win32api/win32gui failed to be imported, disabling notifications: {}".format(e)
+            )
 
     elif renpy.linux:
         #Get session type
@@ -93,16 +97,18 @@ init python in mas_windowutils:
                 import Xlib
 
                 from Xlib.display import Display
-                from Xlib.error import BadWindow
+                from Xlib.error import BadWindow, XError
 
                 __display = Display()
                 __root = __display.screen().root
 
-            except:
+            except Exception as e:
                 store.mas_windowreacts.can_show_notifs = False
                 store.mas_windowreacts.can_do_windowreacts = False
 
-                store.mas_utils.mas_log.warning("Xlib failed to be imported, disabling notifications.")
+                store.mas_utils.mas_log.warning(
+                    "Xlib failed to be imported, disabling notifications: {}".format(e)
+                )
 
         else:
             store.mas_windowreacts.can_show_notifs = False
@@ -154,7 +160,8 @@ init python in mas_windowutils:
 
         try:
             return __display.create_resource_object("window", active_winid)
-        except Xlib.error.XError:
+        except XError as e:
+            mas_utils.mas_log.error("Failed to get active window object: {}".format(e))
             return None
 
     def __getMASWindowLinux():
@@ -183,7 +190,8 @@ init python in mas_windowutils:
                 if transient_for is None and winname and store.mas_getWindowTitle() == winname:
                     return win
 
-        except BadWindow:
+        except XError as e:
+            mas_utils.mas_log.error("Failed to get MAS window object: {}".format(e))
             return None
 
     def __getMASWindowHWND():
@@ -211,6 +219,9 @@ init python in mas_windowutils:
 
         except MASWindowFoundException as e:
             return e.hwnd
+
+        mas_utils.mas_log.error("Failed to get MAS window hwnd")
+        return None
 
     def __getAbsoluteGeometry(win):
         """
@@ -248,7 +259,11 @@ init python in mas_windowutils:
         except Xlib.error.BadDrawable:
             #In the case of a bad drawable, we'll try to re-get the MAS window to get a good one
             _setMASWindow()
-            return None
+
+        except XError as e:
+            mas_utils.mas_log.error("Failed to get window geometry: {}".format(e))
+
+        return None
 
     def _setMASWindow():
         """
@@ -307,6 +322,11 @@ init python in mas_windowutils:
 
         except BadWindow:
             return ""
+
+        except XError as e:
+            mas_utils.mas_log.error("Failed to get active window handle: {}".format(e))
+
+        return ""
 
     def _getActiveWindowHandle_OSX():
         """
@@ -384,7 +404,7 @@ init python in mas_windowutils:
             #Try except here because we may not have permissions to do so
             try:
                 cur_pos = win32gui.GetCursorPos()
-            except:
+            except Exception:
                 cur_pos = DEF_MOUSE_POS_RETURN
 
         else:
@@ -623,9 +643,6 @@ init python:
         if mas_windowreacts.can_show_notifs and mas_canCheckActiveWindow():
             return store.mas_windowutils._window_get()
         return ""
-
-        #TODO: Remove this alias at some point
-        mas_getActiveWindow = mas_getActiveWindowHandle
 
     def mas_display_notif(title, body, group=None, skip_checks=False):
         """


### PR DESCRIPTION
This adds logging to our WR code and tries to catch all possible exceptions from x11 instead of 2 specific. That should help us debug issues as well as prevent the game crashing when x11 fails.
Fixes #9479

### Testing:
- Check window reacts and follow sprites on
- - Windows
- - Linux