### PR TITLE
Fix non-lowercase words handling in Hangman

### DIFF
--- a/Monika After Story/game/zz_hangman.rpy
+++ b/Monika After Story/game/zz_hangman.rpy
@@ -452,12 +452,6 @@ label mas_hangman_game_loop:
 
             word = word[0]
 
-        # Ensure the word is all lowercase so that both lower and uppercase
-        # letters can be revealed properly (keep og_word to maintain case
-        # after player guesses the letter using just its lowercase variant)
-        og_word = word
-        word = word.lower()
-
         # turn the word into hangman letters
         # NOTE: might not need this (or might). keep for reference
 #       hm_letters = list()
@@ -651,14 +645,14 @@ label mas_hangman_game_loop:
                 python:
                     if guess in word:
                         for index in range(0,len(word)):
-                            if guess == word[index]:
-                                display_word[index] = og_word[index]
+                            if guess == word[index].lower():
+                                display_word[index] = word[index]
                     else:
                         chances -= 1
                         missed += guess
                         if chances == 0:
                             # show the word you lost
-                            display_word = og_word
+                            display_word = word
 
                     # remove letter from being entered agin
                     avail_letters.remove(guess)

--- a/Monika After Story/game/zz_hangman.rpy
+++ b/Monika After Story/game/zz_hangman.rpy
@@ -452,6 +452,12 @@ label mas_hangman_game_loop:
 
             word = word[0]
 
+        # Ensure the word is all lowercase so that both lower and uppercase
+        # letters can be revealed properly (keep og_word to maintain case
+        # after player guesses the letter using just its lowercase variant)
+        og_word = word
+        word = word.lower()
+
         # turn the word into hangman letters
         # NOTE: might not need this (or might). keep for reference
 #       hm_letters = list()
@@ -646,13 +652,13 @@ label mas_hangman_game_loop:
                     if guess in word:
                         for index in range(0,len(word)):
                             if guess == word[index]:
-                                display_word[index] = guess
+                                display_word[index] = og_word[index]
                     else:
                         chances -= 1
                         missed += guess
                         if chances == 0:
                             # show the word you lost
-                            display_word = word
+                            display_word = og_word
 
                     # remove letter from being entered agin
                     avail_letters.remove(guess)

--- a/Monika After Story/game/zz_hangman.rpy
+++ b/Monika After Story/game/zz_hangman.rpy
@@ -643,7 +643,7 @@ label mas_hangman_game_loop:
             else:
                 $ guesses += 1
                 python:
-                    if guess in word:
+                    if guess in word.lower():
                         for index in range(0,len(word)):
                             if guess == word[index].lower():
                                 display_word[index] = word[index]


### PR DESCRIPTION
# tl;dr

Currently hangman only works with lowercase letters as guesses are only accepted as single ASCII lowercase letters and current logic is case-sensitive. This PR adds support for non-lowercase words with full proper handling.

# Summary

Recently, [I've seen one of the users ask (MAS Discord)](https://discord.com/channels/372766620977725441/393978515802030091/1154811608502112275) why their hangman word was not guessed, even if they tried the letters correctly. They tried to guess the letter `v`, but their word (apparently, because of using German translation with translated word list where a titlecased word was found with uppercase `V`) had it in uppercase and the game didn't take the guess as correct:

![screenshot of bug report](https://github.com/Monika-After-Story/MonikaModDev/assets/74068927/76f84550-221c-40ca-be75-51c91c851a05)


This PR resolves this issue and additionally, adds support for non-lowercase words that are handled properly and displayed properly (without forcing them lowercase):

<table>
<tr>
<td><img alt="half-guessed" src="https://github.com/Monika-After-Story/MonikaModDev/assets/74068927/d67cd23c-3b64-47ba-983a-7feb62eb098b"></td>
<td><img alt="guessed fully" src="https://github.com/Monika-After-Story/MonikaModDev/assets/74068927/28109dbe-f1b6-4586-a993-ea75cac73316"></td>
</tr>
</table>

