### PR TITLE
Category capitalization fix 

### DIFF
--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -3440,7 +3440,17 @@ label prompts_categories(pool=True):
         # tuplelize the main the category list
         # NOTE: we use a 2nd list here to do displaying, keeping track of the
         # older cat list for checking if a category was picked
-        dis_cat_list = [(x.capitalize() + "...",x) for x in main_cat_list]
+        dis_cat_list = []
+        for x in main_cat_list:
+            if x.lower() == "ddlc":
+                capitalized_string = x.upper() + "..."
+            elif x.lower () == "literature club":
+                capitalized_string = "Literature Club..."
+            else:
+                capitalized_string = x.capitalize() + "..."
+
+            dis_cat_list.append((capitalized_string, x))
+
 
         # tupelize the event list
 #        no_cat_list = evhand.tuplizeEventLabelList(no_cat_list, unlocked_events)


### PR DESCRIPTION
It is a very minor fix for the display of the "DDLC..." and "Literature Club..." categories in the "Hey, Monika..." / "Repeat Conversation" tabs.

![cf3](https://user-images.githubusercontent.com/96905447/192121640-70a0bc1c-be3e-4b20-98dc-ac872a64d5ea.png)

※There are a few times in the dialogue of *DDLC* where "literature club" is not capitalized, but in most instances "Literature Club" is capitalized as a proper noun and name of a (small) organization. 

