### PR TITLE
Add a titlecase counterpart of a pronoun variable

### DIFF
--- a/Monika After Story/game/script-ch30.rpy
+++ b/Monika After Story/game/script-ch30.rpy
@@ -773,7 +773,10 @@ init python:
                 value = sub_map[key]
             else:
                 value = sub_map["X"]
+
             setattr(store, word, value)
+            # Add a Titlecase (he -> He) counterpart
+            setattr(store, word.title(), value.title())
 
 
 init 995 python in mas_reset:


### PR DESCRIPTION
Currently, the pronoun variables are lowercase-only, and it's tricky to use them as subjects (rather than objects) in the script lines. This PR adds a `.title()` variant to the global store, e.g. `he` becomes `He` (in addition to `[he]`, as variables are case-sensitive.)