### PR TITLE
Feature/music add api

### DIFF
--- a/Monika After Story/game/zz_music_selector.rpy
+++ b/Monika After Story/game/zz_music_selector.rpy
@@ -213,6 +213,23 @@ init -1 python in songs:
         if chan.mixer in renpy.game.preferences.volumes:
             renpy.game.preferences.volumes[chan.mixer] = _sanitizeVolume(value)
 
+    def addSongEntry(path, display_name, by_user=False):
+        """
+        Adds song entry to selection list. Automatically paginates and cleans
+        title text.
+
+        NOTE: Does not perform loop/metadata prefix scan. Path will be added as-is.
+
+        IN:
+            path - path to the music file
+            display_name - title of the song to show in music selector
+            by_user (default False) - whether this is an action user has done
+                (sets the corresponding PM variable)
+        """
+
+        music_choices.append((cleanGUIText(display_name), path))
+        music_pages = __paginate(music_choices)
+
 
     def _sanitizeVolume(value):
         """

--- a/Monika After Story/game/zz_music_selector.rpy
+++ b/Monika After Story/game/zz_music_selector.rpy
@@ -219,6 +219,7 @@ init -1 python in songs:
         title text.
 
         NOTE: Does not perform loop/metadata prefix scan. Path will be added as-is.
+        NOTE: Checks if the path exists (loop prefix is ignored for this check.)
 
         IN:
             path - path to the music file
@@ -227,8 +228,15 @@ init -1 python in songs:
                 (sets the corresponding PM variable)
         """
 
+        filepath = path.split(">")[:-1]
+        if not os.path.exists(filepath):
+            raise ValueError("{0} does not exist.".format(filepath))
+
         music_choices.append((cleanGUIText(display_name), path))
         music_pages = __paginate(music_choices)
+
+        if by_user:
+            store.persistent._mas_pm_added_custom_bgm = True
 
 
     def _sanitizeVolume(value):


### PR DESCRIPTION
There is a use case for external code to add songs to the music selector menu ([example how it's currently done in a hacky way](https://github.com/Friends-of-Monika/mas-selfharm/blob/4f7245d275444169575876d893bed13212d9e132/mod/songs.rpy#L20-L43))

However, it's impossible to add music to the list in a non-hacky way, as `__paginate` is protected and name-mangled.

This PR addresses that and adds a simple method for adding a song to the list (optionally, with setting the corresponding PM for custom music)