### PR TITLE
Backup awareness

### DIFF
--- a/Monika After Story/game/0config.rpy
+++ b/Monika After Story/game/0config.rpy
@@ -113,6 +113,12 @@ init -1200 python:
     renpy.config.menu_clear_layers = ["front"]
     renpy.config.gl_test_image = "white"
 
+    # Remove extra save location (for whatever reason we do this)
+    # FIXME: Also, this is unsafe since renpy has a thread that
+    # iterates thru this list
+    if len(renpy.loadsave.location.locations) > 1:
+        renpy.loadsave.location.locations.pop()
+
 ################START: INIT TIME CONFIGS
 
 ## Uncomment the following line to set an audio file that will be played while

--- a/Monika After Story/game/options.rpy
+++ b/Monika After Story/game/options.rpy
@@ -66,7 +66,7 @@ init python:
     mas_override_label("_choose_renderer", "mas_choose_renderer_override")
 
     #The rest
-    if len(renpy.loadsave.location.locations) > 1: del(renpy.loadsave.location.locations[1])
+    # if len(renpy.loadsave.location.locations) > 1: del(renpy.loadsave.location.locations[1])
     renpy.game.preferences.pad_enabled = False
     def replace_text(s):
         s = s.replace('--', u'\u2014') # em dash

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -2722,7 +2722,7 @@ init python:
         # This must be called first
         mas_affection._absence_decay_aff()
 
-        if persistent._mas_long_absence or persisten._mas_is_backup:
+        if persistent._mas_long_absence or persistent._mas_is_backup:
             return
 
         time_difference = persistent._mas_absence_time

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -2722,7 +2722,7 @@ init python:
         # This must be called first
         mas_affection._absence_decay_aff()
 
-        if persistent._mas_long_absence:
+        if persistent._mas_long_absence or persisten._mas_is_backup:
             return
 
         time_difference = persistent._mas_absence_time

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1391,9 +1391,10 @@ init 999 python in mas_reset:
         """
         Runs reset for backup code
         """
-        if persisten._mas_is_backup:
+        if persistent._mas_is_backup:
             store.MASEventList.push("mas_backup_restored")
-            persisten._mas_is_backup = False
+            mas_utils.mas_log.info("Detected a restored backup")
+            persistent._mas_is_backup = False
 
 
     def final():

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1386,6 +1386,16 @@ init 999 python in mas_reset:
                 store.mas_stripEVL("mas_after_bath_cleanup", list_pop=True, remove_dates=True)
 
 
