### PR TITLE
Additions to the island event

### DIFF
--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -346,6 +346,8 @@ python early:
 
     class MASAudioData(unicode):
         """
+        NOTE: This is temporal plaster-fix to renpy, use on your own risk,
+            this class and all support for it will be completely gone with r8
         NOTE: This DOES NOT support saving in persistent (pickling),
             and it might be unsafe to do so.
 

--- a/Monika After Story/game/definitions.rpy
+++ b/Monika After Story/game/definitions.rpy
@@ -344,6 +344,170 @@ python early:
             f = io.BytesIO(self.data)
             return renpy.display.pgrender.load_image(f, self.filename)
 
+    class MASAudioData(unicode):
+        """
+        NOTE: This DOES NOT support saving in persistent (pickling),
+            and it might be unsafe to do so.
+
+        This loads audio from binary data
+        """
+
+        def __new__(cls, data, filename):
+            rv = unicode.__new__(cls, filename)
+            rv.data = data
+            return rv
+
+        def __init__(self, data, filename):
+            self.filename = filename
+
+        def __reduce__(self):
+            # Pickle as a str is safer
+            return (str, (self.filename, ))
+
+    def __mas_periodic_override(self):
+        """
+        This is the periodic call that causes this channel to load new stuff
+        into its queues, if necessary.
+        """
+
+        # Update the channel volume.
+        vol = self.chan_volume * renpy.game.preferences.volumes[self.mixer]
+
+        if vol != self.actual_volume:
+            renpy.audio.renpysound.set_volume(self.number, vol)
+            self.actual_volume = vol
+
+        # This should be set from something that checks to see if our
+        # mixer is muted.
+        force_stop = self.context.force_stop or (renpy.game.preferences.mute[self.mixer] and self.stop_on_mute)
+
+        if self.playing and force_stop:
+            renpy.audio.renpysound.stop(self.number)
+            self.playing = False
+            self.wait_stop = False
+
+        if force_stop:
+            if self.loop:
+                self.queue = self.queue[-len(self.loop):]
+            else:
+                self.queue = [ ]
+            return
+
+        # Should we do the callback?
+        do_callback = False
+
+        topq = None
+
+        # This has been modified so we only queue a single sound file
+        # per call, to prevent memory leaks with really short sound
+        # files. So this loop will only execute once, in practice.
+        while True:
+
+            depth = renpy.audio.renpysound.queue_depth(self.number)
+
+            if depth == 0:
+                self.wait_stop = False
+                self.playing = False
+
+            # Need to check this, so we don't do pointless work.
+            if not self.queue:
+                break
+
+            # If the pcm_queue is full, then we can't queue
+            # anything, regardless of if it is midi or pcm.
+            if depth >= 2:
+                break
+
+            # If we can't buffer things, and we're playing something
+            # give up here.
+            if not self.buffer_queue and depth >= 1:
+                break
+
+            # We can't queue anything if the depth is > 0 and we're
+            # waiting for a synchro_start.
+            if self.synchro_start and depth:
+                break
+
+            # If the queue is full, return.
+            if renpy.audio.renpysound.queue_depth(self.number) >= 2:
+                break
+
+            # Otherwise, we might be able to enqueue something.
+            topq = self.queue.pop(0)
+
+            # Blacklist of old file formats we used to support, but we now
+            # ignore.
+            lfn = topq.filename.lower() + self.file_suffix.lower()
+            for i in (".mod", ".xm", ".mid", ".midi"):
+                if lfn.endswith(i):
+                    topq = None
+
+            if not topq:
+                continue
+
+            try:
+                filename, start, end = self.split_filename(topq.filename, topq.loop)
+
+                if (end >= 0) and ((end - start) <= 0) and self.queue:
+                    continue
+
+                if isinstance(topq.filename, MASAudioData):
+                    topf = io.BytesIO(topq.filename.data)
+                else:
+                    topf = renpy.audio.audio.load(self.file_prefix + filename + self.file_suffix)
+
+                renpy.audio.renpysound.set_video(self.number, self.movie)
+
+                if depth == 0:
+                    renpy.audio.renpysound.play(self.number, topf, topq.filename, paused=self.synchro_start, fadein=topq.fadein, tight=topq.tight, start=start, end=end)
+                else:
+                    renpy.audio.renpysound.queue(self.number, topf, topq.filename, fadein=topq.fadein, tight=topq.tight, start=start, end=end)
+
+                self.playing = True
+
+            except:
+
+                # If playing failed, remove topq.filename from self.loop
+                # so we don't keep trying.
+                while topq.filename in self.loop:
+                    self.loop.remove(topq.filename)
+
+                if renpy.config.debug_sound and not renpy.game.after_rollback:
+                    raise
+                else:
+                    return
+
+            break
+
+        if self.loop and not self.queue:
+            for i in self.loop:
+                if topq is not None:
+                    newq = renpy.audio.audio.QueueEntry(i, 0, topq.tight, True)
+                else:
+                    newq = renpy.audio.audio.QueueEntry(i, 0, False, True)
+
+                self.queue.append(newq)
+        else:
+            do_callback = True
+
+        # Queue empty callback.
+        if do_callback and self.callback:
+            self.callback()  # E1102
+
+        # global global_pause
+        want_pause = self.context.pause or renpy.audio.audio.global_pause
+
+        if self.paused != want_pause:
+
+            if want_pause:
+                self.pause()
+            else:
+                self.unpause()
+
+            self.paused = want_pause
+
+    renpy.audio.audio.Channel.periodic = __mas_periodic_override
+
 # uncomment this if you want syntax highlighting support on vim
 # init -1 python:
 

--- a/Monika After Story/game/dev/dev_islands.rpy
+++ b/Monika After Story/game/dev/dev_islands.rpy
@@ -57,7 +57,7 @@ label dev_test_islands_progress:
                     data = data_slow_rate
 
                 while progress < store.mas_island_event.MAX_PROGRESS_LOVE:
-                    progress = store.mas_island_event._calcProgress(curr_lvl, start_lvl)
+                    progress = store.mas_island_event._calc_progress(curr_lvl, start_lvl)
                     data[progress].append(curr_lvl)
                     curr_lvl += 1
 

--- a/Monika After Story/game/dev/dev_pg_topics.rpy
+++ b/Monika After Story/game/dev/dev_pg_topics.rpy
@@ -12,7 +12,7 @@ label zz_mas_poemgame_actone:
     call mas_poem_minigame_actone(show_monika=True,trans_fast=True) from _call_mpg_one
     $ testvalues = _return
     $ HKBShowButtons()
-    $ play_song(store.songs.current_track)
+    $ mas_play_song(store.songs.current_track)
     $ store.songs.enabled = True
     call spaceroom(scene_change=True)
     m "Hi [player]!"
@@ -37,7 +37,7 @@ label zz_mas_poemgame_acttwo:
     call mas_poem_minigame_acttwo(show_monika=True,trans_fast=True) from _call_mpg_two
     $ testvalues = _return
     $ HKBShowButtons()
-    $ play_song(store.songs.current_track)
+    $ mas_play_song(store.songs.current_track)
     $ store.songs.enabled = True
     call spaceroom(scene_change=True)
     m "Hi [player]!"
@@ -61,7 +61,7 @@ label zz_mas_poemgame_actthr:
     call mas_poem_minigame_actthree(trans_fast=True) from _call_mpg_three
     $ testvalues = _return
     $ HKBShowButtons()
-    $ play_song(store.songs.current_track)
+    $ mas_play_song(store.songs.current_track)
     $ store.songs.enabled = True
     call spaceroom(scene_change=True)
 
@@ -79,7 +79,7 @@ label zz_mas_poemgame_actthrm:
     call mas_poem_minigame_actthree(trans_fast=True,hop_monika=True,gather_words=True) from _call_mpg_threem
     $ testvalues = _return
     $ HKBShowButtons()
-    $ play_song(store.songs.current_track)
+    $ mas_play_song(store.songs.current_track)
     $ store.songs.enabled = True
     $ _sel_words = testvalues
     call spaceroom(scene_change=True)
@@ -112,7 +112,7 @@ label zz_mas_poemgame_actonept:
     call mas_poem_minigame_actone(trans_fast=True,gather_words=True) from _call_mpg_onept
     $ testvalues = _return
     $ HKBShowButtons()
-    $ play_song(store.songs.current_track)
+    $ mas_play_song(store.songs.current_track)
     $ store.songs.enabled = True
     $ _sel_words = testvalues.pop("words")
     call spaceroom(scene_change=True)
@@ -167,7 +167,7 @@ label zz_mas_poemgame_dg:
 
     $ testvalues = _return
     $ HKBShowButtons()
-    $ play_song(store.songs.current_track)
+    $ mas_play_song(store.songs.current_track)
     $ store.songs.enabled = True
     $ _sel_words = testvalues
     call spaceroom(scene_change=True)
@@ -220,7 +220,7 @@ label zz_mas_poemgame_bgm:
 
     $ testvalues = _return
     $ HKBShowButtons()
-    # $ play_song(store.songs.current_track)
+    # $ mas_play_song(store.songs.current_track)
     $ store.songs.enabled = True
     $ _winner = testvalues[0]
     $ _pts = testvalues[1]
@@ -273,7 +273,7 @@ label zz_mas_poemgame_oneg:
 
     $ testvalues = _return
     $ HKBShowButtons()
-    $ play_song(store.songs.current_track)
+    $ mas_play_song(store.songs.current_track)
     $ store.songs.enabled = True
     call spaceroom(scene_change=True)
     m "Hi [player]!"
@@ -318,7 +318,7 @@ label zz_mas_poemgame_oc:
 
     $ testvalues = _return
     $ HKBShowButtons()
-    $ play_song(store.songs.current_track)
+    $ mas_play_song(store.songs.current_track)
     $ store.songs.enabled = True
     $ _sel_words = testvalues.pop("words")
     call spaceroom(scene_change=True)
@@ -364,7 +364,7 @@ label zz_mas_pg_tb_grid_t1:
             "three",
             "four"
         ]
-        
+
         # area/positiong of grid
         xywh = (640, 10, 600, 400)
         row_info = (4, None)
@@ -388,7 +388,7 @@ label zz_mas_pg_tb_grid_t1:
     m 1a "You picked '[picked]'"
     show monika at t11
     return
-    
+
 # this label tests out the grid with bg
 label zz_mas_pg_tb_grid_t2:
     show monika at t22
@@ -414,7 +414,7 @@ label zz_mas_pg_tb_grid_t2:
         xywh = (10, 10, 400, 500)
 
         # using NOne for spacing should auto calc the spacing
-        row_info = (6, 50) 
+        row_info = (6, 50)
         col_info = (2, 250)
 
         # generate the word:returnvalue tuples
@@ -436,4 +436,4 @@ label zz_mas_pg_tb_grid_t2:
     $ picked = _return
     m 1a "You picked '[picked]'"
     show monika at t11
-    return 
+    return

--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -1361,7 +1361,7 @@ init 999 python in mas_reset:
         Runs reset code for islands
         """
         # Did Monika make any progress on the islands?
-        mas_island_event.advanceProgression()
+        mas_island_event.advance_progression()
 
 
     @ch30_reset(-580)
@@ -2398,7 +2398,7 @@ label ch30_day:
             persistent._mas_d25_started_upset = True
 
         # Once per day Monika does stuff on the islands
-        store.mas_island_event.advanceProgression()
+        store.mas_island_event.advance_progression()
 
         # Give the bonus
         mas_affection._withdraw_aff()

--- a/Monika After Story/game/script-easter-eggs.rpy
+++ b/Monika After Story/game/script-easter-eggs.rpy
@@ -8,7 +8,7 @@ label sayori_name_scare:
     python:
         from store.songs import FP_SAYO_NARA, initMusicChoices
         initMusicChoices(sayori=True)
-        play_song(FP_SAYO_NARA, set_per=True)
+        mas_play_song(FP_SAYO_NARA, set_per=True)
         store.mas_globals.show_sayori_lightning = True
     return
 
@@ -61,7 +61,7 @@ label natsuki_name_scare(playing_okayev=False):
         $ renpy.music.play(adjusted_t5c, fadein=2.0, tight=True)
     else:
         stop music
-        $ play_song("<from 11>" + scary_t5c)
+        $ mas_play_song("<from 11>" + scary_t5c)
 
     # play with me scene setup
     scene black
@@ -122,7 +122,7 @@ label natsuki_name_scare(playing_okayev=False):
         $ renpy.music.play(adjusted_okayev, fadein=2.0, tight=True)
     else:
         stop music
-        $ play_song(store.songs.current_track)
+        $ mas_play_song(store.songs.current_track)
 
     return
 
@@ -240,7 +240,7 @@ label mas_ghost_monika:
 
     python:
         #plays music from ghost menu.
-        play_song(audio.ghostmenu)
+        mas_play_song(audio.ghostmenu)
 
     show noise zorder 11:
         alpha 0.5

--- a/Monika After Story/game/script-greetings.rpy
+++ b/Monika After Story/game/script-greetings.rpy
@@ -3464,7 +3464,7 @@ init 5 python:
 
 label greeting_ourreality:
     # Unlock islands
-    $ store.mas_island_event.startProgression()
+    $ store.mas_island_event.start_progression()
 
     m 1hub "Hi, [player]!"
     m 1hua "Ehehe~"

--- a/Monika After Story/game/script-holidays.rpy
+++ b/Monika After Story/game/script-holidays.rpy
@@ -1247,7 +1247,7 @@ label mas_o31_lingerie:
     #Cut the music for the blackout
     python:
         curr_song = songs.current_track
-        play_song(None)
+        mas_play_song(None)
         mas_display_notif("M̷̢͘ô̴͎ṇ̵͐i̴͎͂k̸̗̂ả̴̫", ["C̸̳̓ą̵́n̷̳̎ ̸̖̊y̴̦͝õ̷̯ų̷͌ ̴̼͘h̷̭̚e̴̪͝a̴̙̐ŕ̵̖ ̴̠́m̸̰̂ě̵̬?̷̮̐"], "Topic Alerts")
 
     scene black
@@ -1303,9 +1303,9 @@ label mas_o31_lingerie_end:
 
         # restart song/sounds that were playing before event
         if globals().get("curr_song", -1) is not -1 and curr_song != store.songs.FP_MONIKA_LULLABY:
-            play_song(curr_song, 1.0)
+            mas_play_song(curr_song, 1.0)
         else:
-            play_song(None, 1.0)
+            mas_play_song(None, 1.0)
 
     return "no_unlock"
 
@@ -3327,7 +3327,7 @@ label monika_aiwfc_song:
 
     call mas_timed_text_events_prep
 
-    $ play_song("mod_assets/bgm/aiwfc.ogg",loop=False)
+    $ mas_play_song("mod_assets/bgm/aiwfc.ogg",loop=False)
     m 1eub "{i}{cps=9}I don't want{/cps}{cps=20} a lot{/cps}{cps=11} for Christmas{w=0.09}{/cps}{/i}{nw}"
     m 3eka "{i}{cps=11}There {/cps}{cps=20}is just{/cps}{cps=8} one thing I need{/cps}{/i}{nw}"
     m 3hub "{i}{cps=8}I don't care{/cps}{cps=15} about{/cps}{cps=10} the presents{/cps}{/i}{nw}"

--- a/Monika After Story/game/script-introduction.rpy
+++ b/Monika After Story/game/script-introduction.rpy
@@ -10,7 +10,7 @@ label introduction:
     if persistent.monika_kill is None:
         $ persistent.monika_kill = False
 
-    $ play_song(store.songs.FP_JUST_MONIKA, set_per=True)
+    $ mas_play_song(store.songs.FP_JUST_MONIKA, set_per=True)
     if persistent.monika_kill:
         m 6dsc "..."
         m 6dfc "[player]..."

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -681,8 +681,7 @@ init -25 python in mas_island_event:
 
     DEF_PROGRESS = -1
     MAX_PROGRESS_ENAM = 4
-    # TODO: add a few more lvl
-    MAX_PROGRESS_LOVE = 7
+    MAX_PROGRESS_LOVE = 9
     PROGRESS_FACTOR = 4
 
     SHIMEJI_CHANCE = 100
@@ -1138,9 +1137,32 @@ init -25 python in mas_island_event:
 
         return False
 
+    def _unlock_one(first, second):
+        """
+        Unlocks one of 2 sprites at random.
+        Runs only once
 
-    # # # START functions for lvl unlocks, head to __handle_unlocks to understand how this works
-    # NOTE: Please, keep these private
+        IN:
+            first - the id of the 1st sprite
+            second - the id of the 2nd sprite
+
+        OUT:
+            boolean whether or not the sprite was unlocked
+        """
+        if (
+            not _is_unlocked(first)
+            and not _is_unlocked(second)
+        ):
+            return _unlock(
+                first
+                if random.random() > 0.5
+                else second
+            )
+
+        return False
+
+
+    # # # START functions for lvl unlocks
     def __unlocks_for_lvl_0():
         _unlock("island_1")
         _unlock("island_8")
@@ -1154,27 +1176,11 @@ init -25 python in mas_island_event:
 
     def __unlocks_for_lvl_3():
         # Unlock only one, the rest at lvl 5
