### PR TITLE
Fix a premature `mas_timed_text_events_prep`

### DIFF
--- a/Monika After Story/game/script-songs.rpy
+++ b/Monika After Story/game/script-songs.rpy
@@ -2217,7 +2217,6 @@ label mas_monika_plays_or(skip_leadin=False):
         $ gen = "their"
 
     window hide
-    call mas_timed_text_events_prep
     $ mas_temp_zoom_level = store.mas_sprites.zoom_level
     call monika_zoom_transition_reset(1.0)
     show monika at rs32
@@ -2232,6 +2231,8 @@ label mas_monika_plays_or(skip_leadin=False):
         $ enable_esc()
         m 6hua "Don't forget about your in-game volume, [player]!"
         $ disable_esc()
+    
+    call mas_timed_text_events_prep
 
     pause 2.0
     $ mas_play_song(songs.FP_PIANO_COVER,loop=False)


### PR DESCRIPTION
Looks like another old bug.

In the event of having Monika play _Your Reality_, we have:

```
    if store.songs.hasMusicMuted():
        $ enable_esc()
        m 6hua "Don't forget about your in-game volume, [player]!"
        $ disable_esc()

    window hide
    call mas_timed_text_events_prep
```

And in _Our Reality_, we have:

```
    call mas_timed_text_events_prep
    $ mas_temp_zoom_level = store.mas_sprites.zoom_level
    call monika_zoom_transition_reset(1.0)
    show monika at rs32
    hide monika
    pause 3.0
    show mas_piano at lps32,rps32 zorder MAS_MONIKA_Z+1
    pause 5.0
    show monika at ls32 zorder MAS_MONIKA_Z
    show monika 6dsa

    if store.songs.hasMusicMuted():
        $ enable_esc()
        m 6hua "Don't forget about your in-game volume, [player]!"
        $ disable_esc()
```

Note the location of `call mas_timed_text_events_prep`.
In _Our Reality_, `mas_timed_text_events_prep` is called before the dialogue prompting the player to unmute the game appears. So, if the player sees that line, it is impossible for the player to click through to the next line.


By the way: I also noticed that in _Our Reality_, `window hide` is called only once, while in Your Reality there are two. I'm not sure about this, so I didn't do anything about it.