### PR TITLE
D25 additions to the island event

### DIFF
--- a/Monika After Story/game/updates.rpy
+++ b/Monika After Story/game/updates.rpy
@@ -374,6 +374,24 @@ label v0_3_1(version=version): # 0.3.1
 
 # non generic updates go here
 
+# 0.12.13
+label v0_12_13(version="v0_12_13"):
+    python hide:
+        isld_p_data = persistent._mas_islands_unlocks
+        if isld_p_data is not None:
+            keys = (
+                "decal_bookshelf_lantern",
+                "decal_circle_garland",
+                "decal_hanging_lantern",
+                "decal_rectangle_garland",
+                "decal_tree_lights",
+                "decal_wreath"
+            )
+            for k in keys:
+                isld_p_data[k] = False
+
+    return
+
 # 0.12.12
 label v0_12_12(version="v0_12_12"):
     python hide:
@@ -2084,8 +2102,8 @@ label v0_10_2(version="v0_10_2"):
 label v0_10_1(version="v0_10_1"):
     #Fix 922 time spent vars if we're not post 922 (so these vars aren't set when they shouldn't be)
     if datetime.date.today() < mas_monika_birthday:
-       $ persistent._mas_bday_no_time_spent = True
-       $ persistent._mas_bday_no_recognize = True
+        $ persistent._mas_bday_no_time_spent = True
+        $ persistent._mas_bday_no_recognize = True
 
     #Fix all of the topics which are now having actions undone (conditional updates)
     python:

--- a/Monika After Story/game/zz_dockingstation.rpy
+++ b/Monika After Story/game/zz_dockingstation.rpy
@@ -24,7 +24,7 @@ init -900 python in mas_ics:
 
     # NOTE: these checksums are BEFORE b64 encoding
 
-    ISLAND_PKG_CHKSUM = "291e6b7b436e4a9910e6062bc5ef6170bd9d4268a2cda344e2f13b86be85df6e"
+    ISLAND_PKG_CHKSUM = "4cff576537c3403985088589fbdfaa10a575c21f13ed3fbd3282ac9697f47cfb"
 
     #################################### O31 ##################################
     # cg folder


### PR DESCRIPTION
Similar to #9689, but for D25.

### Additions:
 - new deco (not everything is available at the current max progression level, but they are all working):
 - - `bookshelf_lantern`
 - - `circle_garland`
 - - `hanging_lantern`
 - - `rectangle_garland`
 - - `tree_lights`
 - - `wreath`

### Recognition:
 - d25 deco by @Nemu-sus

### Testing:
- verify the islands are still working
- verify the new deco looks good and is placed accordingly
- - test during different time of day (filter) and weather
- - - the new deco should only be available during the d25 season and snow weather
- test update script
- verify that the deco is being unlocked in the proper order:
- - `bookshelf_lantern` is after `bookshelf` is available
- - `tree_lights` is after `tree` is available
- - the rest is only available at the final level (not reachable right now)