### PR TITLE
Add min_aff property to selectable sprites

### DIFF
--- a/Monika After Story/game/event-handler.rpy
+++ b/Monika After Story/game/event-handler.rpy
@@ -205,6 +205,11 @@ init -999 python in mas_ev_data_ver:
 
         return isinstance(val, tuple) and len(val) == 2
 
+    def _verify_aff_const(val, allow_none=True):
+        if val is None:
+            return allow_none
+        aff = store.mas_affection.getAffByName(val)
+        return aff is not None
 
     def _verify_item(val, _type, allow_none=True):
         """

--- a/Monika After Story/game/script-affection.rpy
+++ b/Monika After Story/game/script-affection.rpy
@@ -78,6 +78,18 @@ init -900 python in mas_affection:
     ENAMORED = 7
     LOVE = 8
 
+    # Named map for by-name lookups
+    AFF_NAME_MAP = {
+        "BROKEN": BROKEN,
+        "DISTRESSED": DISTRESSED,
+        "UPSET": UPSET,
+        "NORMAL": NORMAL,
+        "HAPPY": HAPPY,
+        "AFFECTIONATE": AFFECTIONATE,
+        "ENAMORED": ENAMORED,
+        "LOVE": LOVE
+    }
+
     # natural order of affection levels
     _aff_order = [
         BROKEN,
@@ -175,6 +187,19 @@ init -900 python in mas_affection:
     }
 
     __STRUCT = struct.Struct(__STRUCT_FMT)
+
+    def getAffByName(name):
+        """
+        Safely returns affection constant by name.
+
+        IN:
+            name - str:
+                Name of the affection level constant (HAPPY, UPSET, etc)
+        OUT:
+            Affection constant or None if name is unknown.
+        """
+
+        return AFF_NAME_MAP.get(name.upper())
 
     # compare functions for affection / group
     def _compareAff(aff_1, aff_2):

--- a/Monika After Story/game/zz_selector.rpy
+++ b/Monika After Story/game/zz_selector.rpy
@@ -959,7 +959,8 @@ init -10 python in mas_selspr:
             visible_when_locked=True,
             hover_dlg=None,
             first_select_dlg=None,
-            select_dlg=None
+            select_dlg=None,
+            min_aff=None
         ):
         """
         Inits the selectable clothes
@@ -979,6 +980,9 @@ init -10 python in mas_selspr:
             select_dlg - list of dialogue to say when the item is selected
                 after the first time
                 (Default: None)
+            min_aff - minimum level of affection (as affection constant or
+                constant name) for this clothing to be displayed in selector
+                (Default: LOVE)
         """
         # no duplicates
         if clothes.name in CLOTH_SEL_MAP:
@@ -994,7 +998,8 @@ init -10 python in mas_selspr:
             visible_when_locked,
             hover_dlg,
             first_select_dlg,
-            select_dlg
+            select_dlg,
+            min_aff
         )
         CLOTH_SEL_MAP[clothes.name] = new_sel_clothes
         store.mas_utils.insert_sort(CLOTH_SEL_SL, new_sel_clothes, selectable_key)

--- a/Monika After Story/game/zz_selector.rpy
+++ b/Monika After Story/game/zz_selector.rpy
@@ -4065,10 +4065,6 @@ label monika_clothes_select:
                 clothes = gifted_clothes[index]
                 spr_obj = clothes.get_sprobj()
 
-                # If clothes has min_aff and it matches, do not remove it.
-                if clothes.aff_allows_selection():
-                    continue
-
                 if (
                     spr_obj.name == clothes_id_to_add
                     or (

--- a/Monika After Story/game/zz_selector.rpy
+++ b/Monika After Story/game/zz_selector.rpy
@@ -625,8 +625,8 @@ init -20 python:
                 select_dlg
             )
 
-            if type(min_aff) is str:
-                store.mas_affection.getAffByName(self.min_aff)
+            if isinstance(min_aff, basestring):
+                min_aff = store.mas_affection.getAffByName(min_aff)
             self.min_aff = min_aff
 
         def aff_allows_selection(self):

--- a/Monika After Story/game/zz_spritejsons.rpy
+++ b/Monika After Story/game/zz_spritejsons.rpy
@@ -2197,6 +2197,9 @@ init 189 python in mas_sprites_json:
 #            ):
 #                return False
 
+        if "min_aff" in select_info:
+            select_info.pop("min_aff")
+
         if "select_dlg" in select_info:
             if not _validate_iterstr(
                 select_info,

--- a/Monika After Story/game/zz_spritejsons.rpy
+++ b/Monika After Story/game/zz_spritejsons.rpy
@@ -408,7 +408,7 @@ init -21 python in mas_sprites_json:
 
     # these imports are for the classes
     from store.mas_ev_data_ver import _verify_bool, _verify_str, \
-        _verify_int, _verify_list, _verify_dict
+        _verify_int, _verify_list, _verify_dict, _verify_aff_const
 
 
     class SpriteJsonLogAdapter(store.mas_logging.MASNewlineLogAdapter):
@@ -788,6 +788,7 @@ init -21 python in mas_sprites_json:
 
     SEL_INFO_OPT_PARAM_NAMES = {
         "visible_when_locked": (bool, _verify_bool),
+        "min_aff": (str, _verify_aff_const)
     }
 
     # pose arm data params
@@ -2196,9 +2197,6 @@ init 189 python in mas_sprites_json:
 #                indent_lvl + 1
 #            ):
 #                return False
-
-        if "min_aff" in select_info:
-            select_info.pop("min_aff")
 
         if "select_dlg" in select_info:
             if not _validate_iterstr(


### PR DESCRIPTION
Addressing #10088 here. Basically, I've added `min_aff` property to selectable sprites (to `select_info` object) that is a string with affection constant (LOVE, ENAMORED etc) with all proper validation and stuff. 

It's still a bit unclear to me, should I do something about the outfit selector topic being locked behind HAPPY?