### PR TITLE
CI fixes for R8

### DIFF
--- a/.github/workflows/mas_check.yml
+++ b/.github/workflows/mas_check.yml
@@ -22,47 +22,55 @@ jobs:
     runs-on: ubuntu-20.04
 
     env:
-      SDL_AUDIODRIVER: dummy # handles ALSA issues
+      MAS_RENPY_VER: 8.1.1
+      MAS_DIR: mas
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           # Version range or exact version of a Python version to use, using SemVer's version range syntax.
           python-version: 3.10.4 # optional, default is 3.x
 
-      # dl renpy src
+      # get/dl renpy src
+      - name: cache rpy source
+        id: cache-rpy
+        uses: actions/cache@v4
+        with:
+          path: renpy/
+          key: ${{ runner.os }}-rpy
+
       - name: Download rpy source
+        if: steps.cache-rpy.outputs.cache-hit != 'true'
         run: |
-          renpysdk=$(wget -qO- https://nightly.renpy.org/current-8/index.html | grep -P -m 1 -o '(?<=href=").*\.tar\.bz2(?=".*)')
-          wget https://nightly.renpy.org/current-8/$renpysdk
+          renpysdk=renpy-$MAS_RENPY_VER-sdk.tar.bz2
+          wget https://www.renpy.org/dl/8.1.1/$renpysdk
           tar xf $renpysdk
           rm $renpysdk
           mv ${renpysdk/.tar.bz2/} renpy
 
       # get/download base mas
-      # - name: cache base MAS
-      #   id: cache-mas
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: mas0105/
-      #     key: ${{ runner.os }}-mas
+      - name: cache base MAS
+        id: cache-mas
+        uses: actions/cache@v4
+        with:
+          path: mas/
+          key: ${{ runner.os }}-mas
 
-      - name: Download base MAS
-      #  if: steps.cache-mas.outputs.cache-hit != 'true'
+      - name: download base MAS
+        if: steps.cache-mas.outputs.cache-hit != 'true'
         run: |
-          wget https://s3-us-west-2.amazonaws.com/monika-after-story/ddlc/mas.zip
-          mkdir mas0105
-          unzip mas.zip -d mas0105
-          rm mas0105/game/scripts.rpa
+          wget https://monika-after-story.s3.us-west-2.amazonaws.com/ddlc/mas8.zip
+          mkdir $MAS_DIR
+          unzip mas8.zip -d $MAS_DIR/
 
       # copy over gh files to base
       - name: copy source over
-        run: cp -Rf Monika\ After\ Story/* mas0105/
+        run: cp -Rf Monika\ After\ Story/* $MAS_DIR/
 
       # run sprite checkers
       - name: check sprites
@@ -72,10 +80,18 @@ jobs:
       - name: rpy lint
         run: |
           cd renpy
-          ./renpy.sh "../mas0105/" lint | grep -E -v "^$|Could not find image \(monika [0-9][^[:space:]]+ corresponding to attributes on say statement\.|'monika [0-9][^[:space:]]+' is not an image\.|The image named 'monika [0-9][^[:space:]]+ was not declared\."
+          ./renpy.sh "../$MAS_DIR/" lint | grep -E -v "^$|Could not find image \(monika [0-9][^[:space:]]+ corresponding to attributes on say statement\.|'monika [0-9][^[:space:]]+' is not an image\.|The image named 'monika [0-9][^[:space:]]+ was not declared\."
+
+      # setup open GL for distribute
+      - name: setup openGL
+        run: |
+          sudo apt-get install cmake pkg-config
+          sudo apt-get install mesa-utils libglu1-mesa-dev freeglut3-dev mesa-common-dev
+          sudo apt-get install libglew-dev libglfw3-dev libglm-dev
+          sudo apt-get install libao-dev libmpg123-dev
 
       # distribute
       - name: rpy distribute
         run: |
           cd renpy
-          ./renpy.sh launcher distribute "../mas0105/" --package market
+          ./renpy.sh launcher distribute "../$MAS_DIR/" --package market

--- a/.github/workflows/mas_check.yml
+++ b/.github/workflows/mas_check.yml
@@ -23,6 +23,7 @@ jobs:
 
     env:
       MAS_RENPY_VER: 8.1.1
+      MAS_BASE_DIR: masbase
       MAS_DIR: mas
       RENPY_DIR: renpy
 
@@ -59,15 +60,17 @@ jobs:
         id: cache-mas
         uses: actions/cache@v4
         with:
-          path: mas/
-          key: mas
+          path: masbase/
+          key: masbase
 
       - name: download base MAS
         if: steps.cache-mas.outputs.cache-hit != 'true'
         run: |
           wget https://monika-after-story.s3.us-west-2.amazonaws.com/ddlc/mas8.zip
+          mkdir $MAS_BASE_DIR
+          unzip mas8.zip -d $MAS_BASE_DIR/ # this is so we cache ONLY the aws download and NOT the full repo
           mkdir $MAS_DIR
-          unzip mas8.zip -d $MAS_DIR/
+          cp -Rf $MAS_BASE_DIR/* $MAS_DIR/
           rm $MAS_DIR/game/scripts.rpa # remove when we can handle scripts rpa
 
       # copy over gh files to base

--- a/.github/workflows/mas_check.yml
+++ b/.github/workflows/mas_check.yml
@@ -42,7 +42,7 @@ jobs:
         id: cache-rpy
         uses: actions/cache@v4
         with:
-          path: $RENPY_DIR/
+          path: renpy/
           key: rpy
 
       - name: Download rpy source
@@ -59,7 +59,7 @@ jobs:
         id: cache-mas
         uses: actions/cache@v4
         with:
-          path: $MAS_DIR/
+          path: mas/
           key: mas
 
       - name: download base MAS

--- a/.github/workflows/mas_check.yml
+++ b/.github/workflows/mas_check.yml
@@ -24,6 +24,7 @@ jobs:
     env:
       MAS_RENPY_VER: 8.1.1
       MAS_DIR: mas
+      RENPY_DIR: renpy
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -41,25 +42,25 @@ jobs:
         id: cache-rpy
         uses: actions/cache@v4
         with:
-          path: renpy/
-          key: ${{ runner.os }}-rpy
+          path: $RENPY_DIR/
+          key: rpy
 
       - name: Download rpy source
         if: steps.cache-rpy.outputs.cache-hit != 'true'
         run: |
           renpysdk=renpy-$MAS_RENPY_VER-sdk.tar.bz2
-          wget https://www.renpy.org/dl/8.1.1/$renpysdk
+          wget https://www.renpy.org/dl/$MAS_RENPY_VER/$renpysdk
           tar xf $renpysdk
           rm $renpysdk
-          mv ${renpysdk/.tar.bz2/} renpy
+          mv ${renpysdk/.tar.bz2/} $RENPY_DIR
 
       # get/download base mas
       - name: cache base MAS
         id: cache-mas
         uses: actions/cache@v4
         with:
-          path: mas/
-          key: ${{ runner.os }}-mas
+          path: $MAS_DIR/
+          key: mas
 
       - name: download base MAS
         if: steps.cache-mas.outputs.cache-hit != 'true'
@@ -67,6 +68,7 @@ jobs:
           wget https://monika-after-story.s3.us-west-2.amazonaws.com/ddlc/mas8.zip
           mkdir $MAS_DIR
           unzip mas8.zip -d $MAS_DIR/
+          rm $MAS_DIR/game/scripts.rpa # remove when we can handle scripts rpa
 
       # copy over gh files to base
       - name: copy source over
@@ -79,7 +81,7 @@ jobs:
       # lint renpy
       - name: rpy lint
         run: |
-          cd renpy
+          cd $RENPY_DIR
           ./renpy.sh "../$MAS_DIR/" lint | grep -E -v "^$|Could not find image \(monika [0-9][^[:space:]]+ corresponding to attributes on say statement\.|'monika [0-9][^[:space:]]+' is not an image\.|The image named 'monika [0-9][^[:space:]]+ was not declared\."
 
       # setup open GL for distribute
@@ -93,5 +95,5 @@ jobs:
       # distribute
       - name: rpy distribute
         run: |
-          cd renpy
-          ./renpy.sh launcher distribute "../$MAS_DIR/" --package market
+          cd $RENPY_DIR
+          ./renpy.sh launcher distribute "../$MAS_DIR/" --package Linux

--- a/.github/workflows/mas_check.yml
+++ b/.github/workflows/mas_check.yml
@@ -96,4 +96,4 @@ jobs:
       - name: rpy distribute
         run: |
           cd $RENPY_DIR
-          ./renpy.sh launcher distribute "../$MAS_DIR/" --package Linux
+          ./renpy.sh launcher distribute "../$MAS_DIR/" --package linux

--- a/.github/workflows/mas_check.yml
+++ b/.github/workflows/mas_check.yml
@@ -43,7 +43,7 @@ jobs:
         id: cache-rpy
         uses: actions/cache@v4
         with:
-          path: renpy/
+          path: ${{ env.RENPY_DIR }}/
           key: rpy
 
       - name: Download rpy source
@@ -60,7 +60,7 @@ jobs:
         id: cache-mas
         uses: actions/cache@v4
         with:
-          path: masbase/
+          path: ${{ env.MAS_BASE_DIR }}/
           key: masbase
 
       - name: download base MAS

--- a/.github/workflows/mas_check.yml
+++ b/.github/workflows/mas_check.yml
@@ -69,6 +69,10 @@ jobs:
           wget https://monika-after-story.s3.us-west-2.amazonaws.com/ddlc/mas8.zip
           mkdir $MAS_BASE_DIR
           unzip mas8.zip -d $MAS_BASE_DIR/ # this is so we cache ONLY the aws download and NOT the full repo
+
+      # setup build folder
+      - name: setup build folder
+        run: |
           mkdir $MAS_DIR
           cp -Rf $MAS_BASE_DIR/* $MAS_DIR/
           rm $MAS_DIR/game/scripts.rpa # remove when we can handle scripts rpa

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__
 #Ide specific things
 *.swp
 **/*.vscode
+tools/*
 
 #Various other clutter-y things
 log.txt


### PR DESCRIPTION
updates CI script for the following changes:
* lint/distribute with renpy 8.1.1 
* * also means the script installs openGL now
* use updated base MAS zip (its basically no scripts.rpa) - I'll update this later when we have handling for that
* updated version numbers for all actions

This should wait until #9493 is in.

*also I did rebasing in this one to squash the commits. I probably should have separated the changes above into separate commits though - next time.*