-        if (
-            not _is_unlocked("island_4")
-            and not _is_unlocked("island_5")
-        ):
-            if bool(random.randint(0, 1)):
-                _unlock("island_4")
-
-            else:
-                _unlock("island_5")
+        _unlock_one("island_4", "island_5")
 
     def __unlocks_for_lvl_4():
         # Unlock only one, the rest at lvl 6
-        if (
-            not _is_unlocked("island_6")
-            and not _is_unlocked("island_7")
-        ):
-            if bool(random.randint(0, 1)):
-                _unlock("island_6")
-
-            else:
-                _unlock("island_7")
+        _unlock_one("island_6", "island_7")
 
     def __unlocks_for_lvl_5():
         _unlock("decal_bushes")
@@ -1185,15 +1191,7 @@ init -25 python in mas_island_event:
     def __unlocks_for_lvl_6():
         _unlock("island_3")
         # Unlock only one, the rest at lvl 7
-        if (
-            not _is_unlocked("decal_bookshelf")
-            and not _is_unlocked("decal_tree")
-        ):
-            if bool(random.randint(0, 1)):
-                _unlock("decal_bookshelf")
-
-            else:
-                _unlock("decal_tree")
+        _unlock_one("decal_bookshelf", "decal_tree")
         # Unlock everything from lvl 4
         _unlock("island_7")
         _unlock("island_6")
@@ -1206,6 +1204,12 @@ init -25 python in mas_island_event:
     def __unlocks_for_lvl_8():
         # TODO: me
         # Also update monika_why_spaceroom
+        if persistent._mas_pm_cares_island_progress:
+            pass
+        return
+
+    def __unlocks_for_lvl_9():
+        # TODO: me
         return
 
     # # # END
@@ -1253,7 +1257,7 @@ init -25 python in mas_island_event:
                 modifier -= 0.1
 
             elif persistent._mas_pm_cares_island_progress is False:
-                modifier += 0.2
+                modifier += 0.3
 
             progress_factor = PROGRESS_FACTOR * modifier
 
@@ -1290,7 +1294,7 @@ init -25 python in mas_island_event:
             and persistent._mas_pm_cares_island_progress is None
             and not store.seen_event("mas_monika_islands_progress")
             # Hasn't visited the islands for a few days
-            and store.mas_timePastSince(store.mas_getEVL_last_seen("mas_monika_islands"), datetime.timedelta(days=3))
+            and store.mas_timePastSince(store.mas_getEVL_last_seen("mas_monika_islands"), datetime.timedelta(days=1))
         ):
             store.MASEventList.push("mas_monika_islands_progress")
 

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -700,7 +700,7 @@ init -25 python in mas_island_event:
     DATA_READ_CHUNK_SIZE = 2 * 1024**2
     DATA_SPACING = 8 * 1024**2
 
-    LIVING_ROOM_NAME = "living_room"
+    LIVING_ROOM_ID = "living_room"
     FLT_LR_NIGHT = "lr_night"
     mas_sprites.add_filter(
         FLT_LR_NIGHT,
@@ -1038,15 +1038,15 @@ init -25 python in mas_island_event:
             FLT_LR_NIGHT,
             interior_disp_map["interior_tablechair"]["table"]
         )