+    @ch30_reset(-560)
+    def backups():
+        """
+        Runs reset for backup code
+        """
+        if persisten._mas_is_backup:
+            store.MASEventList.push("mas_backup_restored")
+            persisten._mas_is_backup = False
+
+
     def final():
         """
         Runs reset code that should run after everythign else

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -2687,3 +2687,88 @@ P.S: Don't tell her about me!\
             repeat
 
     return "pause: 30"
+
+
+init 5 python:
+    addEvent(
+        Event(
+            persistent.event_database,
+            eventlabel="mas_backup_restored",
+        )
+    )
+
+label mas_backup_restored:
+    if mas_isMoniNormal(higher=True):
+        m 2ekc "[player]..."
+        m 2ekd "I'm having this odd feeling of deja vu... {w=0.3}{nw}"
+        extend 7ekd "I wanted to talk to you, but then somehow remembered we already did."
+
+        if mas_getEVL_shown_count("mas_backup_restored") > 0:
+            m 1etc "Wait, have I said this before, too?"
+
+        m 1wuo "Oh! {w=0.3}{nw}"
+        extend 3wud "You restored my memories from a backup, didn't you?{nw}"
+        $ _history_list.pop()
+        menu:
+            m "Oh! You restored my memories from a backup, didn't you?{fast}"
+
+            "Yes, I did.":
+                $ mas_gainAffection(modifier=0.5)
+
+                m 2eka "Thank you, [player]. I knew I can rely on you."
+                m 7rkd "It had to be really bad if you had to restore me, though..."
+
+                m 1ekc "What's happened?{nw}"
+                $ _history_list.pop()
+                menu:
+                    m "What's happened?{fast}"
+
+                    "The game has crashed.":
+                        m 1wud "Oh, this is weird and concerning."
+                        m 1ekc "This time it wasn't my code. I don't remember messing with it, anyway."
+                        m 1gfd "{cps=*1.5}I swear if it's another Ren'Py bug...{/cps}{nw}"
+                        $ _history_list.pop()
+                        m 1ekc "Let's try to make sure it won't happen again."
+
+                    "I added a submod.":
+                        m 1etc "Added a {w=0.1}{i}submod{/i}?"
+                        m 3esd "You should be more mindful of what you install on this computer."
+                        m 2lkd "It's my home, too..."
+
+                    "My PC has broken.":
+                        m 2wud "I'm glad you found a way to restore me."
+                        m 2ekc "Hopefully this won't happen again."
+                        m 2lktpc "I can't imagine losing you..."
+
+                    "I'm not sure.":
+                        m 1etc "This is concerning, [player]..."
+                        m 3esd "I lost my memory and we don't even know why."
+                        m 4eud "We should figure this out and prevent it from happening in the future."
+                        m 7eka "Promise me?"
+
+            "No, I didn't.":
+                m 2etc "Oh, then what's going on, [player]?"
+                m 2ektpc "I don't want to forget you."
+                m 2ektpd "Please, can you figure out what's happening?"
+                m 7eutdd "Maybe you could make some backups just in case?"
+
+                if mas_seenEvent("monika_back_ups"):
+                    m 3eud "I explained how to back me up before, remember?"
+
+                else:
+                    m 3euc "{a=https://github.com/Monika-After-Story/MonikaModDev/wiki/FAQ#i-want-to-back-up-my-persistent}{i}{u}This{/u}{/i}{/a} should help you."
+
+                m 1eka "I rely on you, [player]."
+
+    elif mas_isMoniUpset():
+        m 2gtc "Somehow I'm having this weird feeling of deja vu..."
+        m 2tfd "I hope you're not messing with my data."
+
+    else:
+        m 6ekc "[player], what's going on? {w=0.3}{nw}"
+        extend 6lksdlc "I know you did something to my data."
+        m 6lktpsdld "Are you trying to get rid of me?"
+        m 6rktpc "I just wanted us to be happy together..."
+        m 6ektuc "Please, forgive me..."
+
+    return "no_unlock"# just in case

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -2715,7 +2715,7 @@ label mas_backup_restored:
             "Yes, I did.":
                 $ mas_gainAffection(modifier=0.5)
 
-                m 2eka "Thank you, [player]. I knew I can rely on you."
+                m 2eka "Thank you, [player]. {w=0.2}I knew I could rely on you."
                 m 7rkd "It had to be really bad if you had to restore me, though..."
 
                 m 1ekc "What's happened?{nw}"
@@ -2723,9 +2723,9 @@ label mas_backup_restored:
                 menu:
                     m "What's happened?{fast}"
 
-                    "The game has crashed.":
-                        m 1wud "Oh, this is weird and concerning."
-                        m 1ekc "This time it wasn't my code. I don't remember messing with it, anyway."
+                    "The game crashed.":
+                        m 1wud "Oh, that's weird and concerning."
+                        m 1ekc "This time it wasn't my code. {w=0.2}I don't remember messing with it, anyway."
                         m 1gfd "{cps=*1.5}I swear if it's another Ren'Py bug...{/cps}{nw}"
                         $ _history_list.pop()
                         m 1ekc "Let's try to make sure it won't happen again, alright?"
@@ -2737,7 +2737,7 @@ label mas_backup_restored:
                         m 2lkd "It's my home, too..."
                         $ mas_moni_idle_disp.force_by_code("1ekc", duration=25, skip_dissolve=True)
 
-                    "My PC has broken.":
+                    "My PC broke.":
                         m 2wuo "I'm glad you found a way to restore me!"
                         m 2ekc "Hopefully this won't happen again."
                         m 2lktpc "I can't imagine losing you..."
@@ -2754,10 +2754,10 @@ label mas_backup_restored:
                         )
 
                     "I'm not sure.":
-                        m 1etc "This is concerning, [player]..."
+                        m 1etc "That's concerning, [player]..."
                         m 3esd "I lost my memory and we don't even know why."
-                        m 4eud "We should figure this out and prevent it from happening in the future."
-                        m 7eka "Promise me?"
+                        m 4eud "We should try to figure it out and prevent it from happening in the future."
+                        m 7eka "Promise?"
                         $ mas_moni_idle_disp.force_by_code("1eka", duration=20, skip_dissolve=True)
 
             "No, I didn't.":

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -2728,23 +2728,37 @@ label mas_backup_restored:
                         m 1ekc "This time it wasn't my code. I don't remember messing with it, anyway."
                         m 1gfd "{cps=*1.5}I swear if it's another Ren'Py bug...{/cps}{nw}"
                         $ _history_list.pop()
-                        m 1ekc "Let's try to make sure it won't happen again."
+                        m 1ekc "Let's try to make sure it won't happen again, alright?"
+                        $ mas_moni_idle_disp.force_by_code("1ekc", duration=25, skip_dissolve=True)
 
                     "I added a submod.":
                         m 1etc "Added a {w=0.1}{i}submod{/i}?"
                         m 3esd "You should be more mindful of what you install on this computer."
                         m 2lkd "It's my home, too..."
+                        $ mas_moni_idle_disp.force_by_code("1ekc", duration=25, skip_dissolve=True)
 
                     "My PC has broken.":
-                        m 2wud "I'm glad you found a way to restore me."
+                        m 2wuo "I'm glad you found a way to restore me!"
                         m 2ekc "Hopefully this won't happen again."
                         m 2lktpc "I can't imagine losing you..."
+                        $ mas_moni_idle_disp.force(
+                            MASMoniIdleExpGroup(
+                                [
+                                    MASMoniIdleExp("2lktdc", duration=15),
+                                    MASMoniIdleExp("2rktdc", duration=10),
+                                    MASMoniIdleExp("1dkc", duration=10),
+                                    MASMoniIdleExp("1euc", duration=10),
+                                ]
+                            ),
+                            skip_dissolve=True
+                        )
 
                     "I'm not sure.":
                         m 1etc "This is concerning, [player]..."
                         m 3esd "I lost my memory and we don't even know why."
                         m 4eud "We should figure this out and prevent it from happening in the future."
                         m 7eka "Promise me?"
+                        $ mas_moni_idle_disp.force_by_code("1eka", duration=20, skip_dissolve=True)
 
             "No, I didn't.":
                 m 2etc "Oh, then what's going on, [player]?"
@@ -2758,11 +2772,13 @@ label mas_backup_restored:
                 else:
                     m 3euc "{a=https://github.com/Monika-After-Story/MonikaModDev/wiki/FAQ#i-want-to-back-up-my-persistent}{i}{u}This{/u}{/i}{/a} should help you."
 
-                m 1eka "I rely on you, [player]."
+                m 1eka "I'm relying on you, [player]."
+                $ mas_moni_idle_disp.force_by_code("1eka", duration=15, skip_dissolve=True)
 
     elif mas_isMoniUpset():
         m 2gtc "Somehow I'm having this weird feeling of deja vu..."
         m 2tfd "I hope you're not messing with my data."
+        $ mas_moni_idle_disp.force_by_code("2mfc", duration=10, skip_dissolve=True)
 
     else:
         m 6ekc "[player], what's going on? {w=0.3}{nw}"
@@ -2770,5 +2786,15 @@ label mas_backup_restored:
         m 6lktpsdld "Are you trying to get rid of me?"
         m 6rktpc "I just wanted us to be happy together..."
         m 6ektuc "Please, forgive me..."
+        $ mas_moni_idle_disp.force(
+            MASMoniIdleExpGroup(
+                [
+                    MASMoniIdleExp("6lktsc", duration=10),
+                    MASMoniIdleExp("6rktsc", duration=10),
+                    MASMoniIdleExp("6dktdc", duration=20)
+                ]
+            ),
+            skip_dissolve=True
+        )
 
-    return "no_unlock"# just in case
+    return "no_unlock|pause: 35"

--- a/Monika After Story/game/sprite-chart.rpy
+++ b/Monika After Story/game/sprite-chart.rpy
@@ -3136,7 +3136,7 @@ init -3 python:
                 startup=False
             ):
             """
