### PR TITLE
A missing `_history_list.pop()`

### DIFF
--- a/Monika After Story/game/script-topics.rpy
+++ b/Monika After Story/game/script-topics.rpy
@@ -17091,6 +17091,7 @@ default persistent._mas_pm_swear_frequency = None
 
 label monika_curse_words:
     m 3etc "Say [player], do you swear often?{nw}"
+    $ _history_list.pop()
     menu:
         m "Say [player], do you swear often?{fast}"
 


### PR DESCRIPTION
Title explains this PR. It turns out there is a missing `_history_list.pop()` in `monika_curse_words`.

I did not submit this as a typo since I think this is some code logic fix. Correct me if I was wrong.