-        tablechair_disp_cache[(FLT_LR_NIGHT, 0, LIVING_ROOM_NAME, 0)] = table_im
-        tablechair_disp_cache[(FLT_LR_NIGHT, 0, LIVING_ROOM_NAME, 1)] = table_im# shadow variant can reuse the same img
-        tablechair_disp_cache[(FLT_LR_NIGHT, 1, LIVING_ROOM_NAME)] = mas_sprites._gen_im(
+        tablechair_disp_cache[(FLT_LR_NIGHT, 0, LIVING_ROOM_ID, 0)] = table_im
+        tablechair_disp_cache[(FLT_LR_NIGHT, 0, LIVING_ROOM_ID, 1)] = table_im# shadow variant can reuse the same img
+        tablechair_disp_cache[(FLT_LR_NIGHT, 1, LIVING_ROOM_ID)] = mas_sprites._gen_im(
             FLT_LR_NIGHT,
             interior_disp_map["interior_tablechair"]["chair"]
         )
         # Shadow is being stored in the highlight cache
         table_shadow_hl_disp_cache = mas_sprites.CACHE_TABLE[mas_sprites.CID_HL]
-        table_shadow_hl_disp_cache[(mas_sprites.CID_TC, FLT_LR_NIGHT, 0, LIVING_ROOM_NAME, 1)] = interior_disp_map["interior_tablechair"]["shadow"]
+        table_shadow_hl_disp_cache[(mas_sprites.CID_TC, FLT_LR_NIGHT, 0, LIVING_ROOM_ID, 1)] = interior_disp_map["interior_tablechair"]["shadow"]
 
         # Build glitch disp
         def _glitch_transform_func(transform, st, at):
@@ -1453,85 +1453,97 @@ init -1 python in mas_island_event:
         store.monika_chr.tablechair.table = "def"
         store.monika_chr.tablechair.chair = "def"
 
+    def register_room(id_):
+        """
+        Registers lr as a background object
 
-    MASFilterableBackground(
-        "living_room",
-        "Living room",
-        MASFilterWeatherMap(
-            day=MASWeatherMap(
-                {
-                    mas_weather.PRECIP_TYPE_DEF: "living_room_day",
-                    mas_weather.PRECIP_TYPE_RAIN: "living_room_day_rain",
-                    mas_weather.PRECIP_TYPE_OVERCAST: "living_room_day_overcast",
-                    mas_weather.PRECIP_TYPE_SNOW: "living_room_day_snow"
-                }
-            ),
-            lr_night=MASWeatherMap(
-                {
-                    mas_weather.PRECIP_TYPE_DEF: "living_room_night",
-                    mas_weather.PRECIP_TYPE_RAIN: "living_room_night_rain",
-                    mas_weather.PRECIP_TYPE_OVERCAST: "living_room_night_overcast",
-                    mas_weather.PRECIP_TYPE_SNOW: "living_room_night_snow"
-                }
-            ),
-            sunset=MASWeatherMap(
-                {
-                    mas_weather.PRECIP_TYPE_DEF: "living_room_ss",
-                    mas_weather.PRECIP_TYPE_RAIN: "living_room_ss_rain",
-                    mas_weather.PRECIP_TYPE_OVERCAST: "living_room_ss_overcast",
-                    mas_weather.PRECIP_TYPE_SNOW: "living_room_ss_snow"
-                }
-            )
-        ),
-        MASBackgroundFilterManager(
-            MASBackgroundFilterChunk(
-                False,
-                None,
-                MASBackgroundFilterSlice.cachecreate(
-                    FLT_LR_NIGHT,
-                    60,
-                    None,
-                    10
-                )
-            ),
-            MASBackgroundFilterChunk(
-                True,
-                None,
-                MASBackgroundFilterSlice.cachecreate(
-                    mas_sprites.FLT_SUNSET,
-                    60,
-                    30*60,
-                    10
+        IN:
+            id_ - the id to register under
+
+        OUT:
+            MASFilterableBackground
+        """
+        return MASFilterableBackground(
+            id_,
+            "Living room",
+            MASFilterWeatherMap(
+                day=MASWeatherMap(
+                    {
+                        mas_weather.PRECIP_TYPE_DEF: id_ + "_day",
+                        mas_weather.PRECIP_TYPE_RAIN: id_ + "_day_rain",
+                        mas_weather.PRECIP_TYPE_OVERCAST: id_ + "_day_overcast",
+                        mas_weather.PRECIP_TYPE_SNOW: id_ + "_day_snow"
+                    }
                 ),
-                MASBackgroundFilterSlice.cachecreate(
-                    mas_sprites.FLT_DAY,
-                    60,
-                    None,
-                    10
+                lr_night=MASWeatherMap(
+                    {
+                        mas_weather.PRECIP_TYPE_DEF: id_ + "_night",
+                        mas_weather.PRECIP_TYPE_RAIN: id_ + "_night_rain",
+                        mas_weather.PRECIP_TYPE_OVERCAST: id_ + "_night_overcast",
+                        mas_weather.PRECIP_TYPE_SNOW: id_ + "_night_snow"
+                    }
                 ),
-                MASBackgroundFilterSlice.cachecreate(
-                    mas_sprites.FLT_SUNSET,
-                    60,
-                    30*60,
-                    10
+                sunset=MASWeatherMap(
+                    {
+                        mas_weather.PRECIP_TYPE_DEF: id_ + "_ss",
+                        mas_weather.PRECIP_TYPE_RAIN: id_ + "_ss_rain",
+                        mas_weather.PRECIP_TYPE_OVERCAST: id_ + "_ss_overcast",
+                        mas_weather.PRECIP_TYPE_SNOW: id_ + "_ss_snow"
+                    }
                 )
             ),
-            MASBackgroundFilterChunk(
-                False,
-                None,
-                MASBackgroundFilterSlice.cachecreate(
-                    FLT_LR_NIGHT,
-                    60,
+            MASBackgroundFilterManager(
+                MASBackgroundFilterChunk(
+                    False,
                     None,
-                    10
+                    MASBackgroundFilterSlice.cachecreate(
+                        FLT_LR_NIGHT,
+                        60,
+                        None,
+                        10
+                    )
+                ),
+                MASBackgroundFilterChunk(
+                    True,
+                    None,
+                    MASBackgroundFilterSlice.cachecreate(
+                        mas_sprites.FLT_SUNSET,
+                        60,
+                        30*60,
+                        10
+                    ),
+                    MASBackgroundFilterSlice.cachecreate(
+                        mas_sprites.FLT_DAY,
+                        60,
+                        None,
+                        10
+                    ),
+                    MASBackgroundFilterSlice.cachecreate(
+                        mas_sprites.FLT_SUNSET,
+                        60,
+                        30*60,
+                        10
+                    )
+                ),
+                MASBackgroundFilterChunk(
+                    False,
+                    None,
+                    MASBackgroundFilterSlice.cachecreate(
+                        FLT_LR_NIGHT,
+                        60,
+                        None,
+                        10
+                    )
                 )
-            )
-        ),
-        hide_calendar=True,
-        unlocked=False,
-        entry_pp=_living_room_entry,
-        exit_pp=_living_room_exit
-    )
+            ),
+            hide_calendar=True,
+            unlocked=False,
+            entry_pp=_living_room_entry,
+            exit_pp=_living_room_exit
+        )
+
+    register_room(LIVING_ROOM_ID)
+    register_room(LIVING_ROOM_ID + "_lit")
 
 
 init 5 python:

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -94,6 +94,44 @@ image mas_islands_lightning_overlay:
 
         repeat
 
+
+## Base room
+# Day images
+image living_room_day = mas_island_event._get_room_sprite("d", False)
+image living_room_day_rain = mas_island_event._get_room_sprite("d_r", False)
+image living_room_day_overcast = "living_room_day_rain"
+image living_room_day_snow = mas_island_event._get_room_sprite("d_s", False)
+# Night images
+image living_room_night = mas_island_event._get_room_sprite("n", False)
+image living_room_night_rain = mas_island_event._get_room_sprite("n_r", False)
+image living_room_night_overcast = "living_room_night_rain"
+image living_room_night_snow = mas_island_event._get_room_sprite("n_s", False)
+# Sunset images
+image living_room_ss = MASFilteredSprite(
+    store.mas_sprites.FLT_SUNSET,
+    "living_room_day"
+)
+image living_room_ss_rain = MASFilteredSprite(
+    store.mas_sprites.FLT_SUNSET,
+    "living_room_day_rain"
+)
+image living_room_ss_overcast = MASFilteredSprite(
+    store.mas_sprites.FLT_SUNSET,
+    "living_room_day_overcast"
+)
+image living_room_ss_snow = MASFilteredSprite(
+    store.mas_sprites.FLT_SUNSET,
+    "living_room_day_snow"
+)
+
+## Lit room
+# Day images
+
+# Night images
+
+# Sunset images
+
+
 # # # Image defination
 init -20 python in mas_island_event:
     class IslandsImageDefinition(object):
@@ -648,6 +686,12 @@ init -25 python in mas_island_event:
     )
 
     LIVING_ROOM_NAME = "living_room"
+    FLT_LR_NIGHT = "lr_night"
+    mas_sprites.add_filter(
+        FLT_LR_NIGHT,
+        store.im.matrix.tint(0.421, 0.520, 0.965),
+        mas_sprites.FLT_NIGHT
+    )
 
     # These're being populated later once we decode the imgs
     island_disp_map = dict()
@@ -979,6 +1023,25 @@ init -25 python in mas_island_event:
         overlay_disp_map["overlay_thunder"] = partial_disp()
 
         return
+
+    def _get_room_sprite(key, is_lit):
+        """
+        Returns an appropriate displayable for the room sprite based on the criteria
+
+        IN:
+            key - str - the sprite key
+            is_lit - bool - sprite for the lit or unlit version?
+
+        OUT:
+            MASImageData
+            or Null displayable if we failed to get the image
+        """
+        main_key = "interior_room" if not is_lit else "interior_room_lit"
+        try:
+            return interior_disp_map[main_key][key]
+
+        except KeyError:
+            return NULL_DISP
 
     def _isUnlocked(id_):
         """

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -1793,7 +1793,7 @@ label mas_monika_islands_final_reveal:
     m "..."
     m "I'm surprised it actually worked, ahaha!~"
     m "You know, after spending so much time working on this..."
-    m "It feels so satisfying to not only being able to see the result myself..."
+    m "It feels so satisfying not only being able to see the result myself..."
     m "But also being able to show it to you, [mas_get_player_nickname()]."
     m "I'm sure you had been wondering what was behind that bug on the central island~"
     m "It's a small house for us to spend time in, we can go there any time now, just ask."

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -126,10 +126,20 @@ image living_room_ss_snow = MASFilteredSprite(
 
 ## Lit room
 # Day images
-
+image living_room_lit_day = "living_room_day"
+image living_room_lit_day_rain = "living_room_day_rain"
+image living_room_lit_day_overcast = "living_room_day_overcast"
+image living_room_lit_day_snow = "living_room_day_snow"
 # Night images
-
+image living_room_lit_night = mas_island_event._get_room_sprite("n", True)
+image living_room_lit_night_rain = mas_island_event._get_room_sprite("n_r", True)
+image living_room_lit_night_overcast = "living_room_lit_night_rain"
+image living_room_lit_night_snow = mas_island_event._get_room_sprite("n_s", True)
 # Sunset images
+image living_room_lit_ss = "living_room_ss"
+image living_room_lit_ss_rain = "living_room_ss_rain"
+image living_room_lit_ss_overcast = "living_room_ss_overcast"
+image living_room_lit_ss_snow = "living_room_ss_snow"
 
 
 # # # Image defination
@@ -781,7 +791,7 @@ init -25 python in mas_island_event:
             mas_utils.writelog(err_msg.format("Missing package"))
             return False
 
-        pkg_data = islands_station.unpackPackage(pkg, pkg_slip=mas_ics.ISLAND_PKG_CHKSUM)
+        pkg_data = islands_station.unpackPackage(pkg, pkg_slip=None)#mas_ics.ISLAND_PKG_CHKSUM)# FIXME: undo this
 
         if not pkg_data:
             mas_utils.writelog(err_msg.format("Bad package."))

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -946,6 +946,38 @@ init -25 python in mas_island_event:
 
         return True
 
+    def _build_ifwd(img_map):
+        """
+        Builds a single IslandFilterWeatherDisplayable
+        using the given image map
+        """
+        return IslandFilterWeatherDisplayable(
+            day=MASWeatherMap(
+                {
+                    mas_weather.PRECIP_TYPE_DEF: img_map["d"],
+                    mas_weather.PRECIP_TYPE_RAIN: img_map["d_r"],
+                    mas_weather.PRECIP_TYPE_SNOW: img_map["d_s"],
+                    mas_weather.PRECIP_TYPE_OVERCAST: img_map["d_r"]
+                }
+            ),
+            night=MASWeatherMap(
+                {
+                    mas_weather.PRECIP_TYPE_DEF: img_map["n"],
+                    mas_weather.PRECIP_TYPE_RAIN: img_map["n_r"],
+                    mas_weather.PRECIP_TYPE_SNOW: img_map["n_s"],
+                    mas_weather.PRECIP_TYPE_OVERCAST: img_map["n_r"]
+                }
+            ),
+            sunset=MASWeatherMap(
+                {
+                    mas_weather.PRECIP_TYPE_DEF: img_map["s"],
+                    mas_weather.PRECIP_TYPE_RAIN: img_map["s_r"],
+                    mas_weather.PRECIP_TYPE_SNOW: img_map["s_s"],
+                    mas_weather.PRECIP_TYPE_OVERCAST: img_map["s_r"]
+                }
+            )
+        )
+
     def _build_displayables(
         island_imgs_maps,
         decal_imgs_maps,
@@ -972,94 +1004,19 @@ init -25 python in mas_island_event:
 
         # Build the islands
         for island_name, img_map in island_imgs_maps.iteritems():
-            disp = IslandFilterWeatherDisplayable(
-                day=MASWeatherMap(
-                    {
-                        mas_weather.PRECIP_TYPE_DEF: img_map["d"],
-                        mas_weather.PRECIP_TYPE_RAIN: img_map["d_r"],
-                        mas_weather.PRECIP_TYPE_SNOW: img_map["d_s"],
-                        mas_weather.PRECIP_TYPE_OVERCAST: img_map["d_r"]
-                    }
-                ),
-                night=MASWeatherMap(
-                    {
-                        mas_weather.PRECIP_TYPE_DEF: img_map["n"],
-                        mas_weather.PRECIP_TYPE_RAIN: img_map["n_r"],
-                        mas_weather.PRECIP_TYPE_SNOW: img_map["n_s"],
-                        mas_weather.PRECIP_TYPE_OVERCAST: img_map["n_r"]
-                    }
-                ),
-                sunset=MASWeatherMap(
-                    {
-                        mas_weather.PRECIP_TYPE_DEF: img_map["s"],
-                        mas_weather.PRECIP_TYPE_RAIN: img_map["s_r"],
-                        mas_weather.PRECIP_TYPE_SNOW: img_map["s_s"],
-                        mas_weather.PRECIP_TYPE_OVERCAST: img_map["s_r"]
-                    }
-                )
-            )
+            disp = _build_ifwd(img_map)
             partial_disp = IslandsDataDefinition.getDataFor(island_name).partial_disp
             island_disp_map[island_name] = partial_disp(disp)
 
         # Build the decals
         for decal_name, img_map in decal_imgs_maps.iteritems():
-            disp = IslandFilterWeatherDisplayable(
-                day=MASWeatherMap(
-                    {
-                        mas_weather.PRECIP_TYPE_DEF: img_map["d"],
-                        mas_weather.PRECIP_TYPE_RAIN: img_map["d_r"],
-                        mas_weather.PRECIP_TYPE_SNOW: img_map["d_s"],
-                        mas_weather.PRECIP_TYPE_OVERCAST: img_map["d_r"]
-                    }
-                ),
-                night=MASWeatherMap(
-                    {
-                        mas_weather.PRECIP_TYPE_DEF: img_map["n"],
-                        mas_weather.PRECIP_TYPE_RAIN: img_map["n_r"],
-                        mas_weather.PRECIP_TYPE_SNOW: img_map["n_s"],
-                        mas_weather.PRECIP_TYPE_OVERCAST: img_map["n_r"]
-                    }
-                ),
-                sunset=MASWeatherMap(
-                    {
-                        mas_weather.PRECIP_TYPE_DEF: img_map["s"],
-                        mas_weather.PRECIP_TYPE_RAIN: img_map["s_r"],
-                        mas_weather.PRECIP_TYPE_SNOW: img_map["s_s"],
-                        mas_weather.PRECIP_TYPE_OVERCAST: img_map["s_r"]
-                    }
-                )
-            )
+            disp = _build_ifwd(img_map)
             partial_disp = IslandsDataDefinition.getDataFor(decal_name).partial_disp
             decal_disp_map[decal_name] = partial_disp(disp)
 
         # Build the bg
         for bg_name, img_map in bg_imgs_maps.iteritems():
-            disp = IslandFilterWeatherDisplayable(
-                day=MASWeatherMap(
-                    {
-                        mas_weather.PRECIP_TYPE_DEF: img_map["d"],
-                        mas_weather.PRECIP_TYPE_RAIN: img_map["d_r"],
-                        mas_weather.PRECIP_TYPE_SNOW: img_map["d_s"],
-                        mas_weather.PRECIP_TYPE_OVERCAST: img_map["d_r"]
-                    }
-                ),
-                night=MASWeatherMap(
-                    {
-                        mas_weather.PRECIP_TYPE_DEF: img_map["n"],
-                        mas_weather.PRECIP_TYPE_RAIN: img_map["n_r"],
-                        mas_weather.PRECIP_TYPE_SNOW: img_map["n_s"],
-                        mas_weather.PRECIP_TYPE_OVERCAST: img_map["n_r"]
-                    }
-                ),
-                sunset=MASWeatherMap(
-                    {
-                        mas_weather.PRECIP_TYPE_DEF: img_map["s"],
-                        mas_weather.PRECIP_TYPE_RAIN: img_map["s_r"],
-                        mas_weather.PRECIP_TYPE_SNOW: img_map["s_s"],
-                        mas_weather.PRECIP_TYPE_OVERCAST: img_map["s_r"]
-                    }
-                )
-            )
+            disp = _build_ifwd(img_map)
             partial_disp = IslandsDataDefinition.getDataFor(bg_name).partial_disp
             bg_disp_map[bg_name] = partial_disp(disp)
 

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -1384,6 +1384,111 @@ init -25 python in mas_island_event:
         return store.mas_is_raining or store.mas_current_weather == store.mas_weather_overcast
 
 
+init -1 python in mas_island_event:
+    from store import (
+        MASFilterableBackground,
+        MASFilterWeatherMap,
+        MASBackgroundFilterManager,
+        MASBackgroundFilterChunk,
+        MASBackgroundFilterSlice
+    )
+
+    def _living_room_entry(_old, **kwargs):
+        """
+        Entry pp for lr background
+        """
+        store.monika_chr.tablechair.table = "living_room"
+        store.monika_chr.tablechair.chair = "living_room"
+
+
+    def _living_room_exit(_new, **kwargs):
+        """
+        Exit pp for lr background
+        """
+        store.monika_chr.tablechair.table = "def"
+        store.monika_chr.tablechair.chair = "def"
+
+
+    MASFilterableBackground(
+        "living_room",
+        "Living room",
+        MASFilterWeatherMap(
+            day=MASWeatherMap(
+                {
+                    mas_weather.PRECIP_TYPE_DEF: "living_room_day",
+                    mas_weather.PRECIP_TYPE_RAIN: "living_room_day_rain",
+                    mas_weather.PRECIP_TYPE_OVERCAST: "living_room_day_overcast",
+                    mas_weather.PRECIP_TYPE_SNOW: "living_room_day_snow"
+                }
+            ),
+            lr_night=MASWeatherMap(
+                {
+                    mas_weather.PRECIP_TYPE_DEF: "living_room_night",
+                    mas_weather.PRECIP_TYPE_RAIN: "living_room_night_rain",
+                    mas_weather.PRECIP_TYPE_OVERCAST: "living_room_night_overcast",
+                    mas_weather.PRECIP_TYPE_SNOW: "living_room_night_snow"
+                }
+            ),
+            sunset=MASWeatherMap(
+                {
+                    mas_weather.PRECIP_TYPE_DEF: "living_room_ss",
+                    mas_weather.PRECIP_TYPE_RAIN: "living_room_ss_rain",
+                    mas_weather.PRECIP_TYPE_OVERCAST: "living_room_ss_overcast",
+                    mas_weather.PRECIP_TYPE_SNOW: "living_room_ss_snow"
+                }
+            )
+        ),
+        MASBackgroundFilterManager(
+            MASBackgroundFilterChunk(
+                False,
+                None,
+                MASBackgroundFilterSlice.cachecreate(
+                    FLT_LR_NIGHT,
+                    60,
+                    None,
+                    10
+                )
+            ),
+            MASBackgroundFilterChunk(
+                True,
+                None,
+                MASBackgroundFilterSlice.cachecreate(
+                    mas_sprites.FLT_SUNSET,
+                    60,
+                    30*60,
+                    10
+                ),
+                MASBackgroundFilterSlice.cachecreate(
+                    mas_sprites.FLT_DAY,
+                    60,
+                    None,
+                    10
+                ),
+                MASBackgroundFilterSlice.cachecreate(
+                    mas_sprites.FLT_SUNSET,
+                    60,
+                    30*60,
+                    10
+                )
+            ),
+            MASBackgroundFilterChunk(
+                False,
+                None,
+                MASBackgroundFilterSlice.cachecreate(
+                    FLT_LR_NIGHT,
+                    60,
+                    None,
+                    10
+                )
+            )
+        ),
+        hide_calendar=True,
+        unlocked=False,
+        entry_pp=_living_room_entry,
+        exit_pp=_living_room_exit
+    )
+
+
 init 5 python:
     addEvent(
         Event(

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -554,8 +554,8 @@ init -20 python in mas_island_event:
         partial_disp=functools.partial(
             ParallaxDecal,
             x=358,
-            y=55,
-            z=4,
+            y=62,
+            z=6,
             on_click="mas_island_bookshelf"
         )
     )
@@ -564,8 +564,8 @@ init -20 python in mas_island_event:
         partial_disp=functools.partial(
             ParallaxDecal,
             x=305,
-            y=63,
-            z=5,
+            y=70,
+            z=8,
             on_click=True
         )
     )
@@ -574,7 +574,7 @@ init -20 python in mas_island_event:
         partial_disp=functools.partial(
             ParallaxDecal,
             x=215,
-            y=-44,
+            y=-37,
             z=1
         )
     )
@@ -583,8 +583,8 @@ init -20 python in mas_island_event:
         partial_disp=functools.partial(
             ParallaxDecal,
             x=130,
-            y=-200,
-            z=3,
+            y=-194,
+            z=4,
             on_click="mas_island_cherry_blossom_tree"
         )
     )
@@ -608,6 +608,106 @@ init -20 python in mas_island_event:
             on_click="mas_island_glitchedmess"
         )
     )
+    IslandsDataDefinition(
+        "decal_bloodfall",
+        filenames=("d", "n"),
+        partial_disp=functools.partial(
+            ParallaxDecal,
+            x=213,
+            y=0,
+            z=1,
+            on_click=True
+        )
+    )
+    IslandsDataDefinition(
+        "decal_ghost_0",
+        filenames=("d",),
+        partial_disp=functools.partial(
+            ParallaxDecal,
+            x=355,
+            y=-70,
+            z=5,
+            on_click=True
+        )
+    )
+    IslandsDataDefinition(
+        "decal_ghost_1",
+        filenames=("d",),
+        partial_disp=functools.partial(
+            ParallaxDecal,
+            x=355,
+            y=-70,
+            z=5,
+            on_click=True
+        )
+    )
+    IslandsDataDefinition(
+        "decal_ghost_2",
+        filenames=("d", "n"),
+        partial_disp=functools.partial(
+            ParallaxDecal,
+            x=355,
+            y=-70,
+            z=5,
+            on_click=True
+        )
+    )
+    IslandsDataDefinition(
+        "decal_gravestones",
+        filenames=("d", "n"),
+        partial_disp=functools.partial(
+            ParallaxDecal,
+            x=125,
+            y=15,
+            z=1,
+            on_click=True
+        )
+    )
+    IslandsDataDefinition(
+        "decal_jack",
+        filenames=("d", "n"),
+        partial_disp=functools.partial(
+            ParallaxDecal,
+            x=253,
+            y=63,
+            z=2,
+            on_click=True
+        )
+    )
+    IslandsDataDefinition(
+        "decal_pumpkins",
+        filenames=("d", "n"),
+        partial_disp=functools.partial(
+            ParallaxDecal,
+            x=176,
+            y=61,
+            z=15,
+            on_click=True
+        )
+    )
+    IslandsDataDefinition(
+        "decal_skull",
+        filenames=("d", "n"),
+        partial_disp=functools.partial(
+            ParallaxDecal,
+            x=100,
+            y=0,
+            z=1,
+            on_click=True
+        )
+    )
+    IslandsDataDefinition(
+        "decal_webs",
+        filenames=("d",),
+        partial_disp=functools.partial(
+            ParallaxDecal,
+            x=187,
+            y=-99,
+            z=5,
+            on_click=True
+        )
+    )
+    # TODO: haunted tree
     # Objects
     IslandsDataDefinition(
         "other_shimeji",

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -109,19 +109,19 @@ image living_room_night_snow = mas_island_event._get_room_sprite("n_s", False)
 # Sunset images
 image living_room_ss = MASFilteredSprite(
     store.mas_sprites.FLT_SUNSET,
-    "living_room_day"
+    renpy.displayable("living_room_day")
 )
 image living_room_ss_rain = MASFilteredSprite(
     store.mas_sprites.FLT_SUNSET,
-    "living_room_day_rain"
+    renpy.displayable("living_room_day_rain")
 )
 image living_room_ss_overcast = MASFilteredSprite(
     store.mas_sprites.FLT_SUNSET,
-    "living_room_day_overcast"
+    renpy.displayable("living_room_day_overcast")
 )
 image living_room_ss_snow = MASFilteredSprite(
     store.mas_sprites.FLT_SUNSET,
-    "living_room_day_snow"
+    renpy.displayable("living_room_day_snow")
 )
 
 ## Lit room

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -2560,20 +2560,20 @@ label mas_island_pumpkins:
     return
 
 label mas_island_gravestones:
-    if not mas_safeToRefDokis():
+    if mas_safeToRefDokis():
+        m "What?"
+        m "...{w=0.2}What tombstones? {w=0.2}I'm not sure what you're talking about."
+        m "Are you...{w=0.2}pfft--"
+        m "Ahaha!"
+        m "Sorry, I couldn't resist."
+        m "It would be pretty spooky if those three were still haunting our happy ending, wouldn't it?"
+
+    else:
         m "Ehehe...I'm not sure if those decorations are entirely tasteful."
         m "I was thinking, though...{w=0.2}Halloween is a time when some cultures honor the dead."
         m "Sure, there are a lot of spooky stories about the dead rising, or ghosts haunting people..."
         m "But there's a side of this holiday about remembering, isn't there?"
         m "I guess I just thought I shouldn't leave them out."
-
-    else:
-        m "What?"
-        m "...{w=0.2}What tombstones? {w-0.2}I'm not sure what you're talking about."
-        m "Are you...{w=0.2}pfft--"
-        m "Ahaha!"
-        m "Sorry, I couldn't resist."
-        m "It would be pretty spooky if those three were still haunting our happy ending, wouldn't it?"
 
     return
 

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -22,7 +22,7 @@ init 1:
     #
     #   NOTE: other things to note:
     #       on o31, we cannot have islands event
-    define mas_decoded_islands = store.mas_island_event.decodeImages()
+    define mas_decoded_islands = store.mas_island_event.decode_images()
     define mas_cannot_decode_islands = not mas_decoded_islands
 
     python:
@@ -813,7 +813,7 @@ init -25 python in mas_island_event:
         buf.seek(0)
         return buf
 
-    def decodeImages():
+    def decode_images():
         """
         Attempts to decode the images
 
@@ -877,11 +877,11 @@ init -25 python in mas_island_event:
 
         else:
             # We loaded the images, now create dynamic displayables
-            _buildDisplayables(island_map, decal_map, bg_map, overlay_map, interior_map, glitch_frames)
+            _build_displayables(island_map, decal_map, bg_map, overlay_map, interior_map, glitch_frames)
 
         return True
 
-    def _buildDisplayables(
+    def _build_displayables(
         island_imgs_maps,
         decal_imgs_maps,
         bg_imgs_maps,

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -132,40 +132,40 @@ image mas_islands_lightning_overlay:
         repeat
 
 
-## Base room
-# Day images
-image living_room_day = mas_island_event._get_room_sprite("d", False)
-image living_room_day_rain = mas_island_event._get_room_sprite("d_r", False)
-image living_room_day_overcast = "living_room_day_rain"
-image living_room_day_snow = mas_island_event._get_room_sprite("d_s", False)
-# Night images
-image living_room_night = mas_island_event._get_room_sprite("n", False)
-image living_room_night_rain = mas_island_event._get_room_sprite("n_r", False)
-image living_room_night_overcast = "living_room_night_rain"
-image living_room_night_snow = mas_island_event._get_room_sprite("n_s", False)
-# Sunset images
-image living_room_ss = mas_island_event._apply_flt_on_room_sprite("living_room_day", mas_sprites.FLT_SUNSET)
-image living_room_ss_rain = mas_island_event._apply_flt_on_room_sprite("living_room_day_rain", mas_sprites.FLT_SUNSET)
-image living_room_ss_overcast = mas_island_event._apply_flt_on_room_sprite("living_room_day_overcast", mas_sprites.FLT_SUNSET)
-image living_room_ss_snow = mas_island_event._apply_flt_on_room_sprite("living_room_day_snow", mas_sprites.FLT_SUNSET)
+# ## Base room
+# # Day images
+# image living_room_day = mas_island_event._get_room_sprite("d", False)
+# image living_room_day_rain = mas_island_event._get_room_sprite("d_r", False)
+# image living_room_day_overcast = "living_room_day_rain"
+# image living_room_day_snow = mas_island_event._get_room_sprite("d_s", False)
+# # Night images
+# image living_room_night = mas_island_event._get_room_sprite("n", False)
+# image living_room_night_rain = mas_island_event._get_room_sprite("n_r", False)
+# image living_room_night_overcast = "living_room_night_rain"
+# image living_room_night_snow = mas_island_event._get_room_sprite("n_s", False)
+# # Sunset images
+# image living_room_ss = mas_island_event._apply_flt_on_room_sprite("living_room_day", mas_sprites.FLT_SUNSET)
+# image living_room_ss_rain = mas_island_event._apply_flt_on_room_sprite("living_room_day_rain", mas_sprites.FLT_SUNSET)
+# image living_room_ss_overcast = mas_island_event._apply_flt_on_room_sprite("living_room_day_overcast", mas_sprites.FLT_SUNSET)
+# image living_room_ss_snow = mas_island_event._apply_flt_on_room_sprite("living_room_day_snow", mas_sprites.FLT_SUNSET)
 
 
-## Lit room
-# Day images
-image living_room_lit_day = "living_room_day"
-image living_room_lit_day_rain = "living_room_day_rain"
-image living_room_lit_day_overcast = "living_room_day_overcast"
-image living_room_lit_day_snow = "living_room_day_snow"
-# Night images
-image living_room_lit_night = mas_island_event._get_room_sprite("n", True)
-image living_room_lit_night_rain = mas_island_event._get_room_sprite("n_r", True)
-image living_room_lit_night_overcast = "living_room_lit_night_rain"
-image living_room_lit_night_snow = mas_island_event._get_room_sprite("n_s", True)
-# Sunset images
-image living_room_lit_ss = "living_room_ss"
-image living_room_lit_ss_rain = "living_room_ss_rain"
-image living_room_lit_ss_overcast = "living_room_ss_overcast"
-image living_room_lit_ss_snow = "living_room_ss_snow"
+# ## Lit room
+# # Day images
+# image living_room_lit_day = "living_room_day"
+# image living_room_lit_day_rain = "living_room_day_rain"
+# image living_room_lit_day_overcast = "living_room_day_overcast"
+# image living_room_lit_day_snow = "living_room_day_snow"
+# # Night images
+# image living_room_lit_night = mas_island_event._get_room_sprite("n", True)
+# image living_room_lit_night_rain = mas_island_event._get_room_sprite("n_r", True)
+# image living_room_lit_night_overcast = "living_room_lit_night_rain"
+# image living_room_lit_night_snow = mas_island_event._get_room_sprite("n_s", True)
+# # Sunset images
+# image living_room_lit_ss = "living_room_ss"
+# image living_room_lit_ss_rain = "living_room_ss_rain"
+# image living_room_lit_ss_overcast = "living_room_ss_overcast"
+# image living_room_lit_ss_snow = "living_room_ss_snow"
 
 
 # # # Image defination
@@ -315,8 +315,9 @@ init -20 python in mas_island_event:
 
             OUT:
                 IslandsDataDefinition
+                or None
             """
-            return cls._data_map[id_]
+            return cls._data_map.get(id_, None)
 
         @classmethod
         def getDefaultUnlocks(cls):
@@ -758,24 +759,24 @@ init -20 python in mas_island_event:
             on_click="mas_island_shimeji"
         )
     )
-    IslandsDataDefinition(
-        "other_isly",
-        filenames=("clear", "rain", "snow")
-    )
+    # IslandsDataDefinition(
+    #     "other_isly",
+    #     filenames=("clear", "rain", "snow")
+    # )
 
-    # Interior
-    IslandsDataDefinition(
-        "interior_room",
-        filenames=("d", "d_r", "d_s", "n", "n_r", "n_s")
-    )
-    IslandsDataDefinition(
-        "interior_room_lit",
-        filenames=("d", "d_r", "d_s", "n", "n_r", "n_s")
-    )
-    IslandsDataDefinition(
-        "interior_tablechair",
-        filenames=("chair", "shadow", "table")
-    )
+    # # Interior
+    # IslandsDataDefinition(
+    #     "interior_room",
+    #     filenames=("d", "d_r", "d_s", "n", "n_r", "n_s")
+    # )
+    # IslandsDataDefinition(
+    #     "interior_room_lit",
+    #     filenames=("d", "d_r", "d_s", "n", "n_r", "n_s")
+    # )
+    # IslandsDataDefinition(
+    #     "interior_tablechair",
+    #     filenames=("chair", "shadow", "table")
+    # )
 
     # BGs
     IslandsDataDefinition(
@@ -1029,7 +1030,7 @@ init -25 python in mas_island_event:
             mas_utils.mas_log.error(err_msg.format("Missing package"))
             return False
 
-        pkg_data = islands_station.unpackPackage(pkg, pkg_slip=None)#mas_ics.ISLAND_PKG_CHKSUM)# FIXME: undo this
+        pkg_data = islands_station.unpackPackage(pkg, pkg_slip=mas_ics.ISLAND_PKG_CHKSUM)
 
         if not pkg_data:
             mas_utils.mas_log.error(err_msg.format("Bad package"))
@@ -1074,9 +1075,10 @@ init -25 python in mas_island_event:
 
                 # Audio is being loaded right away
                 isly_data = IslandsDataDefinition.getDataFor("other_isly")
-                for fn, fp in isly_data.fp_map.iteritems():
-                    audio_data = store.MASAudioData(zip_file.read(fp), fp + ".ogg")
-                    setattr(store.audio, "isld_isly_" + fn, audio_data)
+                if isly_data:
+                    for fn, fp in isly_data.fp_map.iteritems():
+                        audio_data = store.MASAudioData(zip_file.read(fp), fp + ".ogg")
+                        setattr(store.audio, "isld_isly_" + fn, audio_data)
 
         except Exception as e:
             # mas_utils.writelog(err_msg.format(e))
@@ -1841,9 +1843,6 @@ init -1 python in mas_island_event:
             exit_pp=_living_room_exit
         )
 
-    register_room(LIVING_ROOM_ID)
-    register_room(LIVING_ROOM_LIT_ID)
-
 
 init 5 python:
     addEvent(
@@ -1926,169 +1925,169 @@ label mas_monika_islands_progress:
 
     return
 
-default persistent._mas_pm_likes_islands = None
+# default persistent._mas_pm_likes_islands = None
 
-init 5 python:
-    addEvent(
-        Event(
-            persistent.event_database,
-            eventlabel="mas_monika_islands_final_reveal"
-        ),
-        restartBlacklist=True
-    )
+# init 5 python:
+#     addEvent(
+#         Event(
+#             persistent.event_database,
+#             eventlabel="mas_monika_islands_final_reveal"
+#         ),
+#         restartBlacklist=True
+#     )
 
-label mas_monika_islands_final_reveal:
-    python:
-        renpy.dynamic("islands_disp")
-        mas_island_event._final_unlocks()
-        islands_disp = mas_island_event.get_islands_displayable(False, False)
+# label mas_monika_islands_final_reveal:
+#     python:
+#         renpy.dynamic("islands_disp")
+#         mas_island_event._final_unlocks()
+#         islands_disp = mas_island_event.get_islands_displayable(False, False)
 
-    m 4sub "I'm so excited to finally show you my work!"
+#     m 4sub "I'm so excited to finally show you my work!"
 
-    if mas_getCurrentBackgroundId() != "spaceroom":
-        m 7eua "Let's return to the classroom for the best view."
-        call mas_background_change(mas_background_def, skip_leadin=True, skip_outro=True)
+#     if mas_getCurrentBackgroundId() != "spaceroom":
+#         m 7eua "Let's return to the classroom for the best view."
+#         call mas_background_change(mas_background_def, skip_leadin=True, skip_outro=True)
 
-    m 1eua "Now let me turn off the light.{w=0.3}.{w=0.3}.{w=0.3}{nw}"
+#     m 1eua "Now let me turn off the light.{w=0.3}.{w=0.3}.{w=0.3}{nw}"
 
-    window hide
-    call .islands_scene
-    window auto
+#     window hide
+#     call .islands_scene
+#     window auto
 
-    m "..."
-    m "I'm surprised it actually worked, ahaha!~"
-    m "You know, after spending so much time working on this..."
-    m "It feels so satisfying not only being able to see the result myself..."
-    m "But also being able to show it to you, [mas_get_player_nickname()]."
-    m "I'm sure you had been wondering what was behind that bug on the central island~"
-    m "It's a small house for us to spend time in, we can go there any time now, just ask."
+#     m "..."
+#     m "I'm surprised it actually worked, ahaha!~"
+#     m "You know, after spending so much time working on this..."
+#     m "It feels so satisfying not only being able to see the result myself..."
+#     m "But also being able to show it to you, [mas_get_player_nickname()]."
+#     m "I'm sure you had been wondering what was behind that bug on the central island~"
+#     m "It's a small house for us to spend time in, we can go there any time now, just ask."
 
-    if mas_background.getUnlockedBGCount() == 1:
-        m "I know staying in this empty classroom can feel tiresome sometimes."
-        m "So it's nice to get more places to visit."
+#     if mas_background.getUnlockedBGCount() == 1:
+#         m "I know staying in this empty classroom can feel tiresome sometimes."
+#         m "So it's nice to get more places to visit."
 
-    else:
-        m "Even with all the other places we have, it's always nice to get new surroundings."
+#     else:
+#         m "Even with all the other places we have, it's always nice to get new surroundings."
 
-    m "Now, why don't we go inside, [player]?"
+#     m "Now, why don't we go inside, [player]?"
 
-    window hide
-    call .zoom_in
-    window auto
+#     window hide
+#     call .zoom_in
+#     window auto
 
-    python hide:
-        bg = mas_getBackground(mas_island_event.LIVING_ROOM_ID)
-        if bg:
-            mas_changeBackground(bg)
-        mas_island_event.stop_music()
+#     python hide:
+#         bg = mas_getBackground(mas_island_event.LIVING_ROOM_ID)
+#         if bg:
+#             mas_changeBackground(bg)
+#         mas_island_event.stop_music()
 
-    call spaceroom(scene_change=True, dissolve_all=True, force_exp="monika 4hub")
+#     call spaceroom(scene_change=True, dissolve_all=True, force_exp="monika 4hub")
 
-    m "Tada!~"
-    m 2eua "So, [player]..."
-    m 3eka "Your opinion is {i}really{/i} important to me."
+#     m "Tada!~"
+#     m 2eua "So, [player]..."
+#     m 3eka "Your opinion is {i}really{/i} important to me."
 
-    call .ask_opinion
+#     call .ask_opinion
 
-    return
+#     return
 
-label mas_monika_islands_final_reveal.islands_scene:
-    $ mas_RaiseShield_core()
-    $ mas_OVLHide()
-    $ mas_hotkeys.no_window_hiding = True
-    $ mas_play_song(None)
-    scene black with dissolve
+# label mas_monika_islands_final_reveal.islands_scene:
+#     $ mas_RaiseShield_core()
+#     $ mas_OVLHide()
+#     $ mas_hotkeys.no_window_hiding = True
+#     $ mas_play_song(None)
+#     scene black with dissolve
 
-    $ mas_island_event.play_music()
+#     $ mas_island_event.play_music()
 
-    # I'd love to split the lines properly, but renpy doesn't allow that, so have this cursed thing instead
-    show expression islands_disp as islands_disp at mas_islands_final_reveal_trans_1(
-        delay=mas_island_event.REVEAL_ANIM_DELAY,
-        move_time=mas_island_event.REVEAL_ANIM_1_DURATION - mas_island_event.REVEAL_ANIM_DELAY
-    ) zorder mas_island_event.DEF_SCREEN_ZORDER with mas_island_event.REVEAL_FADE_TRANSITION
-    $ renpy.pause(mas_island_event.REVEAL_ANIM_1_DURATION - mas_island_event.REVEAL_TRANSITION_TIME - mas_island_event.REVEAL_FADEIN_TIME, hard=True)
+#     # I'd love to split the lines properly, but renpy doesn't allow that, so have this cursed thing instead
+#     show expression islands_disp as islands_disp at mas_islands_final_reveal_trans_1(
+#         delay=mas_island_event.REVEAL_ANIM_DELAY,
+#         move_time=mas_island_event.REVEAL_ANIM_1_DURATION - mas_island_event.REVEAL_ANIM_DELAY
+#     ) zorder mas_island_event.DEF_SCREEN_ZORDER with mas_island_event.REVEAL_FADE_TRANSITION
+#     $ renpy.pause(mas_island_event.REVEAL_ANIM_1_DURATION - mas_island_event.REVEAL_TRANSITION_TIME - mas_island_event.REVEAL_FADEIN_TIME, hard=True)
 
-    show expression islands_disp as islands_disp at mas_islands_final_reveal_trans_2(
-        delay=mas_island_event.REVEAL_ANIM_DELAY,
-        move_time=mas_island_event.REVEAL_ANIM_2_DURATION - mas_island_event.REVEAL_ANIM_DELAY
-    ) zorder mas_island_event.DEF_SCREEN_ZORDER with mas_island_event.REVEAL_FADE_TRANSITION
-    $ renpy.pause(mas_island_event.REVEAL_ANIM_2_DURATION - mas_island_event.REVEAL_TRANSITION_TIME - mas_island_event.REVEAL_FADEIN_TIME, hard=True)
+#     show expression islands_disp as islands_disp at mas_islands_final_reveal_trans_2(
+#         delay=mas_island_event.REVEAL_ANIM_DELAY,
+#         move_time=mas_island_event.REVEAL_ANIM_2_DURATION - mas_island_event.REVEAL_ANIM_DELAY
+#     ) zorder mas_island_event.DEF_SCREEN_ZORDER with mas_island_event.REVEAL_FADE_TRANSITION
+#     $ renpy.pause(mas_island_event.REVEAL_ANIM_2_DURATION - mas_island_event.REVEAL_TRANSITION_TIME - mas_island_event.REVEAL_FADEIN_TIME, hard=True)
 
-    show expression islands_disp as islands_disp at mas_islands_final_reveal_trans_3(
-        delay=mas_island_event.REVEAL_ANIM_DELAY,
-        move_time=mas_island_event.REVEAL_ANIM_3_1_DURATION - mas_island_event.REVEAL_ANIM_DELAY,
-        zoom_time=mas_island_event.REVEAL_ANIM_3_2_DURATION
-    ) zorder mas_island_event.DEF_SCREEN_ZORDER with mas_island_event.REVEAL_FADE_TRANSITION
-    $ renpy.pause(mas_island_event.REVEAL_ANIM_3_1_DURATION + mas_island_event.REVEAL_ANIM_3_2_DURATION - mas_island_event.REVEAL_TRANSITION_TIME, hard=True)
+#     show expression islands_disp as islands_disp at mas_islands_final_reveal_trans_3(
+#         delay=mas_island_event.REVEAL_ANIM_DELAY,
+#         move_time=mas_island_event.REVEAL_ANIM_3_1_DURATION - mas_island_event.REVEAL_ANIM_DELAY,
+#         zoom_time=mas_island_event.REVEAL_ANIM_3_2_DURATION
+#     ) zorder mas_island_event.DEF_SCREEN_ZORDER with mas_island_event.REVEAL_FADE_TRANSITION
+#     $ renpy.pause(mas_island_event.REVEAL_ANIM_3_1_DURATION + mas_island_event.REVEAL_ANIM_3_2_DURATION - mas_island_event.REVEAL_TRANSITION_TIME, hard=True)
 
-    $ renpy.pause(mas_island_event.REVEAL_OVERVIEW_DURATION, hard=True)
-    $ mas_hotkeys.no_window_hiding = False
-    $ mas_OVLShow()
-    $ mas_DropShield_core()
-    $ mas_RaiseShield_dlg()
+#     $ renpy.pause(mas_island_event.REVEAL_OVERVIEW_DURATION, hard=True)
+#     $ mas_hotkeys.no_window_hiding = False
+#     $ mas_OVLShow()
+#     $ mas_DropShield_core()
+#     $ mas_RaiseShield_dlg()
 
-    return
+#     return
 
-label mas_monika_islands_final_reveal.zoom_in:
-    show expression islands_disp as islands_disp at mas_islands_final_reveal_trans_4(
-        delay=0.0,
-        zoom_time=mas_island_event.REVEAL_ANIM_4_DURATION
-    ) zorder mas_island_event.DEF_SCREEN_ZORDER
-    $ renpy.pause(mas_island_event.REVEAL_ANIM_4_DURATION - mas_island_event.REVEAL_FADEOUT_TIME, hard=True)
-    scene black with mas_island_event.REVEAL_DISSOLVE_TRANSITION
+# label mas_monika_islands_final_reveal.zoom_in:
+#     show expression islands_disp as islands_disp at mas_islands_final_reveal_trans_4(
+#         delay=0.0,
+#         zoom_time=mas_island_event.REVEAL_ANIM_4_DURATION
+#     ) zorder mas_island_event.DEF_SCREEN_ZORDER
+#     $ renpy.pause(mas_island_event.REVEAL_ANIM_4_DURATION - mas_island_event.REVEAL_FADEOUT_TIME, hard=True)
+#     scene black with mas_island_event.REVEAL_DISSOLVE_TRANSITION
 
-    return
+#     return
 
-label mas_monika_islands_final_reveal.ask_opinion:
-    m 1eksdla "What do you think?~{nw}"
-    $ _history_list.pop()
-    menu:
-        m "What do you think?~{fast}"
+# label mas_monika_islands_final_reveal.ask_opinion:
+#     m 1eksdla "What do you think?~{nw}"
+#     $ _history_list.pop()
+#     menu:
+#         m "What do you think?~{fast}"
 
-        "It's not too bad.":
-            $ persistent._mas_pm_likes_islands = False
-            $ mas_loseAffectionFraction(min_amount=50, modifier=1.0)
-            $ mas_lockEVL("mas_monika_islands", "EVE")
-            m 2ekd "Oh...{w=0.3}{nw}"
-            extend 2lkc "I guess it's not perfect..."
-            m 2dktpc "But after all that time I've spent working for a place for us, {w=0.1}{nw}"
-            extend 2fktud "you could at least pretend to care."
+#         "It's not too bad.":
+#             $ persistent._mas_pm_likes_islands = False
+#             $ mas_loseAffectionFraction(min_amount=50, modifier=1.0)
+#             $ mas_lockEVL("mas_monika_islands", "EVE")
+#             m 2ekd "Oh...{w=0.3}{nw}"
+#             extend 2lkc "I guess it's not perfect..."
+#             m 2dktpc "But after all that time I've spent working for a place for us, {w=0.1}{nw}"
+#             extend 2fktud "you could at least pretend to care."
 
-            if persistent._mas_pm_cares_island_progress is False:
-                $ mas_loseAffectionFraction(min_amount=50, modifier=0.5)
-                m 2dktsc "..."
-                m 2gftpc "Although, what did I expect...{w=0.3}{nw}"
-                extend 2eftud "you have said you don't care before."
-                m 2dstdc "Forget, {w=0.3}{nw}"
-                extend 2mstdc "this was a waste of time. {w=0.3}{nw}"
-                extend 2tsc "For both of us."
+#             if persistent._mas_pm_cares_island_progress is False:
+#                 $ mas_loseAffectionFraction(min_amount=50, modifier=0.5)
+#                 m 2dktsc "..."
+#                 m 2gftpc "Although, what did I expect...{w=0.3}{nw}"
+#                 extend 2eftud "you have said you don't care before."
+#                 m 2dstdc "Forget, {w=0.3}{nw}"
+#                 extend 2mstdc "this was a waste of time. {w=0.3}{nw}"
+#                 extend 2tsc "For both of us."
 
-            else:
-                m 2dktsc "It hurts, [player]... {w=0.3}It really, {w=0.1}{i}really{/i} hurts."
-                m 2fftdd "You know what? {w=0.1}Forget. {w=0.3}{nw}"
-                extend 2mftdc "It was a mistake from the start."
+#             else:
+#                 m 2dktsc "It hurts, [player]... {w=0.3}It really, {w=0.1}{i}really{/i} hurts."
+#                 m 2fftdd "You know what? {w=0.1}Forget. {w=0.3}{nw}"
+#                 extend 2mftdc "It was a mistake from the start."
 
-            # TODO: reference monika_sweatercurse?
+#             # TODO: reference monika_sweatercurse?
 
-        "You did an amazing job!":
-            $ persistent._mas_pm_likes_islands = True
-            $ mas_gainAffection(10, bypass=True)
-            m 1wuo "Really? {w=0.3}{nw}"
-            extend 2suo "You can't imagine how much that means to me, [player]!"
-            m 2fktpa "I'm so, {w=0.1}{i}so{/i} glad you liked it."
+#         "You did an amazing job!":
+#             $ persistent._mas_pm_likes_islands = True
+#             $ mas_gainAffection(10, bypass=True)
+#             m 1wuo "Really? {w=0.3}{nw}"
+#             extend 2suo "You can't imagine how much that means to me, [player]!"
+#             m 2fktpa "I'm so, {w=0.1}{i}so{/i} glad you liked it."
 
-            if persistent._mas_pm_cares_island_progress is False:
-                $ mas_gainAffection(5, bypass=True)
-                m 3rktdc "You've got me a bit worried before when you said you don't care about our islands..."
-                m 1eka "It makes me incredibly happy you've changed your mind."
+#             if persistent._mas_pm_cares_island_progress is False:
+#                 $ mas_gainAffection(5, bypass=True)
+#                 m 3rktdc "You've got me a bit worried before when you said you don't care about our islands..."
+#                 m 1eka "It makes me incredibly happy you've changed your mind."
 
-            elif persistent._mas_pm_cares_island_progress:
-                $ mas_gainAffection(5, bypass=True)
-                m 3fktda "It's only because of your everlasting love and support I was able to finish this."
+#             elif persistent._mas_pm_cares_island_progress:
+#                 $ mas_gainAffection(5, bypass=True)
+#                 m 3fktda "It's only because of your everlasting love and support I was able to finish this."
 
-            m 3hublb "Thanks for being my inspiration, [mas_get_player_nickname()]~"
+#             m 3hublb "Thanks for being my inspiration, [mas_get_player_nickname()]~"
 
-    return
+#     return
 
 
 label mas_islands(

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -1513,7 +1513,7 @@ init -25 python in mas_island_event:
         )
 
         if _is_unlocked("other_shimeji") and random.random() <= SHIMEJI_CHANCE:
-            shimeji_disp = other_shimeji["other_shimeji"]
+            shimeji_disp = other_disp_map["other_shimeji"]
             _reset_parallax_disp(shimeji_disp)
             SHIMEJI_CHANCE /= 2.0
             sub_displayables.append(shimeji_disp)
@@ -2299,7 +2299,7 @@ label mas_island_shimeji:
     m "Ah!"
     m "How'd she get there?"
     m "Give me a second, [player].{w=0.2}.{w=0.2}.{w=0.2}{nw}"
-    $ islands_displayable.remove(mas_island_event.other_shimeji["other_shimeji"])
+    $ islands_displayable.remove(mas_island_event.other_disp_map["other_shimeji"])
     m "All done!"
     m "Don't worry, I just moved her to a different place."
     return

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -1070,9 +1070,8 @@ init -25 python in mas_island_event:
                     precip_map[p_type] = img_map[k]
 
             if not precip_map:
-                raise Exception("Aiaiai")
+                raise Exception("Failed to make precip map for: {}".format(img_map))
 
-            store.mas_utils.mas_log.info(precip_map)
             return MASWeatherMap(precip_map)
 
         filter_keys = ("day", "night", "sunset")

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -652,6 +652,40 @@ init -20 python in mas_island_event:
             on_click=True
         )
     )
+    # NOTE: these trees have same params as decal_tree
+    IslandsDataDefinition(
+        "decal_haunted_tree_0",
+        filenames=("d", "n"),
+        partial_disp=functools.partial(
+            ParallaxDecal,
+            x=130,
+            y=-194,
+            z=4,
+            on_click=True
+        )
+    )
+    IslandsDataDefinition(
+        "decal_haunted_tree_1",
+        filenames=("d", "n"),
+        partial_disp=functools.partial(
+            ParallaxDecal,
+            x=130,
+            y=-194,
+            z=4,
+            on_click=True
+        )
+    )
+    IslandsDataDefinition(
+        "decal_haunted_tree_2",
+        filenames=("d", "n"),
+        partial_disp=functools.partial(
+            ParallaxDecal,
+            x=130,
+            y=-194,
+            z=4,
+            on_click=True
+        )
+    )
     IslandsDataDefinition(
         "decal_gravestones",
         filenames=("d", "n"),

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -1081,7 +1081,6 @@ init -25 python in mas_island_event:
                         setattr(store.audio, "isld_isly_" + fn, audio_data)
 
         except Exception as e:
-            # mas_utils.writelog(err_msg.format(e))
             mas_utils.mas_log.error(err_msg.format(e), exc_info=True)
             return False
 
@@ -2561,7 +2560,7 @@ label mas_island_pumpkins:
     return
 
 label mas_island_gravestones:
-    if mas_safeToRefDokis():
+    if not mas_safeToRefDokis():
         m "Ehehe...I'm not sure if those decorations are entirely tasteful."
         m "I was thinking, though...{w=0.2}Halloween is a time when some cultures honor the dead."
         m "Sure, there are a lot of spooky stories about the dead rising, or ghosts haunting people..."

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -524,7 +524,7 @@ init -20 python in mas_island_event:
             y=46,
             z=200,
             function=None,
-            on_click=True
+            on_click="mas_island_distant_islands"
         )
     )
     IslandsDataDefinition(
@@ -545,7 +545,7 @@ init -20 python in mas_island_event:
             x=484,
             y=54,
             z=220,
-            on_click=True
+            on_click="mas_island_distant_islands"
         )
     )
 
@@ -618,7 +618,7 @@ init -20 python in mas_island_event:
             x=213,
             y=0,
             z=1,
-            on_click=True
+            on_click="mas_island_bloodfall"
         )
     )
     IslandsDataDefinition(
@@ -696,7 +696,7 @@ init -20 python in mas_island_event:
             x=123,
             y=17,
             z=1,
-            on_click=True
+            on_click="mas_island_gravestones"
         )
     )
     IslandsDataDefinition(
@@ -707,7 +707,7 @@ init -20 python in mas_island_event:
             x=253,
             y=63,
             z=2,
-            on_click=True
+            on_click="mas_island_pumpkins"
         )
     )
     IslandsDataDefinition(
@@ -718,7 +718,7 @@ init -20 python in mas_island_event:
             x=178,
             y=59,
             z=15,
-            on_click=True
+            on_click="mas_island_pumpkins"
         )
     )
     IslandsDataDefinition(
@@ -740,7 +740,7 @@ init -20 python in mas_island_event:
             x=187,
             y=-99,
             z=5,
-            on_click=True
+            # on_click=True
         )
     )
 
@@ -2172,6 +2172,9 @@ label mas_islands(
 
 
 label mas_island_upsidedownisland:
+    if persistent._mas_o31_in_o31_mode and random.random() < 0.3:
+        jump mas_island_spooky_ambience
+
     m "Oh, that."
     m "I guess you're wondering why that island is upside down, right?"
     m "Well...I was about to fix it until I took another good look at it."
@@ -2525,6 +2528,54 @@ label mas_island_bookshelf2:
         m "Maybe I should add a table underneath the Cherry Blossom tree."
         m "It'd be nice to enjoy a cup of coffee with some snacks to go alongside my book reading."
         m "That'd be wonderful~"
+
+    return
+
+label mas_island_distant_islands:
+    if persistent._mas_o31_in_o31_mode:
+        jump mas_island_spooky_ambience
+
+    return
+
+label mas_island_spooky_ambience:
+    m "{i}It was a dark and stormy night...{/i}"
+    m "Ehehe~ This is the perfect time of year for spooky stories, isn't it?"
+    m "If you're in the mood, we should enjoy some together."
+    m "Although, I don't mind just enjoying the ambience with you for now."
+
+    return
+
+label mas_island_bloodfall:
+    m "I'm pretty proud of the waterfall there. It was already looking pretty surreal being upside-down."
+    m "All I really had to do was change the value of the water to #641F21, and..."
+    $ _history_list.pop()
+    m "Wait, I don't want to ruin the magic for you!{w=0.2} Forget I said that, please!"
+
+    return
+
+label mas_island_pumpkins:
+    m "There's nothing that reminds me of Halloween quite as much as pumpkins."
+    m "I thought it would be so cozy to have a bunch of them around my reading nook."
+    m "It's a bit chilly in the rain, but don't you think it would be nice to put on some sweaters and snuggle up together?"
+    m "Maybe I could make some flavored coffee to enhance the mood even more."
+
+    return
+
+label mas_island_gravestones:
+    if mas_safeToRefDokis():
+        m "Ehehe...I'm not sure if those decorations are entirely tasteful."
+        m "I was thinking, though...{w=0.2}Halloween is a time when some cultures honor the dead."
+        m "Sure, there are a lot of spooky stories about the dead rising, or ghosts haunting people..."
+        m "But there's a side of this holiday about remembering, isn't there?"
+        m "I suppose I just thought I shouldn't leave them out."
+
+    else:
+        m "What?"
+        m "...{w=0.2}What tombstones? {w-0.2}I'm not sure what you're talking about."
+        m "Are you...{w=0.2}pfff--"
+        m "Ahaha!"
+        m "Sorry, I couldn't resist."
+        m "It would be pretty spooky if those three were still haunting our happy ending, wouldn't it?"
 
     return
 

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -684,7 +684,7 @@ init -25 python in mas_island_event:
     MAX_PROGRESS_LOVE = 9
     PROGRESS_FACTOR = 4
 
-    SHIMEJI_CHANCE = 100
+    SHIMEJI_CHANCE = 0.01
     DEF_SCREEN_ZORDER = 55
 
     SUPPORTED_FILTERS = frozenset(
@@ -1365,22 +1365,23 @@ init -25 python in mas_island_event:
             # Reset offsets and zoom
             disp.reset_mouse_pos()
             disp.zoom = disp.min_zoom
+            # Return it for convenience
+            return disp
 
         # Progress lvl
         if check_progression:
             advance_progression()
 
-        sub_displayables = list()
-
         # Add all unlocked islands
-        for key, disp in island_disp_map.iteritems():
-            if _is_unlocked(key):
-                _reset_parallax_disp(disp)
-                sub_displayables.append(disp)
+        sub_displayables = [
+            _reset_parallax_disp(disp)
+            for key, disp in island_disp_map.iteritems()
+            if _is_unlocked(key)
+        ]
 
         # Add all unlocked decals for islands 1 (other islands don't have any as of now)
         island_disp_map["island_1"].add_decals(
-            *[
+            *(
                 decal_disp_map[key]
                 for key in (
                     "decal_bookshelf",
@@ -1390,13 +1391,13 @@ init -25 python in mas_island_event:
                     "decal_glitch"
                 )
                 if _is_unlocked(key)
-            ]
+            )
         )
 
-        if _is_unlocked("obj_shimeji") and renpy.random.randint(1, SHIMEJI_CHANCE) == 1:
+        if _is_unlocked("obj_shimeji") and random.random() <= SHIMEJI_CHANCE:
             shimeji_disp = obj_disp_map["obj_shimeji"]
             _reset_parallax_disp(shimeji_disp)
-            SHIMEJI_CHANCE *= 2
+            SHIMEJI_CHANCE /= 2.0
             sub_displayables.append(shimeji_disp)
 
         # Add the bg (we only have one as of now)

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -112,22 +112,11 @@ image living_room_night_rain = mas_island_event._get_room_sprite("n_r", False)
 image living_room_night_overcast = "living_room_night_rain"
 image living_room_night_snow = mas_island_event._get_room_sprite("n_s", False)
 # Sunset images
-image living_room_ss = MASFilteredSprite(
-    store.mas_sprites.FLT_SUNSET,
-    renpy.displayable("living_room_day")
-)
-image living_room_ss_rain = MASFilteredSprite(
-    store.mas_sprites.FLT_SUNSET,
-    renpy.displayable("living_room_day_rain")
-)
-image living_room_ss_overcast = MASFilteredSprite(
-    store.mas_sprites.FLT_SUNSET,
-    renpy.displayable("living_room_day_overcast")
-)
-image living_room_ss_snow = MASFilteredSprite(
-    store.mas_sprites.FLT_SUNSET,
-    renpy.displayable("living_room_day_snow")
-)
+image living_room_ss = mas_island_event._apply_flt_on_room_sprite("living_room_day", mas_sprites.FLT_SUNSET)
+image living_room_ss_rain = mas_island_event._apply_flt_on_room_sprite("living_room_day_rain", mas_sprites.FLT_SUNSET)
+image living_room_ss_overcast = mas_island_event._apply_flt_on_room_sprite("living_room_day_overcast", mas_sprites.FLT_SUNSET)
+image living_room_ss_snow = mas_island_event._apply_flt_on_room_sprite("living_room_day_snow", mas_sprites.FLT_SUNSET)
+
 
 ## Lit room
 # Day images
@@ -1120,6 +1109,26 @@ init -25 python in mas_island_event:
 
         except KeyError:
             return NULL_DISP
+
+    def _apply_flt_on_room_sprite(room_img_tag, flt):
+        """
+        Returns the room image with the filter applied on it
+
+        IN:
+            room_img_tag - str - the image tag
+            flt - str - the filter id to use
+
+        OUT:
+            image manipulator
+            or Null displayable if we failed to decode the images
+        """
+        if not store.mas_decoded_islands:
+            return NULL_DISP
+
+        return store.MASFilteredSprite(
+            flt,
+            renpy.displayable(room_img_tag)
+        )
 
     def _is_unlocked(id_):
         """

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -56,6 +56,35 @@ init 1:
             return mas_decoded_islands and mas_island_event.isFilterSupported(flt)
 
 
+# A bunch of transforms we use for the final islands event
+transform mas_islands_final_reveal_trans_1(delay, move_time):
+    zoom 3.2
+    align (0.45, 0.0)
+
+    pause delay
+    linear move_time align (0.9, 0.0)
+
+transform mas_islands_final_reveal_trans_2(delay, move_time):
+    zoom 2.5
+    align (0.15, 0.5)
+
+    pause delay
+    linear move_time align (0.0, 0.2) zoom 1.9
+
+transform mas_islands_final_reveal_trans_3(delay, move_time, zoom_time):
+    zoom 3.0
+    align (1.0, 0.2)
+
+    pause delay
+    linear move_time align (0.7, 0.6)
+    linear zoom_time zoom 1.0
+
+transform mas_islands_final_reveal_trans_4(delay, zoom_time):
+    align (0.62, 0.55)
+    pause delay
+    linear zoom_time zoom 10.0
+
+
 # Transform for weather overlays
 transform mas_islands_weather_overlay_transform(speed=1.0, img_width=1500, img_height=2000):
     animation

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -647,6 +647,8 @@ init -25 python in mas_island_event:
         }
     )
 
+    LIVING_ROOM_NAME = "living_room"
+
     # These're being populated later once we decode the imgs
     island_disp_map = dict()
     decal_disp_map = dict()
@@ -933,6 +935,24 @@ init -25 python in mas_island_event:
         # Build the interior
         for name, img_map in interior_imgs_map.iteritems():
             interior_disp_map[name] = img_map
+
+        # HACK: add custom tablechair into the cache right here
+        # That's because our images are not on the disk, we can't just use a sprite tag
+        # because the paths are hardcoded and we can't use a displayable directly
+        tablechair_disp_cache = mas_sprites.CACHE_TABLE[mas_sprites.CID_TC]
+        table_im = mas_sprites._gen_im(
+            FLT_LR_NIGHT,
+            interior_disp_map["interior_tablechair"]["table"]
+        )
+        tablechair_disp_cache[(FLT_LR_NIGHT, 0, LIVING_ROOM_NAME, 0)] = table_im
+        tablechair_disp_cache[(FLT_LR_NIGHT, 0, LIVING_ROOM_NAME, 1)] = table_im# shadow variant can reuse the same img
+        tablechair_disp_cache[(FLT_LR_NIGHT, 1, LIVING_ROOM_NAME)] = mas_sprites._gen_im(
+            FLT_LR_NIGHT,
+            interior_disp_map["interior_tablechair"]["chair"]
+        )
+        # Shadow is being stored in the highlight cache
+        table_shadow_hl_disp_cache = mas_sprites.CACHE_TABLE[mas_sprites.CID_HL]
+        table_shadow_hl_disp_cache[(mas_sprites.CID_TC, FLT_LR_NIGHT, 0, LIVING_ROOM_NAME, 1)] = interior_disp_map["interior_tablechair"]["shadow"]
 
         # Build glitch disp
         def _glitch_transform_func(transform, st, at):

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -12,7 +12,7 @@ default persistent._mas_islands_progress = store.mas_island_event.DEF_PROGRESS
 # Most of the progression is linear, but some things are unlocked at random
 # that's so every player gets a bit different progression.
 # Bear in mind, if you decide to add a new item, you'll need an update script
-default persistent._mas_islands_unlocks = store.mas_island_event.IslandsImageDefinition.getDefaultUnlocks()
+default persistent._mas_islands_unlocks = store.mas_island_event.IslandsDataDefinition.getDefaultUnlocks()
 
 # Will be loaded later
 init python in audio:
@@ -170,7 +170,7 @@ image living_room_lit_ss_snow = "living_room_ss_snow"
 
 # # # Image defination
 init -20 python in mas_island_event:
-    class IslandsImageDefinition(object):
+    class IslandsDataDefinition(object):
         """
         A generalised abstraction around raw data for the islands sprites
         """
@@ -314,7 +314,7 @@ init -20 python in mas_island_event:
             Returns data for an id
 
             OUT:
-                IslandsImageDefinition
+                IslandsDataDefinition
             """
             return cls._data_map[id_]
 
@@ -451,7 +451,7 @@ init -20 python in mas_island_event:
     # during composite image building
     # NOTE: Use functools.partial instead of renpy.partial because the latter has an argument conflict. Smh Tom
     # Islands
-    IslandsImageDefinition(
+    IslandsDataDefinition(
         "island_0",
         default_unlocked=True,
         partial_disp=functools.partial(
@@ -462,7 +462,7 @@ init -20 python in mas_island_event:
             on_click=True
         )
     )
-    IslandsImageDefinition(
+    IslandsDataDefinition(
         "island_1",
         partial_disp=functools.partial(
             ParallaxSprite,
@@ -473,7 +473,7 @@ init -20 python in mas_island_event:
             on_click=True
         )
     )
-    IslandsImageDefinition(
+    IslandsDataDefinition(
         "island_2",
         partial_disp=functools.partial(
             ParallaxSprite,
@@ -484,7 +484,7 @@ init -20 python in mas_island_event:
             on_click=True
         )
     )
-    IslandsImageDefinition(
+    IslandsDataDefinition(
         "island_3",
         partial_disp=functools.partial(
             ParallaxSprite,
@@ -495,7 +495,7 @@ init -20 python in mas_island_event:
             on_click=True
         )
     )
-    IslandsImageDefinition(
+    IslandsDataDefinition(
         "island_4",
         partial_disp=functools.partial(
             ParallaxSprite,
@@ -505,7 +505,7 @@ init -20 python in mas_island_event:
             on_click="mas_island_upsidedownisland"
         )
     )
-    IslandsImageDefinition(
+    IslandsDataDefinition(
         "island_5",
         partial_disp=functools.partial(
             ParallaxSprite,
@@ -516,7 +516,7 @@ init -20 python in mas_island_event:
             on_click=True
         )
     )
-    IslandsImageDefinition(
+    IslandsDataDefinition(
         "island_6",
         partial_disp=functools.partial(
             ParallaxSprite,
@@ -527,7 +527,7 @@ init -20 python in mas_island_event:
             on_click=True
         )
     )
-    IslandsImageDefinition(
+    IslandsDataDefinition(
         "island_7",
         partial_disp=functools.partial(
             ParallaxSprite,
@@ -538,7 +538,7 @@ init -20 python in mas_island_event:
             on_click=True
         )
     )
-    IslandsImageDefinition(
+    IslandsDataDefinition(
         "island_8",
         partial_disp=functools.partial(
             ParallaxSprite,
@@ -549,7 +549,7 @@ init -20 python in mas_island_event:
         )
     )
     # Decals
-    IslandsImageDefinition(
+    IslandsDataDefinition(
         "decal_bookshelf",
         partial_disp=functools.partial(
             ParallaxDecal,
@@ -559,7 +559,7 @@ init -20 python in mas_island_event:
             on_click="mas_island_bookshelf"
         )
     )
-    IslandsImageDefinition(
+    IslandsDataDefinition(
         "decal_bushes",
         partial_disp=functools.partial(
             ParallaxDecal,
@@ -569,7 +569,7 @@ init -20 python in mas_island_event:
             on_click=True
         )
     )
-    IslandsImageDefinition(
+    IslandsDataDefinition(
         "decal_house",
         partial_disp=functools.partial(
             ParallaxDecal,
@@ -578,7 +578,7 @@ init -20 python in mas_island_event:
             z=1
         )
     )
-    IslandsImageDefinition(
+    IslandsDataDefinition(
         "decal_tree",
         partial_disp=functools.partial(
             ParallaxDecal,
@@ -597,7 +597,7 @@ init -20 python in mas_island_event:
         "other/glitch/frame_5",
         "other/glitch/frame_6"
     )
-    IslandsImageDefinition(
+    IslandsDataDefinition(
         "decal_glitch",
         fp_map={},# TODO: move GLITCH_FPS to fp_map
         partial_disp=functools.partial(
@@ -609,7 +609,7 @@ init -20 python in mas_island_event:
         )
     )
     # Objects
-    IslandsImageDefinition(
+    IslandsDataDefinition(
         "other_shimeji",
         fp_map={},
         partial_disp=functools.partial(
@@ -622,25 +622,25 @@ init -20 python in mas_island_event:
             on_click="mas_island_shimeji"
         )
     )
-    IslandsImageDefinition(
+    IslandsDataDefinition(
         "other_isly",
         filenames=("clear", "rain", "snow")
     )
     # Interior
-    IslandsImageDefinition(
+    IslandsDataDefinition(
         "interior_room",
         filenames=("d", "d_r", "d_s", "n", "n_r", "n_s")
     )
-    IslandsImageDefinition(
+    IslandsDataDefinition(
         "interior_room_lit",
         filenames=("d", "d_r", "d_s", "n", "n_r", "n_s")
     )
-    IslandsImageDefinition(
+    IslandsDataDefinition(
         "interior_tablechair",
         filenames=("chair", "shadow", "table")
     )
     # BGs
-    IslandsImageDefinition(
+    IslandsDataDefinition(
         "bg_def",
         default_unlocked=True,
         partial_disp=functools.partial(
@@ -654,7 +654,7 @@ init -20 python in mas_island_event:
         )
     )
     # Overlays
-    IslandsImageDefinition(
+    IslandsDataDefinition(
         "overlay_rain",
         default_unlocked=True,
         partial_disp=functools.partial(
@@ -662,7 +662,7 @@ init -20 python in mas_island_event:
             use_fb=True
         )
     )
-    IslandsImageDefinition(
+    IslandsDataDefinition(
         "overlay_snow",
         default_unlocked=True,
         partial_disp=functools.partial(
@@ -670,7 +670,7 @@ init -20 python in mas_island_event:
             use_fb=True
         )
     )
-    IslandsImageDefinition(
+    IslandsDataDefinition(
         "overlay_thunder",
         default_unlocked=True,
         fp_map={},
@@ -915,11 +915,11 @@ init -25 python in mas_island_event:
 
         try:
             with ZipFile(zip_data, "r") as zip_file:
-                island_map = IslandsImageDefinition.getFilepathsForType(IslandsImageDefinition.TYPE_ISLAND)
-                decal_map = IslandsImageDefinition.getFilepathsForType(IslandsImageDefinition.TYPE_DECAL)
-                bg_map = IslandsImageDefinition.getFilepathsForType(IslandsImageDefinition.TYPE_BG)
-                overlay_map = IslandsImageDefinition.getFilepathsForType(IslandsImageDefinition.TYPE_OVERLAY)
-                interior_map = IslandsImageDefinition.getFilepathsForType(IslandsImageDefinition.TYPE_INTERIOR)
+                island_map = IslandsDataDefinition.getFilepathsForType(IslandsDataDefinition.TYPE_ISLAND)
+                decal_map = IslandsDataDefinition.getFilepathsForType(IslandsDataDefinition.TYPE_DECAL)
+                bg_map = IslandsDataDefinition.getFilepathsForType(IslandsDataDefinition.TYPE_BG)
+                overlay_map = IslandsDataDefinition.getFilepathsForType(IslandsDataDefinition.TYPE_OVERLAY)
+                interior_map = IslandsDataDefinition.getFilepathsForType(IslandsDataDefinition.TYPE_INTERIOR)
                 # Now override maps to contain imgs instead of img paths
                 for map_ in (island_map, decal_map, bg_map, overlay_map, interior_map):
                     _read_zip(zip_file, map_)
@@ -930,7 +930,7 @@ init -25 python in mas_island_event:
                 )
 
                 # Audio is being loaded right away
-                isly_data = IslandsImageDefinition.getDataFor("other_isly")
+                isly_data = IslandsDataDefinition.getDataFor("other_isly")
                 for fn, fp in isly_data.fp_map.iteritems():
                     audio_data = store.MASAudioData(zip_file.read(fp), fp + ".ogg")
                     setattr(store.audio, "isld_isly_" + fn, audio_data)
@@ -998,7 +998,7 @@ init -25 python in mas_island_event:
                     }
                 )
             )
-            partial_disp = IslandsImageDefinition.getDataFor(island_name).partial_disp
+            partial_disp = IslandsDataDefinition.getDataFor(island_name).partial_disp
             island_disp_map[island_name] = partial_disp(disp)
 
         # Build the decals
@@ -1029,7 +1029,7 @@ init -25 python in mas_island_event:
                     }
                 )
             )
-            partial_disp = IslandsImageDefinition.getDataFor(decal_name).partial_disp
+            partial_disp = IslandsDataDefinition.getDataFor(decal_name).partial_disp
             decal_disp_map[decal_name] = partial_disp(disp)
 
         # Build the bg
@@ -1060,7 +1060,7 @@ init -25 python in mas_island_event:
                     }
                 )
             )
-            partial_disp = IslandsImageDefinition.getDataFor(bg_name).partial_disp
+            partial_disp = IslandsDataDefinition.getDataFor(bg_name).partial_disp
             bg_disp_map[bg_name] = partial_disp(disp)
 
         # Build the overlays
@@ -1070,7 +1070,7 @@ init -25 python in mas_island_event:
         }
         for overlay_name, img_map in overlay_imgs_maps.iteritems():
             # Overlays are just dynamic displayables
-            partial_disp = IslandsImageDefinition.getDataFor(overlay_name).partial_disp
+            partial_disp = IslandsDataDefinition.getDataFor(overlay_name).partial_disp
             overlay_disp_map[overlay_name] = store.mas_islands_weather_overlay_transform(
                 child=partial_disp(
                     day=MASWeatherMap(
@@ -1128,15 +1128,15 @@ init -25 python in mas_island_event:
             return redraw
 
         glitch_disp = Transform(child=glitch_frames[0], function=_glitch_transform_func)
-        partial_disp = IslandsImageDefinition.getDataFor("decal_glitch").partial_disp
+        partial_disp = IslandsDataDefinition.getDataFor("decal_glitch").partial_disp
         decal_disp_map["decal_glitch"] = partial_disp(glitch_disp)
 
         # Build chibi disp
-        partial_disp = IslandsImageDefinition.getDataFor("other_shimeji").partial_disp
+        partial_disp = IslandsDataDefinition.getDataFor("other_shimeji").partial_disp
         other_disp_map["other_shimeji"] = partial_disp()
 
         # Build thunder overlay
-        partial_disp = IslandsImageDefinition.getDataFor("overlay_thunder").partial_disp
+        partial_disp = IslandsDataDefinition.getDataFor("overlay_thunder").partial_disp
         overlay_disp_map["overlay_thunder"] = partial_disp()
 
         return
@@ -1425,7 +1425,7 @@ init -25 python in mas_island_event:
         """
         persistent._mas_islands_start_lvl = None
         persistent._mas_islands_progress = DEF_PROGRESS
-        persistent._mas_islands_unlocks = IslandsImageDefinition.getDefaultUnlocks()
+        persistent._mas_islands_unlocks = IslandsDataDefinition.getDefaultUnlocks()
 
     def play_music():
         """

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -621,22 +621,22 @@ init -20 python in mas_island_event:
     )
     IslandsDataDefinition(
         "decal_ghost_0",
-        filenames=("d",),
+        filenames=("d", "n"),
         partial_disp=functools.partial(
             ParallaxDecal,
-            x=355,
-            y=-70,
+            x=366,
+            y=-48,
             z=5,
             on_click=True
         )
     )
     IslandsDataDefinition(
         "decal_ghost_1",
-        filenames=("d",),
+        filenames=("d", "n"),
         partial_disp=functools.partial(
             ParallaxDecal,
-            x=355,
-            y=-70,
+            x=366,
+            y=-48,
             z=5,
             on_click=True
         )
@@ -646,8 +646,8 @@ init -20 python in mas_island_event:
         filenames=("d", "n"),
         partial_disp=functools.partial(
             ParallaxDecal,
-            x=355,
-            y=-70,
+            x=366,
+            y=-48,
             z=5,
             on_click=True
         )
@@ -657,8 +657,8 @@ init -20 python in mas_island_event:
         filenames=("d", "n"),
         partial_disp=functools.partial(
             ParallaxDecal,
-            x=125,
-            y=15,
+            x=123,
+            y=17,
             z=1,
             on_click=True
         )
@@ -679,8 +679,8 @@ init -20 python in mas_island_event:
         filenames=("d", "n"),
         partial_disp=functools.partial(
             ParallaxDecal,
-            x=176,
-            y=61,
+            x=178,
+            y=59,
             z=15,
             on_click=True
         )
@@ -690,15 +690,15 @@ init -20 python in mas_island_event:
         filenames=("d", "n"),
         partial_disp=functools.partial(
             ParallaxDecal,
-            x=100,
-            y=0,
+            x=120,
+            y=-10,
             z=1,
             on_click=True
         )
     )
     IslandsDataDefinition(
         "decal_webs",
-        filenames=("d",),
+        filenames=("d", "n"),
         partial_disp=functools.partial(
             ParallaxDecal,
             x=187,

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -2538,14 +2538,14 @@ label mas_island_distant_islands:
 label mas_island_spooky_ambience:
     m "{i}It was a dark and stormy night...{/i}"
     m "Ehehe~ This is the perfect time of year for spooky stories, isn't it?"
-    m "If you're in the mood, we should enjoy some together."
+    m "If you're in the mood, we should read some together."
     m "Although, I don't mind just enjoying the ambience with you for now."
 
     return
 
 label mas_island_bloodfall:
-    m "I'm pretty proud of the waterfall there. It was already looking pretty surreal being upside-down."
-    m "All I really had to do was change the value of the water to #641F21, and..."
+    m "I'm pretty proud of that waterfall there. It was already looking pretty surreal being upside-down."
+    m "All I really had to do was change the value of the water to #641F21, and--{nw}"
     $ _history_list.pop()
     m "Wait, I don't want to ruin the magic for you!{w=0.2} Forget I said that, please!"
 
@@ -2565,12 +2565,12 @@ label mas_island_gravestones:
         m "I was thinking, though...{w=0.2}Halloween is a time when some cultures honor the dead."
         m "Sure, there are a lot of spooky stories about the dead rising, or ghosts haunting people..."
         m "But there's a side of this holiday about remembering, isn't there?"
-        m "I suppose I just thought I shouldn't leave them out."
+        m "I guess I just thought I shouldn't leave them out."
 
     else:
         m "What?"
         m "...{w=0.2}What tombstones? {w-0.2}I'm not sure what you're talking about."
-        m "Are you...{w=0.2}pfff--"
+        m "Are you...{w=0.2}pfft--"
         m "Ahaha!"
         m "Sorry, I couldn't resist."
         m "It would be pretty spooky if those three were still haunting our happy ending, wouldn't it?"

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -1036,7 +1036,7 @@ init -25 python in mas_island_event:
 
     def _get_room_sprite(key, is_lit):
         """
-        Returns an appropriate displayable for the room sprite based on the criteria
+        Returns the appropriate displayable for the room sprite based on the criteria
 
         IN:
             key - str - the sprite key
@@ -1053,7 +1053,7 @@ init -25 python in mas_island_event:
         except KeyError:
             return NULL_DISP
 
-    def _isUnlocked(id_):
+    def _is_unlocked(id_):
         """
         Checks if a sprite is unlocked
 
@@ -1098,7 +1098,7 @@ init -25 python in mas_island_event:
         return False
 
 
-    # # # START functions for lvl unlocks, head to __handleUnlocks to understand how this works
+    # # # START functions for lvl unlocks, head to __handle_unlocks to understand how this works
     # NOTE: Please, keep these private
     def __unlocks_for_lvl_0():
         _unlock("island_1")
@@ -1114,8 +1114,8 @@ init -25 python in mas_island_event:
     def __unlocks_for_lvl_3():
         # Unlock only one, the rest at lvl 5
         if (
-            not _isUnlocked("island_4")
-            and not _isUnlocked("island_5")
+            not _is_unlocked("island_4")
+            and not _is_unlocked("island_5")
         ):
             if bool(random.randint(0, 1)):
                 _unlock("island_4")
@@ -1126,8 +1126,8 @@ init -25 python in mas_island_event:
     def __unlocks_for_lvl_4():
         # Unlock only one, the rest at lvl 6
         if (
-            not _isUnlocked("island_6")
-            and not _isUnlocked("island_7")
+            not _is_unlocked("island_6")
+            and not _is_unlocked("island_7")
         ):
             if bool(random.randint(0, 1)):
                 _unlock("island_6")
@@ -1145,8 +1145,8 @@ init -25 python in mas_island_event:
         _unlock("island_3")
         # Unlock only one, the rest at lvl 7
         if (
-            not _isUnlocked("decal_bookshelf")
-            and not _isUnlocked("decal_tree")
+            not _is_unlocked("decal_bookshelf")
+            and not _is_unlocked("decal_tree")
         ):
             if bool(random.randint(0, 1)):
                 _unlock("decal_bookshelf")
@@ -1170,7 +1170,7 @@ init -25 python in mas_island_event:
     # # # END
 
 
-    def __handleUnlocks():
+    def __handle_unlocks():
         """
         Method to unlock various islands features when the player progresses.
         For example: new decals, new islands, new extra events, set persistent vars, etc.
@@ -1182,7 +1182,7 @@ init -25 python in mas_island_event:
             if callback is not None:
                 callback()
 
-    def _calcProgress(curr_lvl, start_lvl):
+    def _calc_progress(curr_lvl, start_lvl):
         """
         Returns islands progress for the given current and start levels
         NOTE: this has no sanity checks, don't use this directly
@@ -1223,7 +1223,7 @@ init -25 python in mas_island_event:
 
         return progress
 
-    def advanceProgression():
+    def advance_progression():
         """
         Increments the lvl of progression of the islands event,
         it will do nothing if the player hasn't unlocked the islands yet or if
@@ -1233,7 +1233,7 @@ init -25 python in mas_island_event:
         if persistent._mas_islands_start_lvl is None:
             return
 
-        new_progress = _calcProgress(store.mas_xp.level(), persistent._mas_islands_start_lvl)
+        new_progress = _calc_progress(store.mas_xp.level(), persistent._mas_islands_start_lvl)
 
         if new_progress == DEF_PROGRESS:
             return
@@ -1256,25 +1256,25 @@ init -25 python in mas_island_event:
         # Now set new level
         persistent._mas_islands_progress = min(max(new_progress, curr_progress), MAX_PROGRESS_LOVE)
         # Run unlock callbacks
-        __handleUnlocks()
+        __handle_unlocks()
 
         return
 
-    def getProgression():
+    def _get_progression():
         """
         Returns current islands progress lvl
         """
         return persistent._mas_islands_progress
 
-    def startProgression():
+    def start_progression():
         """
         Starts islands progression
         """
         if store.mas_isMoniEnamored(higher=True) and persistent._mas_islands_start_lvl is None:
             persistent._mas_islands_start_lvl = store.mas_xp.level()
-            advanceProgression()
+            advance_progression()
 
-    def _resetProgression():
+    def _reset_progression():
         """
         Resets island progress
         """
@@ -1282,7 +1282,7 @@ init -25 python in mas_island_event:
         persistent._mas_islands_progress = DEF_PROGRESS
         persistent._mas_islands_unlocks = IslandsImageDefinition.getDefaultUnlocks()
 
-    def getIslandsDisplayable(enable_interaction=True, check_progression=False):
+    def get_islands_displayable(enable_interaction=True, check_progression=False):
         """
         Builds an image for islands and returns it
         NOTE: This is temporary until we split islands into foreground/background
@@ -1311,13 +1311,13 @@ init -25 python in mas_island_event:
 
         # Progress lvl
         if check_progression:
-            advanceProgression()
+            advance_progression()
 
         sub_displayables = list()
 
         # Add all unlocked islands
         for key, disp in island_disp_map.iteritems():
-            if _isUnlocked(key):
+            if _is_unlocked(key):
                 _reset_parallax_disp(disp)
                 sub_displayables.append(disp)
 
@@ -1332,11 +1332,11 @@ init -25 python in mas_island_event:
                     "decal_tree",
                     "decal_glitch"
                 )
-                if _isUnlocked(key)
+                if _is_unlocked(key)
             ]
         )
 
-        if _isUnlocked("obj_shimeji") and renpy.random.randint(1, SHIMEJI_CHANCE) == 1:
+        if _is_unlocked("obj_shimeji") and renpy.random.randint(1, SHIMEJI_CHANCE) == 1:
             shimeji_disp = obj_disp_map["obj_shimeji"]
             _reset_parallax_disp(shimeji_disp)
             SHIMEJI_CHANCE *= 2
@@ -1361,7 +1361,7 @@ init -25 python in mas_island_event:
 
         return ParallaxBackground(*sub_displayables)
 
-    def isWinterWeather():
+    def is_winter_weather():
         """
         Checks if the weather on the islands is wintery
 
@@ -1372,7 +1372,7 @@ init -25 python in mas_island_event:
         """
         return store.mas_is_snowing or store.mas_isWinter()
 
-    def isCloudyWeather():
+    def is_cloudy_weather():
         """
         Checks if the weather on the islands is cloudy
 
@@ -1590,7 +1590,7 @@ label mas_islands(
         # Always scene change unless asked not to
         spaceroom_kwargs.setdefault("scene_change", True)
         is_done = False
-        islands_displayable = mas_island_event.getIslandsDisplayable(
+        islands_displayable = mas_island_event.get_islands_displayable(
             enable_interaction=enable_interaction,
             check_progression=check_progression
         )
@@ -1682,7 +1682,7 @@ label mas_island_cherry_blossom_tree:
                 "mas_island_cherry_blossom4"
             ]
 
-            if not mas_island_event.isWinterWeather():
+            if not mas_island_event.is_winter_weather():
                 _mas_cherry_blossom_events.append("mas_island_cherry_blossom2")
 
             renpy.call(renpy.random.choice(_mas_cherry_blossom_events))
@@ -1690,7 +1690,7 @@ label mas_island_cherry_blossom_tree:
     return
 
 label mas_island_cherry_blossom1:
-    if mas_island_event.isWinterWeather():
+    if mas_island_event.is_winter_weather():
         m "This tree may look dead right now...but when it blooms, it's gorgeous."
 
     else:
@@ -1702,7 +1702,7 @@ label mas_island_cherry_blossom1:
     m "I chose it because it's lovely and pleasing to look at."
     m "Just staring at the falling petals is awe-inspiring."
 
-    if mas_island_event.isWinterWeather():
+    if mas_island_event.is_winter_weather():
         m "When it's blooming, that is."
         m "I can't wait until we get the chance to experience that, [player]."
 
@@ -1719,7 +1719,7 @@ label mas_island_cherry_blossom3:
     m "Beautiful, but short-lived."
     m "But with you here, it's always blooming beautifully."
 
-    if mas_island_event.isWinterWeather():
+    if mas_island_event.is_winter_weather():
         m "Even if it's bare now, it'll blossom again soon."
 
     m "Know that I'll always be grateful to you for being in my life."
@@ -1734,7 +1734,7 @@ label mas_island_cherry_blossom4:
     m "Ahaha! I'm just kidding."
     m "I'd rather have tea or coffee."
 
-    if mas_island_event.isWinterWeather():
+    if mas_island_event.is_winter_weather():
         m "Or hot chocolate, even. It'd certainly help with the cold."
         m "Of course, even if that failed, we could always cuddle together...{w=0.5} That'd be really romantic~"
 
@@ -1771,7 +1771,7 @@ label mas_island_sky:
 label mas_island_day1:
     #NOTE: this ordering is key, during winter we only use snow covered islands with clear sky
     # so Winter path needs to be first
-    if mas_island_event.isWinterWeather():
+    if mas_island_event.is_winter_weather():
         m "What a beautiful day today."
         m "Perfect for taking a walk to admire the scenery."
         m "...Huddled together, so as to stave off the cold."
@@ -1791,7 +1791,7 @@ label mas_island_day1:
     else:
         m "It's a nice day today."
 
-        if mas_island_event._isUnlocked("decal_tree"):
+        if mas_island_event._is_unlocked("decal_tree"):
             m "This weather would be good for a little book reading under the Cherry Blossom tree right, [player]?"
 
         else:
@@ -1806,14 +1806,14 @@ label mas_island_day1:
 label mas_island_day2:
     #NOTE: this ordering is key, during winter we only use snow covered islands with clear sky
     # so Winter path needs to be first
-    if mas_island_event.isWinterWeather():
+    if mas_island_event.is_winter_weather():
         m "Have you ever made a snow angel, [player]?"
         m "I've tried in the past, but never had much success..."
         m "It's a lot harder than it looks like."
         m "I bet we'd have a lot of fun, even if whatever we make doesn't end up looking like an angel."
         m "It's just a matter of being a bit silly, you know?"
 
-    elif mas_island_event.isCloudyWeather():
+    elif mas_island_event.is_cloudy_weather():
         m "Going outdoors with this kind of weather doesn't look very appealing..."
         m "Maybe if I had an umbrella I'd feel more comfortable."
         m "Imagine both of us, shielded from the rain, inches apart."
@@ -1827,7 +1827,7 @@ label mas_island_day2:
         m "We even have a great view to accompany it with!"
         m "Wouldn't it be nice?"
 
-        if mas_island_event._isUnlocked("decal_tree"):
+        if mas_island_event._is_unlocked("decal_tree"):
             m "Eating under the Cherry Blossom tree."
 
         m "Adoring the scenery around us."
@@ -1845,7 +1845,7 @@ label mas_island_day3:
     else:
         m "It's pretty peaceful outside."
 
-        if mas_island_event.isWinterWeather():
+        if mas_island_event.is_winter_weather():
             m "We could have a snowball fight, you know."
             m "Ahaha, that'd be so much fun!"
             m "I bet I could land a shot on you a few islands away."
@@ -1865,7 +1865,7 @@ label mas_island_night1:
     return
 
 label mas_island_night2:
-    if not mas_isWinter() and mas_island_event.isCloudyWeather():
+    if not mas_isWinter() and mas_island_event.is_cloudy_weather():
         m "Too bad we can't see the stars tonight..."
         m "I would've loved to gaze at the cosmos with you."
         m "That's alright though, we'll get to see it some other time, then."
@@ -1889,7 +1889,7 @@ label mas_island_night2:
     return
 
 label mas_island_night3:
-    if not mas_isWinter() and mas_island_event.isCloudyWeather():
+    if not mas_isWinter() and mas_island_event.is_cloudy_weather():
         m "Cloudy weather is kind of depressing, don't you think?"
         m "Especially at nighttime, when it hides the stars away from our view."
         m "It's such a shame, really..."
@@ -1897,7 +1897,7 @@ label mas_island_night3:
     else:
         m "What a beautiful night!"
 
-        if mas_island_event.isWinterWeather():
+        if mas_island_event.is_winter_weather():
             m "There's just something about a cold, crisp night that I love."
             m "The contrast of the dark sky and the land covered in snow is really breathtaking, don't you think?"
         else:
@@ -1964,12 +1964,12 @@ label mas_island_bookshelf:
 label mas_island_bookshelf1:
     #NOTE: this ordering is key, during winter we only use snow covered islands with clear sky
     # so Winter path needs to be first
-    if mas_island_event.isWinterWeather():
+    if mas_island_event.is_winter_weather():
         m "That bookshelf might not look terribly sturdy, but I'm sure it can weather a little snow."
         m "It's the books that worry me a bit."
         m "I just hope they don't get too damaged..."
 
-    elif mas_island_event.isCloudyWeather():
+    elif mas_island_event.is_cloudy_weather():
         m "At times like this, I wish I would've kept my books indoors..."
         m "Looks like we'll just have to wait for better weather to read them."
         m "In the meantime..."
@@ -1986,14 +1986,14 @@ label mas_island_bookshelf1:
 label mas_island_bookshelf2:
     #NOTE: this ordering is key, during winter we only use snow covered islands with clear sky
     # so Winter path needs to be first
-    if mas_island_event.isWinterWeather():
+    if mas_island_event.is_winter_weather():
         m "You know, I wouldn't mind doing some reading outside even if there is a bit of snow."
         m "Though I wouldn't venture out without a warm coat, a thick scarf, and a snug pair of gloves."
         m "I guess turning the pages might be a bit hard that way, ahaha..."
         m "But I'm sure we'll manage somehow."
         m "Isn't that right, [player]?"
 
-    elif mas_island_event.isCloudyWeather():
+    elif mas_island_event.is_cloudy_weather():
         m "Reading indoors with rain just outside the window is pretty relaxing."
         m "If only I hadn't left the books outside..."
         m "I should probably bring some in here when I get the chance."

--- a/Monika After Story/game/script-songs.rpy
+++ b/Monika After Story/game/script-songs.rpy
@@ -2127,7 +2127,7 @@ label mas_monika_plays_yr(skip_leadin=False):
     call mas_timed_text_events_prep
 
     pause 2.0
-    $ play_song(store.songs.FP_YOURE_REAL,loop=False)
+    $ mas_play_song(store.songs.FP_YOURE_REAL,loop=False)
 
     # TODO: possibly generalize this for future use
     show monika 6hua
@@ -2234,7 +2234,7 @@ label mas_monika_plays_or(skip_leadin=False):
         $ disable_esc()
 
     pause 2.0
-    $ play_song(songs.FP_PIANO_COVER,loop=False)
+    $ mas_play_song(songs.FP_PIANO_COVER,loop=False)
 
     show monika 1dsa
     pause 9.15

--- a/Monika After Story/game/script-stories.rpy
+++ b/Monika After Story/game/script-stories.rpy
@@ -285,7 +285,7 @@ label mas_scary_story_setup:
     $ are_masks_changing = mas_current_weather != mas_weather_rain
     $ mas_is_raining = True
 
-    $ play_song(None, fadeout=1.0)
+    $ mas_play_song(None, fadeout=1.0)
     pause 1.0
 
     $ mas_temp_zoom_level = store.mas_sprites.zoom_level
@@ -342,7 +342,7 @@ label mas_scary_story_cleanup:
 
     call monika_zoom_transition(mas_temp_zoom_level,transition=1.0)
 
-    $ play_song(None, 1.0)
+    $ mas_play_song(None, 1.0)
     m 1eua "I hope you liked it, [player]~"
     $ mas_DropShield_core()
     $ HKBShowButtons()

--- a/Monika After Story/game/script-story-events.rpy
+++ b/Monika After Story/game/script-story-events.rpy
@@ -2610,8 +2610,8 @@ label mas_islands_reset:
 
             play sound "sfx/glitch3.ogg"
             python:
-                mas_island_event._resetProgression()
-                mas_island_event.startProgression()
+                mas_island_event._reset_progression()
+                mas_island_event.start_progression()
 
             m 3hua "And it's done!"
             m 1eua "Now I've got a fresh, new canvas."

--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -2393,11 +2393,11 @@ label monika_holdme_prep(lullaby=MAS_HOLDME_QUEUE_LULLABY_IF_NO_MUSIC, stop_musi
                 # The user has not started another track
                 and not renpy.music.is_playing(channel="music")
             ):
-                store.play_song(store.songs.FP_MONIKA_LULLABY, fadein=5.0)
+                store.mas_play_song(store.songs.FP_MONIKA_LULLABY, fadein=5.0)
 
         # Stop the music
         if stop_music:
-            play_song(None, fadeout=5.0)
+            mas_play_song(None, fadeout=5.0)
 
         # Queue the lullaby
         if lullaby == MAS_HOLDME_QUEUE_LULLABY_IF_NO_MUSIC:
@@ -2415,7 +2415,7 @@ label monika_holdme_prep(lullaby=MAS_HOLDME_QUEUE_LULLABY_IF_NO_MUSIC, stop_musi
 
         # Just play the lullaby
         elif lullaby == MAS_HOLDME_PLAY_LULLABY:
-            play_song(store.songs.FP_MONIKA_LULLABY)
+            mas_play_song(store.songs.FP_MONIKA_LULLABY)
 
         # Hide ui and disable hotkeys
         HKBHideButtons()
@@ -2671,7 +2671,7 @@ label monika_holdme_long:
         "{i}Wake Monika up.{/i}":
             # Only fadeout if we're playing the lullaby
             if songs.current_track == songs.FP_MONIKA_LULLABY:
-                $ play_song(None, fadeout=5.0)
+                $ mas_play_song(None, fadeout=5.0)
 
             if mas_isMoniLove():
                 m 6dubsa "...{w=1}Mmm~"
@@ -11581,7 +11581,7 @@ label monika_grad_speech_ignored_lock:
 label monika_grad_speech:
     call mas_timed_text_events_prep
 
-    $ play_song("mod_assets/bgm/PaC.ogg",loop=False)
+    $ mas_play_song("mod_assets/bgm/PaC.ogg",loop=False)
 
     m 2dsc "Ahem...{w=0.7}{nw}"
     m ".{w=0.3}.{w=0.3}.{w=0.6}{nw}"

--- a/Monika After Story/game/special-effects.rpy
+++ b/Monika After Story/game/special-effects.rpy
@@ -1293,7 +1293,7 @@ label mas_timed_text_events_prep:
 
         # store/stop current music and background/sounds
         curr_song = songs.current_track
-        play_song(None, 1.0)
+        mas_play_song(None, 1.0)
         amb_vol = songs.getVolume("backsound")
         renpy.music.set_volume(0.0, 1.0, "background")
         renpy.music.set_volume(0.0, 1.0, "backsound")
@@ -1313,9 +1313,9 @@ label mas_timed_text_events_wrapup:
 
         # restart song/sounds that were playing before event
         if globals().get("curr_song", -1) is not -1 and curr_song != store.songs.FP_MONIKA_LULLABY:
-            play_song(curr_song, 1.0)
+            mas_play_song(curr_song, 1.0)
         else:
-            play_song(None, 1.0)
+            mas_play_song(None, 1.0)
 
         renpy.music.set_volume(amb_vol, 1.0, "background")
         renpy.music.set_volume(amb_vol, 1.0, "backsound")

--- a/Monika After Story/game/sprite-chart-matrix.rpy
+++ b/Monika After Story/game/sprite-chart-matrix.rpy
@@ -1450,7 +1450,7 @@ init -4 python in mas_sprites:
         """
         img_key, cid, img_base, hl_base = render_key
         if cid == CID_DYNAMIC:
-            # add the img and hl directly 
+            # add the img and hl directly
             if img_base is not None:
                 render_list.append(img_base)
             if hl_base is not None:
@@ -1542,6 +1542,7 @@ init -4 python in mas_sprites:
 
         RETURNS: generated render key
         """
+        # TODO: consider wrapping img_base in renpy.displayable
         # NOTE: no render
         return store.im.MatrixColor(img_base, FILTERS[flt])
 

--- a/Monika After Story/game/sprite-chart-matrix.rpy
+++ b/Monika After Story/game/sprite-chart-matrix.rpy
@@ -664,7 +664,7 @@ init 1 python in mas_sprites:
         ord_memo = []
         curr_flt = _find_next_fb(flt, memo, ord_memo)
         while not mfwm.has_def(curr_flt):
-            nxt_flt = _find_nxt_fb(curr_flt, memo, ord_memo)
+            nxt_flt = _find_next_fb(curr_flt, memo, ord_memo)
 
             # if filter has not changed, we are done searching.
             if nxt_flt == curr_flt:

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -377,7 +377,10 @@ label v0_3_1(version=version): # 0.3.1
 # 0.12.11.1
 label v0_12_11_1(version="v0_12_11_1"):
     python hide:
-        pass
+        isld_p_data = persistent._mas_islands_unlocks
+        if isld_p_data is not None:
+            isld_p_data["other_shimeji"] = isld_p_data.pop("obj_shimeji", False)
+            isld_p_data["other_isly"] = False
 
     return
 

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -396,6 +396,8 @@ label v0_12_11_1(version="v0_12_11_1"):
             ):
                 isld_p_data[k] = False
 
+            isld_p_data["overlay_vignette"] = True
+
     return
 
 # 0.12.10

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -380,7 +380,21 @@ label v0_12_11_1(version="v0_12_11_1"):
         isld_p_data = persistent._mas_islands_unlocks
         if isld_p_data is not None:
             isld_p_data["other_shimeji"] = isld_p_data.pop("obj_shimeji", False)
-            isld_p_data["other_isly"] = False
+            # isld_p_data["other_isly"] = False
+
+            for k in ("decal_ghost_", "decal_haunted_tree_"):
+                for i in "012":
+                    isld_p_data[k + i] = False
+
+            for k in (
+                "decal_bloodfall",
+                "decal_gravestones",
+                "decal_jack",
+                "decal_pumpkins",
+                "decal_skull",
+                "decal_webs"
+            ):
+                isld_p_data[k] = False
 
     return
 

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -380,7 +380,6 @@ label v0_12_11_1(version="v0_12_11_1"):
         isld_p_data = persistent._mas_islands_unlocks
         if isld_p_data is not None:
             isld_p_data["other_shimeji"] = isld_p_data.pop("obj_shimeji", False)
-            # isld_p_data["other_isly"] = False
 
             for k in ("decal_ghost_", "decal_haunted_tree_"):
                 for i in "012":

--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -3238,11 +3238,11 @@ label mas_lupd_v0_12_3_1:
     python:
         # Unlock for people who has seen the event before
         if seen_event("mas_monika_islands"):
-            mas_island_event.startProgression()
+            mas_island_event.start_progression()
             # Technically it's impossible to have this as 0,
             # So it'll mean the islands were unlocked prior to the revamp
             persistent._mas_islands_start_lvl = 0
-            mas_island_event.advanceProgression()
+            mas_island_event.advance_progression()
 
     return
 

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -2774,7 +2774,7 @@ init -20 python in mas_background:
 
     def saveMBGData():
         """
-        Saves MASBackground data from weather map into persistent
+        Saves MASBackground data from bg map into persistent
         """
         for mbg_id, mbg_obj in BACKGROUND_MAP.iteritems():
             store.persistent._mas_background_MBGdata[mbg_id] = mbg_obj.toTuple()
@@ -2795,18 +2795,55 @@ init -20 python in mas_background:
 
         IN:
             min_amt_unlocked - minimum number of BGs which should be unlocked to return true
+
         OUT:
             True if we have at least min_amt_unlocked BGs unlocked, False otherwise
         """
-        unlocked_count = 0
-        for mbg_obj in BACKGROUND_MAP.itervalues():
-            unlocked_count += int(mbg_obj.unlocked)
+        return getUnlockedBGCount() >= min_amt_unlocked
 
-            #Now check if we've surpassed the minimum
-            if unlocked_count >= min_amt_unlocked:
-                return True
+    def getBackground(id_):
+        """
+        Returns a bg object
 
-        return False
+        IN:
+            id_ - str - background id
+
+        OUT:
+            background object
+            or None if not found
+        """
+        return BACKGROUND_MAP.get(id_)
+
+    def _toggleBackground(id_, value):
+        """
+        Locks/unlocks a bg
+
+        IN:
+            id_ - str - background id
+            value - bool - the value for the unlock field
+        """
+        bg_obj = getBackground(id_)
+        if bg_obj:
+            bg_obj.unlock = True
+            store.persistent._mas_background_MBGdata[id_] = bg_obj.toTuple()
+
+    def unlockBackground(id_):
+        """
+        Unlocks a bg
+
+        IN:
+            id_ - str - background id
+        """
+        _toggleBackground(id_, True)
+
+    def lockBackground(id_):
+        """
+        Locks a bg
+
+        IN:
+            id_ - str - background id
+        """
+        _toggleBackground(id_, False)
 
 
     def log_bg(bg_obj, exc_info=None):

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -2643,7 +2643,9 @@ init -10 python:
                         return
 
             if not img_found:
-                raise Exception("No images found for these filters")
+                raise Exception(
+                    "No images found for filters: {}".format(", ".join(flts))
+                )
 
 
 #Helper methods and such

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -2820,11 +2820,11 @@ init -20 python in mas_background:
 
         IN:
             id_ - str - background id
-            value - bool - the value for the unlock field
+            value - bool - the value for the unlocked field
         """
         bg_obj = getBackground(id_)
         if bg_obj:
-            bg_obj.unlock = True
+            bg_obj.unlocked = value
             store.persistent._mas_background_MBGdata[id_] = bg_obj.toTuple()
 
     def unlockBackground(id_):

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -2819,7 +2819,7 @@ init -20 python in mas_background:
         """
         return BACKGROUND_MAP.get(id_)
 
-    def _toggleBackground(id_, value):
+    def _toggleBackgroundUnlock(id_, value):
         """
         Locks/unlocks a bg
 
@@ -2839,7 +2839,7 @@ init -20 python in mas_background:
         IN:
             id_ - str - background id
         """
-        _toggleBackground(id_, True)
+        _toggleBackgroundUnlock(id_, True)
 
     def lockBackground(id_):
         """
@@ -2848,8 +2848,22 @@ init -20 python in mas_background:
         IN:
             id_ - str - background id
         """
-        _toggleBackground(id_, False)
+        _toggleBackgroundUnlock(id_, False)
 
+    def isBackgroundUnlocked(id_):
+        """
+        Checks if a background is unlocked
+
+        IN:
+            id_ - str - background id
+
+        OUT:
+            boolean
+        """
+        bg = getBackground(id_)
+        if bg:
+            return bg.unlocked
+        return False
 
     def log_bg(bg_obj, exc_info=None):
         """
@@ -2950,10 +2964,9 @@ init 800 python:
         """
         if (
             mas_isMoniEnamored(higher=True)
-            and persistent._mas_current_background in store.mas_background.BACKGROUND_MAP
-            and mas_getBackground(persistent._mas_current_background).unlocked
+            and mas_isBackgroundUnlocked(persistent._mas_current_background)
         ):
-            background_to_set = store.mas_background.BACKGROUND_MAP[persistent._mas_current_background]
+            background_to_set = mas_getBackground(persistent._mas_current_background)
             mas_changeBackground(background_to_set, startup=True)
 
             if background_to_set.disable_progressive:
@@ -2991,7 +3004,36 @@ init python:
         OUT:
             MASFilterableBackground if found, None otherwise
         """
-        return store.mas_background.BACKGROUND_MAP.get(background_id, default)
+        return mas_background.getBackground(background_id, default)
+
+    def mas_getCurrentBackgroundId(default=None):
+        """
+        Returns the id of the current background
+
+        IN:
+            default - the fallback value to return
+                (Default: None)
+
+        OUT:
+            string - the bg id
+            or default if not found
+        """
+        curr_bg = mas_current_background
+        if curr_bg:
+            return curr_bg.background_id
+        return default
+
+    def mas_isBackgroundUnlocked(id_):
+        """
+        Checks if a background with the given id is unlocked
+
+        IN:
+            id_ - str - the background id
+
+        OUT:
+            boolean
+        """
+        return mas_background.isBackgroundUnlocked(id_)
 
 #START: Programming points
 init -2 python in mas_background:

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -2644,7 +2644,10 @@ init -10 python:
 
             if not img_found:
                 raise Exception(
-                    "No images found for filters: {}".format(", ".join(flts))
+                    "In background '{}' no images found for filters: {}".format(
+                        self.background_id,
+                        ", ".join(flts)
+                    )
                 )
 
 

--- a/Monika After Story/game/zz_backgrounds.rpy
+++ b/Monika After Story/game/zz_backgrounds.rpy
@@ -3004,7 +3004,10 @@ init python:
         OUT:
             MASFilterableBackground if found, None otherwise
         """
-        return mas_background.getBackground(background_id, default)
+        bg = mas_background.getBackground(background_id)
+        if bg:
+            return bg
+        return default
 
     def mas_getCurrentBackgroundId(default=None):
         """

--- a/Monika After Story/game/zz_dockingstation.rpy
+++ b/Monika After Story/game/zz_dockingstation.rpy
@@ -24,7 +24,7 @@ init -900 python in mas_ics:
 
     # NOTE: these checksums are BEFORE b64 encoding
 
-    ISLAND_PKG_CHKSUM = "bd3f4859ce2c7014845700e7d949cc21dcb44d4feb986083f21e67f2d8317f85"
+    ISLAND_PKG_CHKSUM = "291e6b7b436e4a9910e6062bc5ef6170bd9d4268a2cda344e2f13b86be85df6e"
 
     #################################### O31 ##################################
     # cg folder

--- a/Monika After Story/game/zz_history.rpy
+++ b/Monika After Story/game/zz_history.rpy
@@ -1160,7 +1160,7 @@ init -810 python:
             "_mas_pm_a_hater": "pm.likes.monika.not",
             "_mas_pm_liked_grad_speech": "pm.likes.monika.grad_speech",
             "_mas_pm_cares_island_progress": "pm.likes.monika.island.progress",
-            "_mas_pm_likes_islands": "pm.likes.monika.island.result",
+            # "_mas_pm_likes_islands": "pm.likes.monika.island.result",
 
             # likes / music
             "_mas_pm_like_rap": "pm.likes.music.rap",

--- a/Monika After Story/game/zz_history.rpy
+++ b/Monika After Story/game/zz_history.rpy
@@ -1160,6 +1160,7 @@ init -810 python:
             "_mas_pm_a_hater": "pm.likes.monika.not",
             "_mas_pm_liked_grad_speech": "pm.likes.monika.grad_speech",
             "_mas_pm_cares_island_progress": "pm.likes.monika.island.progress",
+            "_mas_pm_likes_islands": "pm.likes.monika.island.result",
 
             # likes / music
             "_mas_pm_like_rap": "pm.likes.music.rap",

--- a/Monika After Story/game/zz_monikamovie.rpy
+++ b/Monika After Story/game/zz_monikamovie.rpy
@@ -285,7 +285,7 @@ label mas_monikamovie:
         $ watchingMovie = False
         $ timer.seconds = 0
         $ MovieOverlayHideButtons()
-        $ play_song(store.songs.selected_track)
+        $ mas_play_song(store.songs.selected_track)
         show monika 1esa
         jump ch30_loop
 

--- a/Monika After Story/game/zz_music_selector.rpy
+++ b/Monika After Story/game/zz_music_selector.rpy
@@ -1098,7 +1098,7 @@ init python:
         Meant for usage in startup processes.
         """
         if persistent.current_track is not None:
-            play_song(persistent.current_track, if_changed=True)
+            mas_play_song(persistent.current_track, if_changed=True)
 
 
     def select_music():
@@ -1115,7 +1115,7 @@ init python:
 
             # workaround to handle new context
             if selected_track != songs.current_track:
-                play_song(selected_track, set_per=True)
+                mas_play_song(selected_track, set_per=True)
 
             # unwanted interactions are no longer unwanted
             if store.mas_globals.dlg_workflow:

--- a/Monika After Story/game/zz_music_selector.rpy
+++ b/Monika After Story/game/zz_music_selector.rpy
@@ -1047,7 +1047,7 @@ init python:
             songs.setUserVolume(songs.music_volume, "music")
 
 
-    def play_song(song, fadein=0.0, loop=True, set_per=False, fadeout=0.0, if_changed=False):
+    def mas_play_song(song, fadein=0.0, loop=True, set_per=False, fadeout=0.0, if_changed=False):
         """
         literally just plays a song onto the music channel
         Also sets the currentt track
@@ -1087,6 +1087,9 @@ init python:
         if set_per:
             persistent.current_track = song
 
+    @mas_utils.deprecated(use_instead="mas_play_song")
+    def play_song(*args, **kwargs):
+        mas_play_song(*args, **kwargs)
 
     def mas_startup_song():
         """


### PR DESCRIPTION
### Additions:
- `MASAudioData` - isn't used as of now, but will be used later for the next wave of changes

### Changes:
- `play_song` is deprecated in favour of `mas_play_song`
- various internal functions (island-related) renamed to snake_case to be consistent with the rest of the funcs in the namespace
- backgrounds now properly report which images are missing for which filters
- cleanup of the background framework
- - new internal funcs
- - - `getBackground`
- - - `unlockBackground`
- - - `lockBackground`
- - - `isBackgroundUnlocked`
- - new global funcs
- - - `mas_getCurrentBackgroundId`
- - - `mas_isBackgroundUnlocked`
- background selector was improved
- - we don't suggest to select the current background anymore
- - replaced duplicated code with predicate functions for filtering
- - in case no backgrounds are available, we **will** show the default as a fallback option (you still can't go into the same background)

### Fixes:
- fixed a typo that lead to a name error in `_mfwm_find_fb_def`

### Recognition:
- new deco by @Nemu-sus
- new dlg by @lunulae 

### Testing:
- verify playing music still works
- verify the background selector still works
- - and you can't go into the same room
- - and current room isn't being suggested
- - and on O31 only the rooms with the required deco are shown
- verify the islands still work
- - test during different time of day (filter) and weather
- - test on O31 (don't forget about the update script)
- - - again, test during the day and night
- - verify your unlocks are valid
- - verify the new dialogue (on click events) is good