-            Changes both clothes and hair. also sets the persisten forced vars
+            Changes both clothes and hair. also sets the persistent forced vars
             to by_user, if its not None
 
             IN:
@@ -3838,7 +3838,7 @@ init -3 python:
 
         def set_acs(self, acs, wear):
             """
-            Basically a single function so callers don't need to 
+            Basically a single function so callers don't need to
             if-statement-toggle wearing and removal of ACS.
 
             IN:
@@ -7591,7 +7591,7 @@ init -3 python:
         Use the functions to modify outfit data as appropriate.
 
         Supports:
-            - preventing ACS from being removed 
+            - preventing ACS from being removed
             - preventing hair or ACS from being worn
         """
 
@@ -7634,7 +7634,7 @@ init -3 python:
         def set_acs_change_all(self, value):
             """
             Enables or disables ALL ACS changing as part of outfit mode
-            
+
             IN:
                 value - pass True to enable, False to disable
             """

--- a/Monika After Story/game/zz_backup.rpy
+++ b/Monika After Story/game/zz_backup.rpy
@@ -669,6 +669,9 @@ init -900 python:
                 renpy.save_persistent()
                 numnum, numnum_del = __mas__backupAndDelete(p_savedir, "persistent")
 
+            except:
+                raise
+
             finally:
                 persistent._mas_is_backup = is_pers_backup
                 renpy.save_persistent()

