### PR TITLE
Fix parallax on the islands sky background

### DIFF
--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -861,8 +861,8 @@ init -20 python in mas_island_event:
             x=0,
             y=0,
             z=15000,
-            min_zoom=1.02,
-            max_zoom=4.02,
+            min_zoom=1.01,
+            max_zoom=4.01,
             on_click="mas_island_sky"
         )
     )

--- a/Monika After Story/game/script-islands-event.rpy
+++ b/Monika After Story/game/script-islands-event.rpy
@@ -523,7 +523,7 @@ init -20 python in mas_island_event:
             ParallaxSprite,
             x=912,
             y=46,
-            z=200,
+            z=170,
             function=None,
             on_click="mas_island_distant_islands"
         )


### PR DESCRIPTION
# Problem:
Incorrect parallax effect on the background
Fixes https://github.com/Monika-After-Story/MonikaModDev/issues/10452

# Fix:
1. added extra info in debug mode, now shows how much the sprite can move
2. reduced zoom on the background to reduce its parallax

# Testing:
1. run the game, open the islands
2. enable debug mode (`v`), verify the background has smaller offsets than the islands
3. move around, zoom in/out, click on stuff, verify nothing broke