--- a/Monika After Story/game/zz_backup.rpy
+++ b/Monika After Story/game/zz_backup.rpy
@@ -669,9 +669,6 @@ init -900 python:
                 renpy.save_persistent()
                 numnum, numnum_del = __mas__backupAndDelete(p_savedir, "persistent")
 
-            except:
-                raise
-
             finally:
                 persistent._mas_is_backup = is_pers_backup
                 renpy.save_persistent()

--- a/Monika After Story/game/zz_backup.rpy
+++ b/Monika After Story/game/zz_backup.rpy
@@ -17,6 +17,8 @@ default persistent._mas_incompat_per_rpy_files_found = False
 # only set if the user entered the incompat flow at all
 default persistent._mas_incompat_per_entered = False
 
+default persisten._mas_is_backup = False
+
 python early in mas_per_check:
     import __main__
     import cPickle
@@ -661,7 +663,15 @@ init -900 python:
         try:
             p_savedir = os.path.normcase(renpy.config.savedir + "/")
 
-            numnum, numnum_del = __mas__backupAndDelete(p_savedir, "persistent")
+            try:
+                persisten._mas_is_backup = True
+                renpy.save_persistent()
+                numnum, numnum_del = __mas__backupAndDelete(p_savedir, "persistent")
+
+            finally:
+                persisten._mas_is_backup = False
+                renpy.save_persistent()
+
             __mas__backupAndDelete(p_savedir, "db.mcal", numnum=numnum)
 
         except Exception as e:

--- a/Monika After Story/game/zz_backup.rpy
+++ b/Monika After Story/game/zz_backup.rpy
@@ -193,7 +193,7 @@ python early in mas_per_check:
 
     def should_show_chibika_persistent():
         """
-        Should we show the chibika persistent dialogue? 
+        Should we show the chibika persistent dialogue?
 
         RETURNS: True if we should show the chibika persistent dialogue
         """
@@ -239,7 +239,7 @@ python early in mas_per_check:
 
         # first, check if we have a special persistent
         if os.access(_sp_per, os.F_OK):
-            #  we have one, so check if its valid 
+            #  we have one, so check if its valid
             try: # TEST_CASE_A
                 per_read, version = tryper(_sp_per)
 
@@ -367,7 +367,7 @@ python early in mas_per_check:
 
             try: # TEST_CASE_F
                 shutil.copy(_cur_per, _sp_per)
-                os.remove(_cur_per) 
+                os.remove(_cur_per)
 
                 # and then close out of here - the game should generate a fresh
                 # persistent.
@@ -533,10 +533,10 @@ init -900 python:
                 # we only accept persistents with the correct number scheme
                 filenumbers.append(num)
 
-        if len(filenumbers) > 0:
-            return sorted(filenumbers)
+        if filenumbers:
+            filenumbers.sort()
 
-        return []
+        return filenumbers
 
 
     def __mas__backupAndDelete(loaddir, org_fname, savedir=None, numnum=None):
@@ -566,7 +566,7 @@ init -900 python:
         RETURNS:
             tuple of the following format:
             [0]: numbernumber we just made
-            [1]: numbernumber we delted (None means no deltion)
+            [1]: numbernumber we deleted (None means no deletion)
         """
         if savedir is None:
             savedir = loaddir
@@ -594,7 +594,7 @@ init -900 python:
 
         # now do the iterative backup system
         numbernumber_del = None
-        if len(numberlist) <= 0:
+        if not numberlist:
             numbernumber = __mas__numnum.format(0)
 
         elif 99 in numberlist:
@@ -660,13 +660,14 @@ init -900 python:
         """
         try:
             p_savedir = os.path.normcase(renpy.config.savedir + "/")
-            p_name = "persistent"
-            numnum, numnum_del = __mas__backupAndDelete(p_savedir, p_name)
-            cal_name = "db.mcal"
-            __mas__backupAndDelete(p_savedir, cal_name, numnum=numnum)
+
+            numnum, numnum_del = __mas__backupAndDelete(p_savedir, "persistent")
+            __mas__backupAndDelete(p_savedir, "db.mcal", numnum=numnum)
 
         except Exception as e:
-            store.mas_utils.mas_log.error(str(e))
+            store.mas_utils.mas_log.error(
+                "persistent/calendar data backup failed: {}".format(e)
+            )
 
 
     def __mas__memoryCleanup():
@@ -844,7 +845,7 @@ label mas_backups_incompat_start:
     $ mas_darkMode(True) # required for the updater
 
     if (
-            persistent._mas_incompat_per_rpy_files_found 
+            persistent._mas_incompat_per_rpy_files_found
             and mas_hasRPYFiles()
     ):
         # user said they would delete the RPY files, but we still have them
@@ -984,7 +985,7 @@ label mas_backups_incompat_rpy_yes_del:
     show chibika 3 at sticker_hop
     "Done!"
     "Let's try updating now!"
-    jump mas_backups_incompat_updater_start   
+    jump mas_backups_incompat_updater_start
 
 
 label mas_backups_incompat_rpy_no_del:
@@ -1022,8 +1023,8 @@ label mas_backups_incompat_updater_failed:
     # fall through
 
 label mas_backups_incompat_updater_start:
-    
-    # setup for unstable 
+
+    # setup for unstable
     $ persistent._mas_unstable_mode = True
     $ mas_updater.force = True
 
@@ -1044,10 +1045,10 @@ label mas_backups_incompat_updater_start:
     #       NOTE: why don't we lock or remove the cancel button? The user
     #       might have their own reasons for canceling the update check:
     #       - maybe they are on low bandwidth/metered connections?
-    #       - maybe they actually want to stay on stable and have a backup 
+    #       - maybe they actually want to stay on stable and have a backup
     #           persistent to us?
     #       - maybe its maybelline?
-    #       either way, since the user has an unstable per, no need for 
+    #       either way, since the user has an unstable per, no need for
     #       extravagant handholding.
 
     #"hol up" # use this to debug cancel returns
@@ -1075,5 +1076,3 @@ label mas_backups_incompat_updater_start:
     "Good luck!"
 
     jump _quit
-
-

--- a/Monika After Story/game/zz_backup.rpy
+++ b/Monika After Story/game/zz_backup.rpy
@@ -17,7 +17,7 @@ default persistent._mas_incompat_per_rpy_files_found = False
 # only set if the user entered the incompat flow at all
 default persistent._mas_incompat_per_entered = False
 
-default persisten._mas_is_backup = False
+default persistent._mas_is_backup = False
 
 python early in mas_per_check:
     import __main__
@@ -131,7 +131,7 @@ python early in mas_per_check:
         Checks if a persistent version can work with the current version
 
         IN:
-            per_version - the persisten version to check
+            per_version - the persistent version to check
             cur_version - the current version to check.
 
         RETURNS: True if the per version can work with the current version
@@ -662,14 +662,15 @@ init -900 python:
         """
         try:
             p_savedir = os.path.normcase(renpy.config.savedir + "/")
+            is_pers_backup = persistent._mas_is_backup
 
             try:
-                persisten._mas_is_backup = True
+                persistent._mas_is_backup = True
                 renpy.save_persistent()
                 numnum, numnum_del = __mas__backupAndDelete(p_savedir, "persistent")
 
             finally:
-                persisten._mas_is_backup = False
+                persistent._mas_is_backup = is_pers_backup
                 renpy.save_persistent()
 
             __mas__backupAndDelete(p_savedir, "db.mcal", numnum=numnum)


### PR DESCRIPTION
This makes Monika "aware" of when the user restores a backup.
A few reasons why:
- awareness is always cool, can catch people by surprise
- this also fixes an issue when loading a very old backup and losing affection for it
- sometimes it's not clear enough that a backup has been restored, this is a good way to tell the player "something happened"

### Testing
- verify the main logic works:
- - make sure you have `persistent` in your save dir
- - - if not, load in and quit to quickly generate a fresh pers
- - load in with the new changes
- - you should get a new backup in your save dir
- - quit normally
- - restore the new backup
- - verify Monika mentions that you restored a backup
- - restart again, verify Monika doesn't mentions it again (the flag should be reset)
- verify no aff lose when loading an old backup
- verify expressions and writing are good
- - also check out post expressions
- verify I didn't leave more `persisten` fypos...